### PR TITLE
GTK3: Replace gtk_{v,h}box new with gtk_box_new

### DIFF
--- a/eel/eel-debug-drawing.c
+++ b/eel/eel-debug-drawing.c
@@ -54,6 +54,10 @@
 #define DEBUG_IS_PIXBUF_VIEWER(obj) \
   (G_TYPE_CHECK_INSTANCE_TYPE ((obj), DEBUG_TYPE_PIXBUF_VIEWER))
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 typedef struct DebugPixbufViewer DebugPixbufViewer;
 typedef struct DebugPixbufViewerClass DebugPixbufViewerClass;
 

--- a/libcaja-private/caja-autorun.c
+++ b/libcaja-private/caja-autorun.c
@@ -43,6 +43,11 @@
 #include "caja-desktop-icon-file.h"
 #include "caja-file-utilities.h"
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 enum
 {
     AUTORUN_ASK,

--- a/libcaja-private/caja-column-chooser.c
+++ b/libcaja-private/caja-column-chooser.c
@@ -31,6 +31,10 @@
 
 #include "caja-column-utilities.h"
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 struct _CajaColumnChooserDetails
 {
     GtkTreeView *view;

--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -70,6 +70,11 @@ G_DEFINE_TYPE (CajaFileConflictDialog,
 	(G_TYPE_INSTANCE_GET_PRIVATE ((object), CAJA_TYPE_FILE_CONFLICT_DIALOG, \
 				      CajaFileConflictDialogDetails))
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 static void
 file_icons_changed (CajaFile *file,
                     CajaFileConflictDialog *fcd)

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -58,6 +58,10 @@
 #define GTK_SCROLLABLE GTK_LAYOUT
 #endif
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 #define TAB_NAVIGATION_DISABLED
 
 /* Interval for updating the rubberband selection, in milliseconds.  */

--- a/libcaja-private/caja-open-with-dialog.c
+++ b/libcaja-private/caja-open-with-dialog.c
@@ -39,6 +39,11 @@
 #define sure_string(s)                    ((const char *)((s)!=NULL?(s):""))
 #define DESKTOP_ENTRY_GROUP		  "Desktop Entry"
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 struct _CajaOpenWithDialogDetails
 {
     GAppInfo *selected_app_info;

--- a/libcaja-private/caja-progress-info.c
+++ b/libcaja-private/caja-progress-info.c
@@ -46,6 +46,11 @@ enum
 
 #define SIGNAL_DELAY_MSEC 100
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 static guint signals[LAST_SIGNAL] = { 0 };
 
 struct _CajaProgressInfo

--- a/src/caja-connect-server-dialog.c
+++ b/src/caja-connect-server-dialog.c
@@ -40,6 +40,11 @@
 #include <libcaja-private/caja-global-preferences.h>
 #include <libcaja-private/caja-icon-names.h>
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 /* TODO:
  * - name entry + pre-fill
  * - NetworkManager integration

--- a/src/caja-emblem-sidebar.c
+++ b/src/caja-emblem-sidebar.c
@@ -64,6 +64,10 @@ struct CajaEmblemSidebarDetails
 #define STANDARD_EMBLEM_HEIGHT			52
 #define EMBLEM_LABEL_SPACING			2
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 static void caja_emblem_sidebar_populate          (CajaEmblemSidebar        *emblem_sidebar);
 static void caja_emblem_sidebar_refresh           (CajaEmblemSidebar        *emblem_sidebar);
 static void caja_emblem_sidebar_iface_init        (CajaSidebarIface         *iface);

--- a/src/caja-image-properties-page.c
+++ b/src/caja-image-properties-page.c
@@ -46,6 +46,10 @@
 
 #define LOAD_BUFFER_SIZE 8192
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 struct CajaImagePropertiesPageDetails
 {
     GCancellable *cancellable;

--- a/src/caja-location-bar.c
+++ b/src/caja-location-bar.c
@@ -58,6 +58,10 @@ static const char untranslated_go_to_label[] = N_("Go To:");
 #define LOCATION_LABEL _(untranslated_location_label)
 #define GO_TO_LABEL _(untranslated_go_to_label)
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 struct CajaLocationBarDetails
 {
     GtkLabel *label;

--- a/src/caja-location-dialog.c
+++ b/src/caja-location-dialog.c
@@ -32,6 +32,10 @@
 #include "caja-desktop-window.h"
 #include <glib/gi18n.h>
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 struct _CajaLocationDialogDetails
 {
     GtkWidget *entry;

--- a/src/caja-navigation-window-pane.c
+++ b/src/caja-navigation-window-pane.c
@@ -45,6 +45,10 @@ G_DEFINE_TYPE (CajaNavigationWindowPane,
                CAJA_TYPE_WINDOW_PANE)
 #define parent_class caja_navigation_window_pane_parent_class
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
 
 static void
 real_set_active (CajaWindowPane *pane, gboolean is_active)

--- a/src/caja-navigation-window.c
+++ b/src/caja-navigation-window.c
@@ -108,6 +108,10 @@ static CajaWindowSlot *create_extra_pane         (CajaNavigationWindow *window);
 G_DEFINE_TYPE (CajaNavigationWindow, caja_navigation_window, CAJA_TYPE_WINDOW)
 #define parent_class caja_navigation_window_parent_class
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 static const struct
 {
     unsigned int keyval;

--- a/src/caja-notebook.c
+++ b/src/caja-notebook.c
@@ -45,6 +45,10 @@
 
 #define INSANE_NUMBER_OF_URLS 20
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 static void caja_notebook_init		 (CajaNotebook *notebook);
 static void caja_notebook_class_init	 (CajaNotebookClass *klass);
 static int  caja_notebook_insert_page	 (GtkNotebook *notebook,

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -39,6 +39,10 @@
 #define gtk_widget_get_preferred_size(x,y,z) gtk_widget_size_request(x,y)
 #endif
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 enum
 {
     PATH_CLICKED,

--- a/src/caja-property-browser.c
+++ b/src/caja-property-browser.c
@@ -182,6 +182,10 @@ static GdkPixbuf * make_color_drag_image                        (CajaPropertyBro
 
 #define ERASE_OBJECT_NAME "erase.png"
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 enum
 {
     PROPERTY_TYPE
@@ -347,7 +351,11 @@ caja_property_browser_init (CajaPropertyBrowser *property_browser)
     gtk_widget_show(temp_frame);
     gtk_container_add(GTK_CONTAINER(property_browser->details->title_box), temp_frame);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+    temp_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+#else
     temp_hbox = gtk_hbox_new(FALSE, 0);
+#endif
     gtk_widget_show(temp_hbox);
 
     gtk_container_add(GTK_CONTAINER(temp_frame), temp_hbox);
@@ -372,7 +380,11 @@ caja_property_browser_init (CajaPropertyBrowser *property_browser)
     temp_box = gtk_event_box_new();
     gtk_widget_show(temp_box);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+    property_browser->details->bottom_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+#else
     property_browser->details->bottom_box = gtk_hbox_new (FALSE, 6);
+#endif
     gtk_widget_show (property_browser->details->bottom_box);
 
     gtk_box_pack_end (GTK_BOX (vbox), temp_box, FALSE, FALSE, 0);
@@ -1137,7 +1149,11 @@ caja_emblem_dialog_new (CajaPropertyBrowser *property_browser)
     gtk_widget_show (label);
     gtk_table_attach (GTK_TABLE(table), label, 0, 1, 1, 2, GTK_FILL, GTK_FILL, 0, 0);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+    widget = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+#else
     widget = gtk_hbox_new (FALSE, 0);
+#endif
     gtk_widget_show (widget);
 
     button = gtk_button_new ();

--- a/src/caja-query-editor.c
+++ b/src/caja-query-editor.c
@@ -34,6 +34,11 @@
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 typedef enum
 {
     CAJA_QUERY_EDITOR_ROW_LOCATION,

--- a/src/caja-search-bar.c
+++ b/src/caja-search-bar.c
@@ -29,6 +29,10 @@
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 struct CajaSearchBarDetails
 {
     GtkWidget *entry;

--- a/src/caja-side-pane.c
+++ b/src/caja-side-pane.c
@@ -34,6 +34,10 @@
 #define gtk_widget_get_preferred_size(x,y,z) gtk_widget_size_request(x,y)
 #endif
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 typedef struct
 {
     char *title;

--- a/src/caja-sidebar-title.c
+++ b/src/caja-sidebar-title.c
@@ -57,6 +57,10 @@
 #define DEFAULT_LIGHT_INFO_COLOR 0xFFFFFF
 #define DEFAULT_DARK_INFO_COLOR  0x2A2A2A
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 static void                caja_sidebar_title_size_allocate     (GtkWidget             *widget,
         							 GtkAllocation         *allocation);
 static void                update_icon                          (CajaSidebarTitle      *sidebar_title);

--- a/src/caja-spatial-window.c
+++ b/src/caja-spatial-window.c
@@ -75,6 +75,10 @@
 #define SPATIAL_ACTION_CLOSE_ALL_FOLDERS    "Close All Folders"
 #define MENU_PATH_SPATIAL_BOOKMARKS_PLACEHOLDER	"/MenuBar/Other Menus/Places/Bookmarks Placeholder"
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 struct _CajaSpatialWindowDetails
 {
     GtkActionGroup *spatial_action_group; /* owned by ui_manager */

--- a/src/caja-view-as-action.c
+++ b/src/caja-view-as-action.c
@@ -42,6 +42,10 @@ static GObjectClass *parent_class = NULL;
 
 #define CAJA_VIEW_AS_ACTION_GET_PRIVATE(object)(G_TYPE_INSTANCE_GET_PRIVATE ((object), CAJA_TYPE_VIEW_AS_ACTION, CajaViewAsActionPrivate))
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 struct CajaViewAsActionPrivate
 {
     CajaNavigationWindow *window;

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -127,6 +127,10 @@
 #define MAX_MENU_LEVELS 5
 #define TEMPLATE_LIMIT 30
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#endif
+
 enum {
 	ADD_FILE,
 	BEGIN_FILE_CHANGES,

--- a/src/file-manager/fm-ditem-page.c
+++ b/src/file-manager/fm-ditem-page.c
@@ -36,6 +36,10 @@
 
 #define MAIN_GROUP "Desktop Entry"
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 typedef struct ItemEntry
 {
     const char *field;

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -61,6 +61,10 @@
 #include <libcaja-private/caja-clipboard.h>
 #include <libcaja-private/caja-cell-renderer-text-ellipsized.h>
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 struct FMListViewDetails
 {
     GtkTreeView *tree_view;

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -81,6 +81,11 @@
 
 #define ROW_PAD 6
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 static GHashTable *windows;
 static GHashTable *pending_lists;
 

--- a/test/test-eel-editable-label.c
+++ b/test/test-eel-editable-label.c
@@ -6,6 +6,10 @@
 
 #include <eel/eel-editable-label.h>
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
+
 
 static void
 quit (GtkWidget *widget, gpointer data)

--- a/test/test-eel-labeled-image.c
+++ b/test/test-eel-labeled-image.c
@@ -2,6 +2,9 @@
 
 #include <eel/eel-labeled-image.h>
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#endif
 
 static const char pixbuf_name[] = "/usr/share/pixmaps/mate-globe.png";
 


### PR DESCRIPTION
- gtk_{v,h}box usage is deprecated since gtk+-3.2.0