### PR TITLE
Fix drag rectangle going off the screen (Issue #90)

### DIFF
--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -608,8 +608,8 @@ caja_icon_container_scroll (CajaIconContainer *container,
     old_h_value = gtk_adjustment_get_value (hadj);
     old_v_value = gtk_adjustment_get_value (vadj);
 
-    gtk_adjustment_set_value (hadj, gtk_adjustment_get_value (hadj) + delta_x);
-    gtk_adjustment_set_value (vadj, gtk_adjustment_get_value (vadj) + delta_y);
+    eel_gtk_adjustment_set_value (hadj, gtk_adjustment_get_value (hadj) + delta_x);
+    eel_gtk_adjustment_set_value (vadj, gtk_adjustment_get_value (vadj) + delta_y);
 
     /* return TRUE if we did scroll */
     return gtk_adjustment_get_value (hadj) != old_h_value || gtk_adjustment_get_value (vadj) != old_v_value;
@@ -763,16 +763,16 @@ reveal_icon (CajaIconContainer *container,
         item_get_canvas_bounds (EEL_CANVAS_ITEM (icon->item), &bounds, TRUE);
     }
     if (bounds.y0 < gtk_adjustment_get_value (vadj)) {
-        gtk_adjustment_set_value (vadj, bounds.y0);
+        eel_gtk_adjustment_set_value (vadj, bounds.y0);
     } else if (bounds.y1 > gtk_adjustment_get_value (vadj) + allocation.height) {
-        gtk_adjustment_set_value
+        eel_gtk_adjustment_set_value
                 (vadj, bounds.y1 - allocation.height);
     }
 
     if (bounds.x0 < gtk_adjustment_get_value (hadj)) {
-        gtk_adjustment_set_value (hadj, bounds.x0);
+        eel_gtk_adjustment_set_value (hadj, bounds.x0);
     } else if (bounds.x1 > gtk_adjustment_get_value (hadj) + allocation.width) {
-        gtk_adjustment_set_value
+        eel_gtk_adjustment_set_value
                 (hadj, bounds.x1 - allocation.width);
     }
 }
@@ -1215,6 +1215,11 @@ caja_icon_container_update_scroll_region (CajaIconContainer *container)
         gtk_adjustment_set_step_increment (vadj, step_increment);
         gtk_adjustment_changed (vadj);
     }
+    /* Now that we have a new scroll region, clamp the
+     * adjustments so we are within the valid scroll area.
+     */
+    eel_gtk_adjustment_clamp_value (hadj);
+    eel_gtk_adjustment_clamp_value (vadj); 
 }
 
 static int
@@ -7263,12 +7268,12 @@ caja_icon_container_scroll_to_icon (CajaIconContainer  *container,
 
             if (caja_icon_container_is_layout_vertical (container)) {
                 if (caja_icon_container_is_layout_rtl (container)) {
-                    gtk_adjustment_set_value (hadj, bounds.x1 - allocation.width);
+                    eel_gtk_adjustment_set_value (hadj, bounds.x1 - allocation.width);
                 } else {
-                    gtk_adjustment_set_value (hadj, bounds.x0);
+                    eel_gtk_adjustment_set_value (hadj, bounds.x0);
                 }
             } else {
-                gtk_adjustment_set_value (vadj, bounds.y0);
+                eel_gtk_adjustment_set_value (vadj, bounds.y0);
             }
         }
 


### PR DESCRIPTION
Commit 99f8b5f25192b8593ae337efe7f49c59ff13a3f4 caused this issue, and this reverts the code (not formatting) changes in that commit to work properly (use eel_gtk_adjustment_set_value instead of gtk_adjustment_set_value).
