### PR TITLE
icon-container: reset the double click counter after a double click

### DIFF
--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -4833,7 +4833,12 @@ clicked_within_double_click_interval (CajaIconContainer *container)
     last_click_time = current_time;
 
     /* Only allow double click */
-    return (click_count == 1);
+    if (click_count == 1) {
+            click_count = 0;
+            return TRUE;
+    } else {
+            return FALSE;
+    }
 }
 
 static void


### PR DESCRIPTION
If we don't do this, we ignore any other double click event that happen
during the next 'gtk-double-click-time' interval after the first double
click.

taken from:
https://git.gnome.org/browse/nautilus/commit/?id=a8539a6