### PR TITLE
No daemon mode on other desktop environments

### DIFF
--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -504,7 +504,11 @@ main (int argc, char *argv[])
     caja_global_preferences_init ();
 
     /* exit_with_last_window being FALSE, caja can run without window. */
-    exit_with_last_window = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_EXIT_WITH_LAST_WINDOW);
+    /* But we should need this still set as TRUE on other desktop environments. Otherwise caja wont quit */
+    if (g_strcmp0 (g_getenv ("XDG_CURRENT_DESKTOP"), "MATE") == 0)
+    {
+        exit_with_last_window = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_EXIT_WITH_LAST_WINDOW);
+    }
 
     application = NULL;
 

--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -505,7 +505,9 @@ main (int argc, char *argv[])
 
     /* exit_with_last_window being FALSE, caja can run without window. */
     /* But we should need this still set as TRUE on other desktop environments. Otherwise caja wont quit */
-    if (g_strcmp0 (g_getenv ("XDG_CURRENT_DESKTOP"), "MATE") == 0)
+    if (g_strcmp0 (g_getenv ("XDG_CURRENT_DESKTOP"), "MATE") == 0
+    || g_strcmp0 (g_getenv ("XDG_SESSION_DESKTOP"), "MATE") == 0
+    || g_strcmp0 (g_getenv ("DESKTOP_SESSION"), "MATE") == 0)
     {
         exit_with_last_window = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_EXIT_WITH_LAST_WINDOW);
     }


### PR DESCRIPTION
Caja should exit when last window closed on non MATE desktops.
Otherwise it keeps running altough its daemon mode is not needed
KDE, XFCE and others don't need caja's automount features so
Caja should behave like other file managers out there on these
environments. Please review this pull request.