### PR TITLE
Create caja.appdata.xml

### DIFF
--- a/data/caja.appdata.xml
+++ b/data/caja.appdata.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 MATE team <mate-dev@ml.mate-desktop.org> -->
+<component type="desktop">
+ <id>caja.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Caja</name>
+ <summary>File manager for the MATE desktop environment</summary>
+ <description>
+  <p>
+   Caja is the official file manager for the MATE desktop. It allows for
+   browsing directories, as well as previewing files and launching applications
+   associated with them. It is also responsible for handling the icons on
+   the MATE desktop. It works on local and remote file systems.
+  </p>
+  <p>
+   Caja is extensible through a plugin system, similar to that of GNOME Nautilus,
+   of which Caja is a fork.
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/caja/screens/caja_01.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/caja/screens/caja_02.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/caja/screens/caja_03.png
+   </image>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.mate-desktop.org</url>
+ <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
+ <project_group>MATE</project_group>
+</component>


### PR DESCRIPTION
An appdata file for inclusion in the upcoming software centers as per the new freedesktop.org specs.

It should be placed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

Please, skim through the file in case I made a mistake and please, include it in the 1.8 branch as well.

Thanks!
