### PR TITLE
Revert "Fix for x-caja-desktop windows at login"

### DIFF
--- a/data/caja.desktop.in.in
+++ b/data/caja.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 _Name=Caja
 _GenericName=File Manager
-Exec=caja -n
+Exec=caja
 Icon=system-file-manager
 Terminal=false
 Type=Application


### PR DESCRIPTION
This reverts commit d116bf8ba8be698869fef81b30d576bcacf3234c.

Revert because it does not solve the problem and it causes problems
for users with other docks like plank. See issue #211.
