### PR TITLE
replace g_free call on GFile objects, fixes #196

### DIFF
--- a/src/file-manager/fm-tree-view.c
+++ b/src/file-manager/fm-tree-view.c
@@ -1120,7 +1120,7 @@ fm_tree_view_trash_cb (GtkWidget *menu_item,
     caja_file_operations_trash_or_delete (list,
                                           fm_tree_view_get_containing_window (view),
                                           NULL, NULL);
-    g_list_free_full (list, g_free);
+    g_list_free_full (list, g_object_unref);
 }
 
 static void


### PR DESCRIPTION
This fixes #196, further details can be found in the issue comments. 
