### PR TITLE
Quick fix for #105

### DIFF
--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -9414,7 +9414,7 @@ setup_label_gcs (CajaIconContainer *container)
                           "frame_text", &frame_text,
                           NULL);
 
-    if (frame_text || !eel_background_is_set(background))
+    if (frame_text /* || !eel_background_is_set(background) */)
     {
         setup_gc_with_fg (container, LABEL_COLOR,
                           eel_gdk_color_to_rgb (&style->text[GTK_STATE_NORMAL]));


### PR DESCRIPTION
Enclosed is a trivial one-line change that successfully fixes bug #105.

(A more sophisticated fix might be possible by inspecting this one.
At least, I have figured out exactly where the problem manifests itself.)

Here is a "before" screenshot with incorrect font color on logon:
![](https://sites.google.com/site/bl0ckeduserssoftware/before.png)

And here is an "after" (after the fix) screenshot with correct font color:
![](https://sites.google.com/site/bl0ckeduserssoftware/after.png)
