### PR TITLE
add the primary-toolbar style class to the primary toolbar

### DIFF
--- a/src/caja-navigation-window.c
+++ b/src/caja-navigation-window.c
@@ -185,6 +185,9 @@ caja_navigation_window_init (CajaNavigationWindow *window)
 
     ui_manager = caja_window_get_ui_manager (CAJA_WINDOW (window));
     toolbar = gtk_ui_manager_get_widget (ui_manager, "/Toolbar");
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gtk_style_context_add_class (gtk_widget_get_style_context (toolbar), GTK_STYLE_CLASS_PRIMARY_TOOLBAR);
+#endif
     window->details->toolbar = toolbar;
     gtk_table_attach (GTK_TABLE (CAJA_WINDOW (window)->details->table),
                       toolbar,


### PR DESCRIPTION
some GTK3 themes use a different styling for primary toolbars compared to other toolbars. To make this work the primary-toolbar style class has to be set.
