### PR TITLE
GTK3 replace deprecated gdk_app_launch_context

### DIFF
--- a/eel/eel-mate-extensions.c
+++ b/eel/eel-mate-extensions.c
@@ -182,11 +182,17 @@ eel_mate_open_terminal_on_screen (const char *command,
                                   GdkScreen  *screen)
 {
     char *command_line;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GAppInfo *app;
+    GdkAppLaunchContext *ctx;
+    GError *error = NULL;
+#else
 
     if (screen == NULL)
     {
         screen = gdk_screen_get_default ();
     }
+#endif
 
     command_line = eel_mate_make_terminal_command (command);
     if (command_line == NULL)
@@ -195,7 +201,28 @@ eel_mate_open_terminal_on_screen (const char *command,
         return;
     }
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+    app = g_app_info_create_from_commandline (command_line, NULL, 0, &error);
+
+    if (app != NULL && screen != NULL) {
+            ctx = gdk_app_launch_context_new ();
+            gdk_app_launch_context_set_screen (ctx, screen);
+
+            g_app_info_launch (app, NULL, G_APP_LAUNCH_CONTEXT (ctx), &error);
+
+            g_object_unref (app);
+            g_object_unref (ctx);
+    }
+
+    if (error != NULL) {
+            g_message ("Could not start application on terminal: %s", error->message);
+
+            g_error_free (error);
+    }
+
+#else
     mate_gdk_spawn_command_line_on_screen(screen, command_line, NULL);
+#endif
     g_free (command_line);
 }
 

--- a/eel/eel-mate-extensions.c
+++ b/eel/eel-mate-extensions.c
@@ -160,7 +160,11 @@ get_terminal_command_prefix (gboolean for_command)
     return command;
 }
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+static char *
+#else
 char *
+#endif
 eel_mate_make_terminal_command (const char *command)
 {
     char *prefix, *quoted, *terminal_command;
@@ -186,6 +190,7 @@ eel_mate_open_terminal_on_screen (const char *command,
     GAppInfo *app;
     GdkAppLaunchContext *ctx;
     GError *error = NULL;
+    GdkDisplay *display;
 #else
 
     if (screen == NULL)
@@ -205,7 +210,8 @@ eel_mate_open_terminal_on_screen (const char *command,
     app = g_app_info_create_from_commandline (command_line, NULL, 0, &error);
 
     if (app != NULL && screen != NULL) {
-            ctx = gdk_app_launch_context_new ();
+            display = gdk_screen_get_display (screen);
+            ctx = gdk_display_get_app_launch_context (display);
             gdk_app_launch_context_set_screen (ctx, screen);
 
             g_app_info_launch (app, NULL, G_APP_LAUNCH_CONTEXT (ctx), &error);
@@ -226,8 +232,10 @@ eel_mate_open_terminal_on_screen (const char *command,
     g_free (command_line);
 }
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 void
 eel_mate_open_terminal (const char *command)
 {
     eel_mate_open_terminal_on_screen (command, NULL);
 }
+#endif

--- a/eel/eel-mate-extensions.h
+++ b/eel/eel-mate-extensions.h
@@ -29,11 +29,15 @@
 
 #include <gtk/gtk.h>
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 /* Return a command string containing the path to a terminal on this system. */
 char *        eel_mate_make_terminal_command                         (const char               *command);
+#endif
 
 /* Open up a new terminal, optionally passing in a command to execute */
+#if !GTK_CHECK_VERSION (3, 0, 0)
 void          eel_mate_open_terminal                                 (const char               *command);
+#endif
 void          eel_mate_open_terminal_on_screen                       (const char               *command,
         GdkScreen                *screen);
 

--- a/libcaja-private/caja-mime-actions.c
+++ b/libcaja-private/caja-mime-actions.c
@@ -1792,7 +1792,11 @@ activate_files (ActivateParameters *parameters)
     GList *l;
     int count;
     char *uri;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    char *executable_path, *quoted_path;
+#else
     char *executable_path, *quoted_path, *name;
+#endif
     char *old_working_dir;
     ActivationAction action;
     GdkScreen *screen;
@@ -1877,6 +1881,14 @@ activate_files (ActivateParameters *parameters)
         uri = caja_file_get_activation_uri (file);
         executable_path = g_filename_from_uri (uri, NULL, NULL);
         quoted_path = g_shell_quote (executable_path);
+#if GTK_CHECK_VERSION (3, 0, 0)
+
+        caja_debug_log (FALSE, CAJA_DEBUG_LOG_DOMAIN_USER,
+                        "directory view activate_callback launch_file window=%p: %s",
+                        parameters->parent_window, quoted_path);
+
+        caja_launch_application_from_command (screen, quoted_path, FALSE, NULL);
+#else
         name = caja_file_get_name (file);
 
         caja_debug_log (FALSE, CAJA_DEBUG_LOG_DOMAIN_USER,
@@ -1885,6 +1897,7 @@ activate_files (ActivateParameters *parameters)
 
         caja_launch_application_from_command (screen, name, quoted_path, FALSE, NULL);
         g_free (name);
+#endif
         g_free (quoted_path);
         g_free (executable_path);
         g_free (uri);
@@ -1899,6 +1912,14 @@ activate_files (ActivateParameters *parameters)
         uri = caja_file_get_activation_uri (file);
         executable_path = g_filename_from_uri (uri, NULL, NULL);
         quoted_path = g_shell_quote (executable_path);
+#if GTK_CHECK_VERSION (3, 0, 0)
+
+        caja_debug_log (FALSE, CAJA_DEBUG_LOG_DOMAIN_USER,
+                        "directory view activate_callback launch_in_terminal window=%p: %s",
+                        parameters->parent_window, quoted_path);
+
+        caja_launch_application_from_command (screen, quoted_path, TRUE, NULL);
+#else
         name = caja_file_get_name (file);
 
         caja_debug_log (FALSE, CAJA_DEBUG_LOG_DOMAIN_USER,
@@ -1907,6 +1928,7 @@ activate_files (ActivateParameters *parameters)
 
         caja_launch_application_from_command (screen, name, quoted_path, TRUE, NULL);
         g_free (name);
+#endif
         g_free (quoted_path);
         g_free (executable_path);
         g_free (uri);

--- a/libcaja-private/caja-program-choosing.c
+++ b/libcaja-private/caja-program-choosing.c
@@ -303,7 +303,9 @@ caja_launch_application_by_uri (GAppInfo *application,
  */
 void
 caja_launch_application_from_command (GdkScreen  *screen,
+#if !GTK_CHECK_VERSION (3, 0, 0)
                                       const char *name,
+#endif
                                       const char *command_string,
                                       gboolean use_terminal,
                                       ...)
@@ -312,6 +314,10 @@ caja_launch_application_from_command (GdkScreen  *screen,
     char *quoted_parameter;
     char *parameter;
     va_list ap;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GAppInfo *app;
+    GdkAppLaunchContext *ctx;
+#endif
 
     full_command = g_strdup (command_string);
 
@@ -337,19 +343,16 @@ caja_launch_application_from_command (GdkScreen  *screen,
     else
     {
 #if GTK_CHECK_VERSION (3, 0, 0)
-        GdkAppLaunchContext *launch_context;
-        GAppInfo *app_info = NULL;
-        app_info = g_app_info_create_from_commandline (full_command,
-                                                       NULL,
-                                                       G_APP_INFO_CREATE_NONE,
-                                                       NULL);
-        if (app_info != NULL)
-        {
-            launch_context = gdk_app_launch_context_new ();
-            gdk_app_launch_context_set_screen (launch_context, screen);
-            g_app_info_launch (app_info, NULL, G_APP_LAUNCH_CONTEXT (launch_context), NULL);
-            g_object_unref (launch_context);
-            g_object_unref (app_info);
+        app = g_app_info_create_from_commandline (full_command, NULL, 0, NULL);
+
+        if (app != NULL) {
+                ctx = gdk_app_launch_context_new ();
+                gdk_app_launch_context_set_screen (ctx, screen);
+
+                g_app_info_launch (app, NULL, G_APP_LAUNCH_CONTEXT (ctx), NULL);
+
+                g_object_unref (app);
+                g_object_unref (ctx);
         }
 #else
         GError *error = NULL;
@@ -400,7 +403,9 @@ caja_launch_application_from_command (GdkScreen  *screen,
  */
 void
 caja_launch_application_from_command_array (GdkScreen  *screen,
+#if !GTK_CHECK_VERSION (3, 0, 0)
         const char *name,
+#endif
         const char *command_string,
         gboolean use_terminal,
         const char * const * parameters)
@@ -408,6 +413,10 @@ caja_launch_application_from_command_array (GdkScreen  *screen,
     char *full_command, *tmp;
     char *quoted_parameter;
     const char * const *p;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GAppInfo *app;
+    GdkAppLaunchContext *ctx;
+#endif
 
     full_command = g_strdup (command_string);
 
@@ -431,19 +440,16 @@ caja_launch_application_from_command_array (GdkScreen  *screen,
     else
     {
 #if GTK_CHECK_VERSION (3, 0, 0)
-        GdkAppLaunchContext *launch_context;
-        GAppInfo *app_info = NULL;
-        app_info = g_app_info_create_from_commandline (full_command,
-                                                       NULL,
-                                                       G_APP_INFO_CREATE_NONE,
-                                                       NULL);
-        if (app_info != NULL)
-        {
-            launch_context = gdk_app_launch_context_new ();
-            gdk_app_launch_context_set_screen (launch_context, screen);
-            g_app_info_launch (app_info, NULL, G_APP_LAUNCH_CONTEXT (launch_context), NULL);
-            g_object_unref (launch_context);
-            g_object_unref (app_info);
+        app = g_app_info_create_from_commandline (full_command, NULL, 0, NULL);
+
+        if (app != NULL) {
+                ctx = gdk_app_launch_context_new ();
+                gdk_app_launch_context_set_screen (ctx, screen);
+
+                g_app_info_launch (app, NULL, G_APP_LAUNCH_CONTEXT (ctx), NULL);
+
+                g_object_unref (app);
+                g_object_unref (ctx);
         }
 #else
         GError *error = NULL;

--- a/libcaja-private/caja-program-choosing.h
+++ b/libcaja-private/caja-program-choosing.h
@@ -40,12 +40,16 @@ void caja_launch_application_by_uri          (GAppInfo                          
         GList                             *uris,
         GtkWindow                         *parent_window);
 void caja_launch_application_from_command    (GdkScreen                         *screen,
+#if !GTK_CHECK_VERSION (3, 0, 0)
         const char                        *name,
+#endif
         const char                        *command_string,
         gboolean                           use_terminal,
         ...) G_GNUC_NULL_TERMINATED;
 void caja_launch_application_from_command_array (GdkScreen                         *screen,
+#if !GTK_CHECK_VERSION (3, 0, 0)
         const char                        *name,
+#endif
         const char                        *command_string,
         gboolean                           use_terminal,
         const char * const *               parameters);

--- a/src/caja-connect-server-dialog-main.c
+++ b/src/caja-connect-server-dialog-main.c
@@ -82,7 +82,11 @@ caja_connect_server_dialog_display_location_async (CajaConnectServerDialog *self
 
     error = NULL;
     uri = g_file_get_uri (location);
+#if GTK_CHECK_VERSION (3, 0, 0)
+    launch_context = gdk_display_get_app_launch_context (gtk_widget_get_display (GTK_WIDGET (self)));
+#else
     launch_context = gdk_app_launch_context_new ();
+#endif
     gdk_app_launch_context_set_screen (launch_context,
                                        gtk_widget_get_screen (GTK_WIDGET (self)));
 

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -671,7 +671,9 @@ action_new_launcher_callback (GtkAction *action, gpointer data)
     desktop_directory = caja_get_desktop_directory ();
 
     caja_launch_application_from_command (gtk_widget_get_screen (GTK_WIDGET (data)),
+#if !GTK_CHECK_VERSION (3, 0, 0)
                                           "mate-desktop-item-edit",
+#endif
                                           "mate-desktop-item-edit",
                                           FALSE,
                                           "--create-new", desktop_directory, NULL);
@@ -686,7 +688,9 @@ action_change_background_callback (GtkAction *action,
     g_assert (FM_DIRECTORY_VIEW (data));
 
     caja_launch_application_from_command (gtk_widget_get_screen (GTK_WIDGET (data)),
+#if !GTK_CHECK_VERSION (3, 0, 0)
                                           _("Background"),
+#endif
                                           "mate-appearance-properties",
                                           FALSE,
                                           "--show-page=background", NULL);

--- a/src/file-manager/fm-tree-view.c
+++ b/src/file-manager/fm-tree-view.c
@@ -427,7 +427,11 @@ got_activation_uri_callback (CajaFile *file, gpointer callback_data)
             caja_debug_log (FALSE, CAJA_DEBUG_LOG_DOMAIN_USER,
                             "tree view launch_application_from_command window=%p: %s",
                             view->details->window, file_uri);
+#if GTK_CHECK_VERSION (3, 0, 0)
+            caja_launch_application_from_command (screen, file_uri, FALSE, NULL);
+#else
             caja_launch_application_from_command (screen, NULL, file_uri, FALSE, NULL);
+#endif
             g_free (file_uri);
         }
 


### PR DESCRIPTION
@monsta 
Please test and review
The gdk_spawn_ API commits were needed to apply the gdk_app_launch_context commit clean.
I used for all commits gtk3 checks because i wasn't sure if this works for gtk2.
Maybe this can be improved.
Links to upstream commits are mentioned.