### PR TITLE
Small additional fix for #457

### DIFF
--- a/src/caja-notebook.c
+++ b/src/caja-notebook.c
@@ -218,7 +218,7 @@ button_press_cb (CajaNotebook *notebook,
     tab_clicked = find_tab_num_at_pos (notebook, event->x_root, event->y_root);
 
     if (event->type == GDK_BUTTON_PRESS &&
-            event->button == 3 &&
+            (event->button == 3 || event->button == 2) &&
             (event->state & gtk_accelerator_get_default_mod_mask ()) == 0)
     {
         if (tab_clicked == -1)


### PR DESCRIPTION
For the existing feature code to work the current selected tab must be correctly update when a middle click is made to a tab label. otherwise, middle click will always close the currently open tab and not the clicked one.

I am investigating making a gsettings parameter for this too as requested, it should be trivial.