### PR TITLE
U fixes for file management preferences

### DIFF
--- a/src/caja-file-management-properties.ui
+++ b/src/caja-file-management-properties.ui
@@ -271,6 +271,8 @@
     <property name="border_width">5</property>
     <property name="title" translatable="yes">File Management Preferences</property>
     <property name="window_position">center</property>
+    <property name="default_width">600</property>
+    <property name="default_height">600</property>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkVBox" id="dialog-vbox1">

--- a/src/caja-file-management-properties.ui
+++ b/src/caja-file-management-properties.ui
@@ -1522,14 +1522,14 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
+                        <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
+                    <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>


### PR DESCRIPTION
Setting a default windows size fixes that the preferences window display always to huge with GTK3.
Expanding list colums avoid to use a scrollbar for a few entries.