### PR TITLE
Flashfix5

### DIFF
--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -138,6 +138,11 @@ caja_desktop_window_new (CajaApplication *application,
 
     /* Special sawmill setting*/
     gtk_window_set_wmclass (GTK_WINDOW (window), "desktop_window", "Caja");
+    
+#if GTK_CHECK_VERSION (3, 0, 0)      /*turn remaining gtk3.16 and later flashes transparent */   
+    GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+    gtk_widget_set_visual(GTK_WIDGET(window), visual);
+#endif
 
     g_signal_connect (window, "delete_event", G_CALLBACK (caja_desktop_window_delete_event), NULL);
 

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -836,6 +836,24 @@ fm_desktop_icon_view_create (CajaWindowSlotInfo *slot)
     view = g_object_new (FM_TYPE_DESKTOP_ICON_VIEW,
                          "window-slot", slot,
                          NULL);
+                         
+     /*fix most of the nasty gtk3.16 and later flashes*/
+#if GTK_CHECK_VERSION (3, 0, 0) 
+    gtk_widget_set_name(view, "fmdesktopiconview");
+    GtkCssProvider  *cssProvider;
+    cssProvider = gtk_css_provider_new ();
+    gtk_css_provider_load_from_data (cssProvider,
+                                     "#fmdesktopiconview, \n"
+                                     "#fmdesktopiconview>.view,  \n"
+                                     "#fmdesktopiconview>.view:backdrop {\n"                                       
+                                     "background-color:transparent;\n"
+                                     "color: black;" /*theme can override with #fmdesktopiconview>.view>* selector*/
+                                      "}",-1, NULL);
+    gtk_style_context_add_provider_for_screen (gdk_screen_get_default(), 
+    GTK_STYLE_PROVIDER(cssProvider),  
+    GTK_STYLE_PROVIDER_PRIORITY_APPLICATION); /*don't let themes bring the flashes back*/
+#endif                          
+                         
     return CAJA_VIEW (view);
 }
 


### PR DESCRIPTION
New version of previous PR for fixing desktop flashes, this version works both before and after the commit to gtk3.19.4 that broke the previous effort. The first commit here, as before, stops most flashes. A single additional line was needed to hardcode #fmdesktopiconview (the icon view) as well as #fmdesktopiconview .view (the icon container within) to stop flashes on themes other than Adwaita. This branch now works again,  though the previously reported issue with crashes on changing backgrounds with fade enabled will probably be unchanged. Also the memory leak on a flash is still present, this covers up the symptoms rather than fixing the underlying problem. This is a "good enough for now" fix but not the RIGHT fix.  