### PR TITLE
fix a GTK3 bug and simplify things

### DIFF
--- a/src/caja-navigation-window-pane.c
+++ b/src/caja-navigation-window-pane.c
@@ -739,15 +739,15 @@ caja_navigation_window_pane_setup (CajaNavigationWindowPane *pane)
                         FALSE, FALSE, 0);
     gtk_widget_show (hbox);
 
+    /* the header size group ensures that the location bar has the same height as the sidebar header */
     header_size_group = CAJA_NAVIGATION_WINDOW (CAJA_WINDOW_PANE (pane)->window)->details->header_size_group;
+    gtk_size_group_add_widget (header_size_group, pane->location_bar);
 
     pane->location_button = location_button_create (pane);
-    gtk_size_group_add_widget (header_size_group, pane->location_button);
     gtk_box_pack_start (GTK_BOX (hbox), pane->location_button, FALSE, FALSE, 0);
     gtk_widget_show (pane->location_button);
 
     pane->path_bar = g_object_new (CAJA_TYPE_PATH_BAR, NULL);
-    gtk_size_group_add_widget (header_size_group, pane->path_bar);
     gtk_widget_show (pane->path_bar);
 
     g_signal_connect_object (pane->path_bar, "path_clicked",
@@ -760,7 +760,6 @@ caja_navigation_window_pane_setup (CajaNavigationWindowPane *pane)
                         TRUE, TRUE, 0);
 
     pane->navigation_bar = caja_location_bar_new (pane);
-    gtk_size_group_add_widget (header_size_group, pane->navigation_bar);
     g_signal_connect_object (pane->navigation_bar, "location_changed",
                              G_CALLBACK (navigation_bar_location_changed_callback), pane, 0);
     g_signal_connect_object (pane->navigation_bar, "cancel",
@@ -774,7 +773,6 @@ caja_navigation_window_pane_setup (CajaNavigationWindowPane *pane)
                         TRUE, TRUE, 0);
 
     pane->search_bar = caja_search_bar_new ();
-    gtk_size_group_add_widget (header_size_group, pane->search_bar);
     g_signal_connect_object (pane->search_bar, "activate",
                              G_CALLBACK (search_bar_activate_callback), pane, 0);
     g_signal_connect_object (pane->search_bar, "cancel",

--- a/src/caja-side-pane.c
+++ b/src/caja-side-pane.c
@@ -48,7 +48,6 @@ struct _CajaSidePaneDetails
     GtkWidget *notebook;
     GtkWidget *menu;
 
-    GtkWidget *title_frame;
     GtkWidget *title_hbox;
     GtkWidget *title_label;
     GtkWidget *shortcut_box;
@@ -302,7 +301,6 @@ static void
 caja_side_pane_init (GObject *object)
 {
     CajaSidePane *side_pane;
-    GtkWidget *frame;
     GtkWidget *hbox;
     GtkWidget *close_button;
     GtkWidget *select_button;
@@ -314,19 +312,11 @@ caja_side_pane_init (GObject *object)
 
     side_pane->details = G_TYPE_INSTANCE_GET_PRIVATE (object, CAJA_TYPE_SIDE_PANE, CajaSidePaneDetails);
 
-    /* The frame (really a vbox) has the border */
-    frame = gtk_vbox_new (FALSE, 0);
-    gtk_container_set_border_width (GTK_CONTAINER (frame), 4);
-    side_pane->details->title_frame = frame;
-    gtk_widget_show (frame);
-    gtk_box_pack_start (GTK_BOX (side_pane), frame, FALSE, FALSE, 0);
-
-    /* And the title_hbox is what gets the same size as the other
-       headers */
     hbox = gtk_hbox_new (FALSE, 0);
+    gtk_container_set_border_width (GTK_CONTAINER (hbox), 4);
     side_pane->details->title_hbox = hbox;
     gtk_widget_show (hbox);
-    gtk_container_add (GTK_CONTAINER (frame), hbox);
+    gtk_box_pack_start (GTK_BOX (side_pane), hbox, FALSE, FALSE, 0);
 
     select_button = gtk_toggle_button_new ();
     gtk_button_set_relief (GTK_BUTTON (select_button), GTK_RELIEF_NONE);


### PR DESCRIPTION
This fixes the problem in GTK3 that the side bar combo box is cut off at the bottom.

The removal of the custom size allocation needs some review (to me it looks just wrong but maybe there is a good reason why it needs to be there).
