### PR TITLE
GTK3: editable-label : only clear the selection if we change to insensitive

### DIFF
--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -1208,7 +1208,9 @@ eel_editable_label_state_changed (GtkWidget   *widget,
 
     label = EEL_EDITABLE_LABEL (widget);
 
-    eel_editable_label_select_region (label, 0, 0);
+    /* clear any selection if we're insensitive */
+    if (!gtk_widget_is_sensitive (widget))
+        eel_editable_label_select_region (label, 0, 0);
 
     if (GTK_WIDGET_CLASS (eel_editable_label_parent_class)->state_changed)
         GTK_WIDGET_CLASS (eel_editable_label_parent_class)->state_changed (widget, prev_state);


### PR DESCRIPTION
this fixes non selected text if renaming a file

taken from:
https://git.gnome.org/browse/nautilus/commit/?h=gnome-3-0&id=d2c3410