### PR TITLE
fixed thumbnail frame not being displayed for some files

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -4276,7 +4276,9 @@ caja_file_get_icon (CajaFile *file,
 
 		pixbuf = caja_icon_info_get_pixbuf (icon);
 		if (pixbuf != NULL) {
-			caja_ui_frame_image (&pixbuf);
+			if (!file->details->is_launcher && !gdk_pixbuf_get_has_alpha (pixbuf)) {
+				caja_ui_frame_image (&pixbuf);
+			}
 			g_object_unref (icon);
 
 			icon = caja_icon_info_new_for_pixbuf (pixbuf);
@@ -4320,7 +4322,14 @@ caja_file_get_icon (CajaFile *file,
 								 MAX (h * scale, 1),
 								 GDK_INTERP_BILINEAR);
 
-			caja_ui_frame_image (&scaled_pixbuf);
+			/* Render frames only for thumbnails of non-image files 
+			   and for images with no alpha channel. */ 
+			gboolean is_image = strncmp(eel_ref_str_peek (file->details->mime_type), "image/", 6) == 0;
+     			if (!is_image || 
+     			    is_image && !gdk_pixbuf_get_has_alpha (raw_pixbuf)) {
+				caja_ui_frame_image (&scaled_pixbuf);
+     			}
+     			
 			g_object_unref (raw_pixbuf);
 
 			/* Don't scale up if more than 25%, then read the original

--- a/libcaja-private/caja-ui-utilities.c
+++ b/libcaja-private/caja-ui-utilities.c
@@ -287,18 +287,9 @@ caja_ui_frame_image (GdkPixbuf **pixbuf)
 {
     GdkPixbuf *pixbuf_with_frame, *frame;
     int left_offset, top_offset, right_offset, bottom_offset;
-    int size;
 
     frame = caja_get_thumbnail_frame ();
     if (frame == NULL) {
-        return;
-    }
-
-    size = MAX (gdk_pixbuf_get_width (*pixbuf),
-            gdk_pixbuf_get_height (*pixbuf));
-
-    /* We don't want frames around small icons */
-    if (size < 128 && gdk_pixbuf_get_has_alpha (*pixbuf)) {
         return;
     }
 


### PR DESCRIPTION
Currently:
![without_frame](https://f.cloud.github.com/assets/2727288/1021605/4094422a-0d13-11e3-9adb-03a3c143cb56.png)

After this fix:
![with_frame](https://f.cloud.github.com/assets/2727288/1021608/702a1424-0d13-11e3-8d22-4b25a796edda.png)

(Ported back from https://git.gnome.org/browse/nautilus/commit/?h=gnome-3-6&id=a83f876687a9f5704d64a93f7ea5c27781b43baf)
