### PR TITLE
compact view: don't auto-scroll to the right on long filenames

### DIFF
--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -763,15 +763,17 @@ reveal_icon (CajaIconContainer *container,
     if (bounds.y0 < gtk_adjustment_get_value (vadj)) {
         eel_gtk_adjustment_set_value (vadj, bounds.y0);
     } else if (bounds.y1 > gtk_adjustment_get_value (vadj) + allocation.height) {
-        eel_gtk_adjustment_set_value
-                (vadj, bounds.y1 - allocation.height);
+        eel_gtk_adjustment_set_value (vadj, bounds.y1 - allocation.height);
     }
 
     if (bounds.x0 < gtk_adjustment_get_value (hadj)) {
         eel_gtk_adjustment_set_value (hadj, bounds.x0);
     } else if (bounds.x1 > gtk_adjustment_get_value (hadj) + allocation.width) {
-        eel_gtk_adjustment_set_value
-                (hadj, bounds.x1 - allocation.width);
+        if (bounds.x1 - allocation.width > bounds.x0) {
+            eel_gtk_adjustment_set_value (hadj, bounds.x0);
+        } else {
+            eel_gtk_adjustment_set_value (hadj, bounds.x1 - allocation.width);
+        }
     }
 }
 


### PR DESCRIPTION
however, now it will auto-scroll to the left if you manually
scroll to the right and then click on any filename. I presume
this behavior is more desired than the previous one. if it's
not so, let me know (in the comments).

adapted from
https://github.com/linuxmint/nemo/commit/72c2214c82637ab622438d46c28e67289a49d472
(thanks to @glebihan)

fixes https://github.com/mate-desktop/caja/issues/406

@flexiondotorg @NiceandGently @stefano-k 
It works fine in GTK+2 build in Debian Testing, but I'd like to get it tested more before merging (e.g. GTK+3 build, other distros, etc.) :smile: