### PR TITLE
fixed: Adjust Default _zoom level always get the same old metadata value in icon/compact and list view.

### DIFF
--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -1323,22 +1323,7 @@ fm_icon_view_begin_loading (FMDirectoryView *view)
     /* Set up the zoom level from the metadata. */
     if (fm_directory_view_supports_zooming (FM_DIRECTORY_VIEW (icon_view)))
     {
-        if (icon_view->details->compact)
-        {
-            level = caja_file_get_integer_metadata
-                    (file,
-                     CAJA_METADATA_KEY_COMPACT_VIEW_ZOOM_LEVEL,
-                     get_default_zoom_level (icon_view));
-        }
-        else
-        {
-            level = caja_file_get_integer_metadata
-                    (file,
-                     CAJA_METADATA_KEY_ICON_VIEW_ZOOM_LEVEL,
-                     get_default_zoom_level (icon_view));
-        }
-
-        fm_icon_view_set_zoom_level (icon_view, level, TRUE);
+        fm_icon_view_set_zoom_level (icon_view, get_default_zoom_level (icon_view), TRUE);
     }
 
     /* Set the sort mode.

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -2792,21 +2792,7 @@ default_zoom_level_changed_callback (gpointer callback_data)
 
     if (fm_directory_view_supports_zooming (FM_DIRECTORY_VIEW (icon_view)))
     {
-        file = fm_directory_view_get_directory_as_file (FM_DIRECTORY_VIEW (icon_view));
-
-        if (fm_icon_view_is_compact (icon_view))
-        {
-            level = caja_file_get_integer_metadata (file,
-                                                    CAJA_METADATA_KEY_COMPACT_VIEW_ZOOM_LEVEL,
-                                                    get_default_zoom_level (icon_view));
-        }
-        else
-        {
-            level = caja_file_get_integer_metadata (file,
-                                                    CAJA_METADATA_KEY_ICON_VIEW_ZOOM_LEVEL,
-                                                    get_default_zoom_level (icon_view));
-        }
-        fm_directory_view_zoom_to_level (FM_DIRECTORY_VIEW (icon_view), level);
+        fm_directory_view_zoom_to_level (FM_DIRECTORY_VIEW (icon_view), get_default_zoom_level (icon_view));
     }
 }
 
@@ -3291,6 +3277,9 @@ fm_icon_view_init (FMIconView *icon_view)
 
         setup_sound_preview = TRUE;
     }
+
+    //Ignore the return value
+    get_default_zoom_level(icon_view);
 
     g_signal_connect_swapped (caja_preferences,
                               "changed::" CAJA_PREFERENCES_DEFAULT_SORT_ORDER,

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -1996,11 +1996,7 @@ set_zoom_level_from_metadata_and_preferences (FMListView *list_view)
 
     if (fm_directory_view_supports_zooming (FM_DIRECTORY_VIEW (list_view)))
     {
-        file = fm_directory_view_get_directory_as_file (FM_DIRECTORY_VIEW (list_view));
-        level = caja_file_get_integer_metadata (file,
-                                                CAJA_METADATA_KEY_LIST_VIEW_ZOOM_LEVEL,
-                                                get_default_zoom_level ());
-        fm_list_view_set_zoom_level (list_view, level, TRUE);
+        fm_list_view_set_zoom_level (list_view, get_default_zoom_level (), TRUE);
 
         /* updated the rows after updating the font size */
         gtk_tree_model_foreach (GTK_TREE_MODEL (list_view->details->model),


### PR DESCRIPTION
Always get the old metadata value update the metadata value, lead to adjusting default zoom level failure.