### PR TITLE
file properties dialog: bring back two missing tabs

### DIFF
--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -4948,9 +4948,23 @@ static void
 append_extension_pages (FMPropertiesWindow *window)
 {
 	GList *providers;
+	GList *module_providers;
 	GList *p;
 
 	providers = caja_extensions_get_for_type (CAJA_TYPE_PROPERTY_PAGE_PROVIDER);
+
+	/* FIXME: we also need the property pages from two old modules that
+	 * are not registered as proper extensions. This is going to work
+	 * this way until some generic solution is introduced.
+	 */
+	module_providers = caja_module_get_extensions_for_type (CAJA_TYPE_PROPERTY_PAGE_PROVIDER);
+	for (p = module_providers; p != NULL; p = p->next) {
+		const gchar *type_name = G_OBJECT_TYPE_NAME (G_OBJECT (p->data));
+		if (g_strcmp0 (type_name, "CajaNotesViewerProvider") == 0 ||
+		    g_strcmp0 (type_name, "CajaImagePropertiesPageProvider") == 0) {
+			providers = g_list_prepend (providers, p->data);
+		}
+	}
 
 	for (p = providers; p != NULL; p = p->next) {
 		CajaPropertyPageProvider *provider;


### PR DESCRIPTION
Notes and Image Properties tabs went missing after https://github.com/mate-desktop/caja/commit/451eef9b275ce006b270a3569d96e531e24dd15a

fixes https://github.com/mate-desktop/caja/issues/433

@infirit @flexiondotorg @NiceandGently
please test for any possible regressions