### PR TITLE
[1.10] don't crash on Ctrl-Z after deleting file when original path isn't stored in trash

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -2459,7 +2459,7 @@ update_info_internal (CajaFile *file,
 	}
 
 	trash_time = 0;
-	time_string = g_file_info_get_attribute_string (info, "trash::deletion-date");
+	time_string = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_TRASH_DELETION_DATE);
 	if (time_string != NULL) {
 		g_time_val_from_iso8601 (time_string, &g_trash_time);
 		trash_time = g_trash_time.tv_sec;
@@ -2469,7 +2469,7 @@ update_info_internal (CajaFile *file,
 		file->details->trash_time = trash_time;
 	}
 
-	trash_orig_path = g_file_info_get_attribute_byte_string (info, "trash::orig-path");
+	trash_orig_path = g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_TRASH_ORIG_PATH);
 	if (eel_strcmp (file->details->trash_orig_path, trash_orig_path) != 0) {
 		changed = TRUE;
 		g_free (file->details->trash_orig_path);

--- a/libcaja-private/caja-undostack-manager.c
+++ b/libcaja-private/caja-undostack-manager.c
@@ -1974,7 +1974,9 @@ retrieve_files_to_restore (GHashTable * trashed)
       G_FILE_ATTRIBUTE_STANDARD_NAME
       ","
       G_FILE_ATTRIBUTE_TIME_MODIFIED
-      ",trash::orig-path", G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, FALSE, NULL);
+      ","
+      G_FILE_ATTRIBUTE_TRASH_ORIG_PATH,
+      G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, FALSE, NULL);
 
   GHashTable *to_restore = g_hash_table_new_full (g_direct_hash,
       g_direct_equal, g_object_unref, g_free);
@@ -1983,7 +1985,7 @@ retrieve_files_to_restore (GHashTable * trashed)
     GFileInfo *info;
     while ((info = g_file_enumerator_next_file (enumerator, NULL, NULL)) != NULL) {
       /* Retrieve the original file uri */
-      const char *origpath = g_file_info_get_attribute_byte_string (info, "trash::orig-path");
+      const char *origpath = g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_TRASH_ORIG_PATH);
       GFile *origfile = g_file_new_for_path (origpath);
       char *origuri = g_file_get_uri (origfile);
       g_object_unref (origfile);

--- a/libcaja-private/caja-undostack-manager.c
+++ b/libcaja-private/caja-undostack-manager.c
@@ -1986,6 +1986,11 @@ retrieve_files_to_restore (GHashTable * trashed)
     while ((info = g_file_enumerator_next_file (enumerator, NULL, NULL)) != NULL) {
       /* Retrieve the original file uri */
       const char *origpath = g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_TRASH_ORIG_PATH);
+      if (origpath == NULL) {
+        g_warning ("The item cannot be restored from trash: could not determine original location");
+        continue;
+      }
+
       GFile *origfile = g_file_new_for_path (origpath);
       char *origuri = g_file_get_uri (origfile);
       g_object_unref (origfile);


### PR DESCRIPTION
Fixes #361.

@infirit @flexiondotorg @NiceandGently
please test for any possible regressions :smile: