### PR TITLE
GTK3: add missing style class view to FMIconContainer

### DIFF
--- a/src/file-manager/fm-icon-container.c
+++ b/src/file-manager/fm-icon-container.c
@@ -595,6 +595,10 @@ fm_icon_container_class_init (FMIconContainerClass *klass)
 static void
 fm_icon_container_init (FMIconContainer *icon_container)
 {
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_style_context_add_class (gtk_widget_get_style_context (GTK_WIDGET (icon_container)),
+                                 GTK_STYLE_CLASS_VIEW);
+#endif
 }
 
 CajaIconContainer *


### PR DESCRIPTION
fixes https://github.com/mate-desktop/caja/issues/382