### PR TITLE
list-view: make sure not to select the extension on rename

### DIFF
--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -1299,7 +1299,6 @@ cell_renderer_editing_started_cb (GtkCellRenderer *renderer,
                                   FMListView *list_view)
 {
     GtkEntry *entry;
-    gint start_offset, end_offset;
 
     entry = GTK_ENTRY (editable);
     list_view->details->editable_widget = editable;
@@ -1308,9 +1307,6 @@ cell_renderer_editing_started_cb (GtkCellRenderer *renderer,
     g_free (list_view->details->original_name);
 
     list_view->details->original_name = g_strdup (gtk_entry_get_text (entry));
-    eel_filename_get_rename_region (list_view->details->original_name,
-                                    &start_offset, &end_offset);
-    gtk_editable_select_region (GTK_EDITABLE (entry), start_offset, end_offset);
 
     caja_clipboard_set_up_editable
     (GTK_EDITABLE (entry),
@@ -2842,6 +2838,7 @@ fm_list_view_start_renaming_file (FMDirectoryView *view,
     FMListView *list_view;
     GtkTreeIter iter;
     GtkTreePath *path;
+    gint start_offset, end_offset;
 
     list_view = FM_LIST_VIEW (view);
 
@@ -2878,6 +2875,15 @@ fm_list_view_start_renaming_file (FMDirectoryView *view,
                               path,
                               list_view->details->file_name_column,
                               TRUE);
+
+    /* set cursor also triggers editing-started, where we save the editable widget */
+    if (list_view->details->editable_widget != NULL) {
+            eel_filename_get_rename_region (list_view->details->original_name,
+                                            &start_offset, &end_offset);
+
+            gtk_editable_select_region (GTK_EDITABLE (list_view->details->editable_widget),
+                                        start_offset, end_offset);
+    }
 
     gtk_tree_path_free (path);
 }


### PR DESCRIPTION
Delay calling gtk_editable_select_region() until after
gtk_tree_view_set_cursor()

https://bugzilla.gnome.org/show_bug.cgi?id=627110
(cherry picked from commit 5e2edee2e8dc6b4eababdff993176d591cc2a6e6)

taken from http://git.gnome.org/browse/nautilus/commit/?h=gnome-2-32&id=0fa8f53c89b84a47fac33eb923a5fb196ca564ee
