### PR TITLE
[To be tested] Fix for x-caja-desktop multiple windows being spawned on first login

### DIFF
--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -65,7 +65,7 @@
 /* Keeps track of everyone who wants the main event loop kept active */
 static GSList* event_loop_registrants;
 
-static gboolean exit_with_last_window = TRUE;
+static gboolean exit_with_last_window = FALSE;
 
 static gboolean is_event_loop_needed(void)
 {
@@ -497,10 +497,7 @@ main (int argc, char *argv[])
      * defaults are available before any preference peeking
      * happens.
      */
-    caja_global_preferences_init ();
-
-    /* exit_with_last_window being FALSE, caja can run without window. */
-    exit_with_last_window = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_EXIT_WITH_LAST_WINDOW);
+    caja_global_preferences_init ();  
 
     application = NULL;
 


### PR DESCRIPTION
This wasn't tested or verified yet. Please help with the testing.

Here's the theory:
- X-MATE-AutoRestart is set to TRUE in caja.desktop, meaning mate-session will automatically respawn caja whenever it either crashes or exits.
- Caja handles the desktop and the automounts and therefore needs to be running.
- On first login, say there's a race condition between /etc/skel, the creation of the various hidden files in the home dir and mate-session... what could happen is that mate-session would spawn caja while ~/.dconf isn't totally ready (this is just a theory...we don't know for sure what's going on). If caja failed to read exit_on_last_window from gsettings it would either crash or exits.. thus being restarted by mate-session.

This would explain why we get a series of caja spawn and they stop whenever dconf is ready. 

It doesn't explain why they open windows though (maybe another bug in caja, or in mate-session losing arguments on autorestarts?). 

Another aspect of this is that we don't need the setting exit-on-last-window. Caja always runs in the background and should always do. Using another filemanager is possible and mate-session will only pick one. Launching a second one in the same session would make both filemanagers stay in memory but that isn't a real problem (note that nemo for instance doesn't support such a setting).
