### PR TITLE
GTK3: fix desktop flashes

### DIFF
--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -138,6 +138,11 @@ caja_desktop_window_new (CajaApplication *application,
 
     /* Special sawmill setting*/
     gtk_window_set_wmclass (GTK_WINDOW (window), "desktop_window", "Caja");
+    
+#if GTK_CHECK_VERSION (3, 0, 0)      /*turn remaining gtk3.16 and later flashes transparent */   
+    GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+    gtk_widget_set_visual(GTK_WIDGET(window), visual);
+#endif    
 
     g_signal_connect (window, "delete_event", G_CALLBACK (caja_desktop_window_delete_event), NULL);
 

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -836,6 +836,23 @@ fm_desktop_icon_view_create (CajaWindowSlotInfo *slot)
     view = g_object_new (FM_TYPE_DESKTOP_ICON_VIEW,
                          "window-slot", slot,
                          NULL);
+                         
+     /*fix most of the nasty gtk3.16 and later flashes*/
+#if GTK_CHECK_VERSION (3, 0, 0) 
+    gtk_widget_set_name(view, "fmdesktopiconview");
+    GtkCssProvider  *cssProvider;
+    cssProvider = gtk_css_provider_new ();
+    gtk_css_provider_load_from_data (cssProvider,
+                                     "#fmdesktopiconview>.view,  \n"
+                                     "#fmdesktopiconview>.view:backdrop {\n"                                       
+                                     "background-color:transparent;\n"
+                                     "color: black;" /*theme can override with #fmdesktopiconview>.view>* selector*/
+                                      "}",-1, NULL);
+    gtk_style_context_add_provider_for_screen (gdk_screen_get_default(), 
+    GTK_STYLE_PROVIDER(cssProvider),  
+    GTK_STYLE_PROVIDER_PRIORITY_APPLICATION); /*don't let themes bring the flashes back*/
+#endif  
+
     return CAJA_VIEW (view);
 }
 


### PR DESCRIPTION
Two commits, both can be used or just the first.

The first commit stops the flashes when clicking between the desktop and open windows, in all themes. Remaining flashes turn black.  Text on desktop rename labels (unselected text)  had to be hardcoded to black (sane default), themes can override by using the #fmdesktopiconview>.view>* selector.  This commit overrides the .view and .view:backdrop selectors that differ in themes like Adwaita and cause desktop flashes when clicking between the desktop and open windows.
 
The second commit turns the remaining flashes transparent, so they are never seen except by momentary intensification of shadows when changing themes or during heavy disk activity. By forcing transparency for the desktop icon view window, the flashes become transparent and thus almost invisible instead of black. Testing with gtk3.19 I could not reproduce the reported crash on changing backgrounds with fade option enabled. 

The second commit did introduce one new compiz issue, compiz must be restarted to switch to a solid color background. Not necessary for gradient or picture backgrounds.

There are compiz issues with current git master compiz that did not come from these commits. These are a requirement to enable the fade option to swtich to a solid color background, and an ugly failure to redraw the desktop on moving a window when a soild color background is used with icons on the desktop disabled. I tested these issues with and without these commits to be sure.