### PR TITLE
Make sorting by display name case-insensitive

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -2876,7 +2876,7 @@ compare_by_display_name (CajaFile *file_1, CajaFile *file_2)
 	} else {
 		key_1 = caja_file_peek_display_name_collation_key (file_1);
 		key_2 = caja_file_peek_display_name_collation_key (file_2);
-		compare = strcmp (key_1, key_2);
+		compare = strcasecmp (key_1, key_2);
 	}
 
 	return compare;


### PR DESCRIPTION
Hey guys,

I find very annoying that filenames with Capitals letters are sorted before the small ones.  
For example when you have to go and find something starting with 'W', 'w', you don't actually know if it'll be in the middle (capital case) or at the end.

This small change should deal with the issue. It's just a "feature request", although I have already made it - I think it's a better way than a bug report.  

Merge it or not, it's up to you.