### PR TITLE
[eel-background] drawable deprecations (GTK2), rendering-cleanup (GTK3)

### DIFF
--- a/eel/eel-background.h
+++ b/eel/eel-background.h
@@ -75,54 +75,59 @@ EelBackground *             eel_background_new                              (voi
 
 
 /* Calls to change a background. */
-void                        eel_background_set_use_base                     (EelBackground               *background,
-        gboolean                     use_base);
-void                        eel_background_set_color                        (EelBackground               *background,
-        const char                  *color_or_gradient);
-void                        eel_background_set_image_uri                    (EelBackground               *background,
-        const char                  *image_uri);
+void                        eel_background_set_use_base                     (EelBackground   *background,
+        								     gboolean         use_base);
+void                        eel_background_set_color                        (EelBackground   *background,
+        								     const char      *color_or_gradient);
+void                        eel_background_set_image_uri                    (EelBackground   *background,
+        								     const char      *image_uri);
 
-void                        eel_background_reset                            (EelBackground               *background);
-void                        eel_background_set_image_placement              (EelBackground               *background,
-        EelBackgroundImagePlacement  placement);
+void                        eel_background_reset                            (EelBackground   *background);
+void                        eel_background_set_image_placement              (EelBackground   *background,
+        								     EelBackgroundImagePlacement placement);
 
 /* Should be TRUE for desktop background */
-void			    eel_background_set_desktop 			    (EelBackground              *background,
-        GtkWidget *widget,
-        gboolean is_desktop);
-gboolean		    eel_background_is_desktop 			    (EelBackground              *background);
+void			    eel_background_set_desktop 			    (EelBackground   *background,
+        								     GtkWidget       *widget,
+        								     gboolean         is_desktop);
+gboolean		    eel_background_is_desktop 			    (EelBackground   *background);
 
 /* Calls to interrogate the current state of a background. */
-char *                      eel_background_get_color                        (EelBackground               *background);
-char *                      eel_background_get_image_uri                    (EelBackground               *background);
-EelBackgroundImagePlacement eel_background_get_image_placement              (EelBackground               *background);
-gboolean                    eel_background_is_dark                          (EelBackground               *background);
-gboolean                    eel_background_is_set                           (EelBackground               *background);
+char *                      eel_background_get_color                        (EelBackground   *background);
+char *                      eel_background_get_image_uri                    (EelBackground   *background);
+EelBackgroundImagePlacement eel_background_get_image_placement              (EelBackground   *background);
+gboolean                    eel_background_is_dark                          (EelBackground   *background);
+gboolean                    eel_background_is_set                           (EelBackground   *background);
 
 /* Helper function for widgets using EelBackground */
-void                        eel_background_expose                           (GtkWidget                   *widget,
-        GdkEventExpose              *event);
+#if GTK_CHECK_VERSION (3, 0, 0)
+void                        eel_background_draw                             (GtkWidget       *widget,
+        								     cairo_t   *cr)
+#else
+void                        eel_background_expose                           (GtkWidget       *widget,
+        								     GdkEventExpose  *event);
+#endif
 
 /* Handles a dragged color being dropped on a widget to change the background color. */
-void                        eel_background_receive_dropped_color            (EelBackground               *background,
-        GtkWidget                   *widget,
-        GdkDragAction                action,
-        int                          drop_location_x,
-        int                          drop_location_y,
-        const GtkSelectionData      *dropped_color);
+void                        eel_background_receive_dropped_color            (EelBackground   *background,
+        								     GtkWidget       *widget,
+        								     GdkDragAction    action,
+        								     int              drop_location_x,
+        								     int              drop_location_y,
+        								     const GtkSelectionData *dropped_color);
 
 /* Handles a special-case image name that means "reset to default background" too. */
-void                        eel_background_receive_dropped_background_image (EelBackground               *background,
-        GdkDragAction                action,
-        const char                  *image_uri);
+void                        eel_background_receive_dropped_background_image (EelBackground   *background,
+        								     GdkDragAction    action,
+        								     const char      *image_uri);
 
 /* Gets or creates a background so that it's attached to a widget. */
-EelBackground *             eel_get_widget_background                       (GtkWidget                   *widget);
-void			    eel_background_save_to_settings                    (EelBackground               *background);
+EelBackground *             eel_get_widget_background                       (GtkWidget       *widget);
+void			    eel_background_save_to_settings                 (EelBackground   *background);
 
 /* Set activity status of background. Inactive backgrounds are drawn in the theme's INSENSITIVE color. */
-void                        eel_background_set_active                       (EelBackground               *background,
-        gboolean                     is_active);
+void                        eel_background_set_active                       (EelBackground   *background,
+        								     gboolean         is_active);
 
 typedef struct EelBackgroundDetails EelBackgroundDetails;
 


### PR DESCRIPTION
1. Don't use gdk_drawable_get_display (deprecated in 2.24)
2. Use GDK_PIXMAP_XDISPLAY(pixmap) directly instead of
   GDK_DISPLAY_XDISPLAY(gdk_drawable_get_display(GDK_DRAWABLE (pixmap)))
3. Don't require GTK3 for stuff in GTK2.24, which we now require, and
   don't use gdk_drawable_get_size at all. So, use (i/o = instead of):
   gdk_window_get_width|height i/o gdk_drawable_get_size
   gdk_window_get_screen       i/o gdk_drawable_get_screen
   gdk_window_get_visual       i/o of gdk_drawable_get_visual
4. add eel_background_draw for GTK3, eel_background_expose for GTK2
   This was removed in nautilus (after eel-background-box was removed):
   http://git.gnome.org/browse/nautilus/commit/?id=87eb53a0701252607b494f34c677b6506f82278c
5. background: port to rendering-cleanup & cope with renamings of gnome-bg APIs
   http://git.gnome.org/browse/nautilus/commit/?id=0b664aae4090704fa2e44d42f213da2cea8bd828
   http://git.gnome.org/browse/nautilus/commit/?id=426079ef07d5f902911f30b0a9d7de95f3020374
6. Fix remaining issue #41: crashes w/ gdk_x_error BadPixmap when changing screen resolution
   Remove eel_background_get_pixmap_and_color(), and use the pixmap/surface & color properties
   in background->details directly, when needed. i.e. No more g_object/surface referencing.
   And call eel_background_ensure_realized() and make_color_inactive() where appropriate.
