### PR TITLE
libcaja-private: fix always-false expressions

### DIFF
--- a/libcaja-private/caja-autorun.c
+++ b/libcaja-private/caja-autorun.c
@@ -1052,11 +1052,11 @@ show_dialog:
     {
         media_greeting = _("You have just inserted a blank DVD.");
     }
-    else if (strcmp (x_content_type, "x-content/blank-cd") == 0)
+    else if (strcmp (x_content_type, "x-content/blank-bd") == 0)
     {
         media_greeting = _("You have just inserted a blank Blu-Ray disc.");
     }
-    else if (strcmp (x_content_type, "x-content/blank-cd") == 0)
+    else if (strcmp (x_content_type, "x-content/blank-hddvd") == 0)
     {
         media_greeting = _("You have just inserted a blank HD DVD.");
     }

--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -4815,12 +4815,6 @@ move_file_prepare (CopyMoveJob *move_job,
 								 response->new_name);
 			conflict_response_data_free (response);
 			goto retry;
-		} else if (response->id == CONFLICT_RESPONSE_RENAME) {
-			g_object_unref (dest);
-			dest = get_target_file_for_display_name (dest_dir,
-								 response->new_name);
-			conflict_response_data_free (response);
-			goto retry;
 		} else {
 			g_assert_not_reached ();
 		}


### PR DESCRIPTION
CppCheck detected a few 'always false' expressions in caja.

First two definitely appeareed due to copy-paste (mime-types
comparison). It would be nice to move x_content_type's and corresponding
greetings to some table (array of structs), wouldn't it?

The last one looks like copy-paste problem too. There were two identical
blocks of code in move_file_prepare() checking conflict type. BTW, there
is exactly the same code in the same file inside copy_move_file().
According to DRY, it would be nice to move this code to its own
function.
