### PR TITLE
places-sidebar: enable both creating bookmarks and dropping files

### DIFF
--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -1134,7 +1134,6 @@ compute_drop_position (GtkTreeView *tree_view,
         /* never drop on headings, but special case the bookmarks heading,
          * so we can drop bookmarks in between it and the first item.
          */
-
         gtk_tree_path_free (*path);
         *path = NULL;
 
@@ -1145,9 +1144,8 @@ compute_drop_position (GtkTreeView *tree_view,
         sidebar->drag_data_received &&
         sidebar->drag_data_info == GTK_TREE_MODEL_ROW) {
         /* don't allow dropping bookmarks into non-bookmark areas */
-
-    gtk_tree_path_free (*path);
-    *path = NULL;
+        gtk_tree_path_free (*path);
+        *path = NULL;
 
         return FALSE;
     }
@@ -1266,10 +1264,10 @@ drag_motion_callback (GtkTreeView *tree_view,
     }
 
     if (pos == GTK_TREE_VIEW_DROP_BEFORE ||
-            pos == GTK_TREE_VIEW_DROP_AFTER )
+        pos == GTK_TREE_VIEW_DROP_AFTER )
     {
         if (sidebar->drag_data_received &&
-                sidebar->drag_data_info == GTK_TREE_MODEL_ROW)
+            sidebar->drag_data_info == GTK_TREE_MODEL_ROW)
         {
             action = GDK_ACTION_MOVE;
         }
@@ -1527,7 +1525,7 @@ drag_data_received_callback (GtkWidget *widget,
     success = FALSE;
 
     if (tree_pos == GTK_TREE_VIEW_DROP_BEFORE ||
-            tree_pos == GTK_TREE_VIEW_DROP_AFTER)
+        tree_pos == GTK_TREE_VIEW_DROP_AFTER)
     {
         model = gtk_tree_view_get_model (tree_view);
 
@@ -1538,7 +1536,7 @@ drag_data_received_callback (GtkWidget *widget,
 
         gtk_tree_model_get (model, &iter,
                             PLACES_SIDEBAR_COLUMN_SECTION_TYPE, &section_type,
-                                PLACES_SIDEBAR_COLUMN_ROW_TYPE, &place_type,
+                            PLACES_SIDEBAR_COLUMN_ROW_TYPE, &place_type,
                             PLACES_SIDEBAR_COLUMN_INDEX, &position,
                             -1);
 


### PR DESCRIPTION
- drag a folder to the top or bottom of the bookmark list to add
a new bookmark. a horizontal line will be shown and the mouse
pointer will have a '+' at its right side.
- if there are no bookmarks (and that section isn't shown), drag
a folder over the network section's heading. this will add a new
bookmark and make the bookmarks list visible.
- drag a file or a folder over some existing bookmark to move it
into the bookmarked folder. the mouse pointer will have an arrow
at its right side.
- if you want to copy a file or a folder there instead, perform
the same operation but hold ctrl during that. the mouse pointer
will have a '+' at its right side. no horizontal line will be
shown, so you will be able to distinguish this operation from
adding a new bookmark. :)

adapted from https://github.com/linuxmint/nemo/commit/f18c4dd842be0998cbe6a519d9904bfd9993ca3e
(thanks to @mtwebster)

fixes https://github.com/mate-desktop/caja/issues/345
closes https://github.com/mate-desktop/caja/issues/423


@stefano-k @flexiondotorg @NiceandGently @sunweaver @willysr @infirit @denispr
please test it, if all goes well, I'll merge it.