### PR TITLE
GTK3: fix deprecated GtkMisc

### DIFF
--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -483,8 +483,8 @@ eel_gtk_message_dialog_set_details_label (GtkMessageDialog *dialog,
 	label = gtk_label_new (details_text);
 	gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
 	gtk_label_set_selectable (GTK_LABEL (label), TRUE);
-#if GTK_CHECK_VERSION (3, 14, 0)
-	gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+	gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
 	gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif

--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -1102,8 +1102,13 @@ labeled_image_update_alignments (EelLabeledImage *labeled_image)
 
         if (labeled_image->details->fill)
         {
+#if GTK_CHECK_VERSION (3, 16, 0)
+            x_alignment = gtk_label_get_xalign (GTK_LABEL (labeled_image->details->label));
+            y_alignment = gtk_label_get_yalign (GTK_LABEL (labeled_image->details->label));
+#else
             gtk_misc_get_alignment (GTK_MISC (labeled_image->details->label),
                                     &x_alignment, &y_alignment);
+#endif
 
             /* Only the label is shown */
             if (!labeled_image_show_image (labeled_image))
@@ -1139,9 +1144,9 @@ labeled_image_update_alignments (EelLabeledImage *labeled_image)
 
             }
 
-#if GTK_CHECK_VERSION (3, 14, 0)
-            gtk_widget_set_halign (labeled_image->details->label, GTK_ALIGN_CENTER);
-            gtk_widget_set_valign (labeled_image->details->label, GTK_ALIGN_CENTER);
+#if GTK_CHECK_VERSION (3, 16, 0)
+            gtk_label_set_xalign (GTK_LABEL (labeled_image->details->label), x_alignment);
+            gtk_label_set_yalign (GTK_LABEL (labeled_image->details->label), y_alignment);
 #else
             gtk_misc_set_alignment (GTK_MISC (labeled_image->details->label),
                                     x_alignment,
@@ -1157,8 +1162,13 @@ labeled_image_update_alignments (EelLabeledImage *labeled_image)
 
         if (labeled_image->details->fill)
         {
+#if GTK_CHECK_VERSION (3, 0, 0)
+            x_alignment = gtk_widget_get_halign (labeled_image->details->image);
+            y_alignment = gtk_widget_get_valign (labeled_image->details->image);
+#else
             gtk_misc_get_alignment (GTK_MISC (labeled_image->details->image),
                                     &x_alignment, &y_alignment);
+#endif
 
             /* Only the image is shown */
             if (!labeled_image_show_label (labeled_image))
@@ -1193,9 +1203,9 @@ labeled_image_update_alignments (EelLabeledImage *labeled_image)
                 }
             }
 
-#if GTK_CHECK_VERSION (3, 14, 0)
-            gtk_widget_set_halign (labeled_image->details->image, GTK_ALIGN_CENTER);
-            gtk_widget_set_valign (labeled_image->details->image, GTK_ALIGN_CENTER);
+#if GTK_CHECK_VERSION (3, 0, 0)
+            gtk_widget_set_halign (labeled_image->details->image, x_alignment);
+            gtk_widget_set_valign (labeled_image->details->image, y_alignment);
 #else
             gtk_misc_set_alignment (GTK_MISC (labeled_image->details->image),
                                     x_alignment,

--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -221,7 +221,11 @@ file_list_ready_cb (GList *files,
     gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
     gtk_label_set_line_wrap_mode (GTK_LABEL (label), PANGO_WRAP_WORD_CHAR);
 #if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+#else
+    gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
     gtk_box_pack_start (GTK_BOX (details->titles_vbox),
                         label, FALSE, FALSE, 0);
     gtk_widget_show (label);
@@ -255,9 +259,12 @@ file_list_ready_cb (GList *files,
     gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
 #if GTK_CHECK_VERSION (3, 0, 0)
     gtk_label_set_max_width_chars (GTK_LABEL (label), 60);
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
 #else
     gtk_widget_set_size_request (label, 350, -1);
+#endif
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+#else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif
     gtk_box_pack_start (GTK_BOX (details->titles_vbox),
@@ -595,7 +602,7 @@ caja_file_conflict_dialog_init (CajaFileConflictDialog *fcd)
     widget = gtk_image_new_from_icon_name ("dialog-warning",
                                        GTK_ICON_SIZE_DIALOG);
     gtk_box_pack_start (GTK_BOX (hbox), widget, FALSE, FALSE, 0);
-#if GTK_CHECK_VERSION (3, 14, 0)
+#if GTK_CHECK_VERSION (3, 0, 0)
     gtk_widget_set_halign (widget, GTK_ALIGN_CENTER);
     gtk_widget_set_valign (widget, GTK_ALIGN_START);
 #else

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -9252,7 +9252,14 @@ caja_icon_container_start_renaming_selected_item (CajaIconContainer *container,
             eel_editable_label_set_justify (EEL_EDITABLE_LABEL (details->rename_widget), GTK_JUSTIFY_CENTER);
         }
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gtk_widget_set_margin_start (details->rename_widget, 1);
+        gtk_widget_set_margin_end (details->rename_widget, 1);
+        gtk_widget_set_margin_top (details->rename_widget, 1);
+        gtk_widget_set_margin_bottom (details->rename_widget, 1);
+#else
         gtk_misc_set_padding (GTK_MISC (details->rename_widget), 1, 1);
+#endif
         gtk_layout_put (GTK_LAYOUT (container),
                         details->rename_widget, 0, 0);
     }

--- a/libcaja-private/caja-mime-application-chooser.c
+++ b/libcaja-private/caja-mime-application-chooser.c
@@ -388,8 +388,8 @@ caja_mime_application_chooser_init (CajaMimeApplicationChooser *chooser)
     gtk_box_set_homogeneous (GTK_BOX (chooser), FALSE);
 
     chooser->details->label = gtk_label_new ("");
-#if GTK_CHECK_VERSION (3, 14, 0)
-    gtk_widget_set_halign (chooser->details->label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (chooser->details->label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (chooser->details->label), 0.0, 0.5);
 #endif

--- a/libcaja-private/caja-open-with-dialog.c
+++ b/libcaja-private/caja-open-with-dialog.c
@@ -857,8 +857,8 @@ caja_open_with_dialog_init (CajaOpenWithDialog *dialog)
     gtk_box_pack_start (GTK_BOX (vbox), vbox2, TRUE, TRUE, 0);
 
     dialog->details->label = gtk_label_new ("");
-#if GTK_CHECK_VERSION (3, 14, 0)
-    gtk_widget_set_halign (dialog->details->label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (dialog->details->label), 0.0);
 #else
     gtk_misc_set_alignment (GTK_MISC (dialog->details->label), 0.0, 0.5);
 #endif
@@ -884,8 +884,8 @@ caja_open_with_dialog_init (CajaOpenWithDialog *dialog)
     gtk_box_pack_start (GTK_BOX (vbox2), scrolled_window, TRUE, TRUE, 0);
 
     dialog->details->desc_label = gtk_label_new (_("Select an application to view its description."));
-#if GTK_CHECK_VERSION (3, 14, 0)
-    gtk_widget_set_halign (dialog->details->desc_label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (dialog->details->desc_label), 0.0);
 #else
     gtk_misc_set_alignment (GTK_MISC (dialog->details->desc_label), 0.0, 0.5);
 #endif

--- a/libcaja-private/caja-progress-info.c
+++ b/libcaja-private/caja-progress-info.c
@@ -375,8 +375,8 @@ progress_widget_new (CajaProgressInfo *info)
     gtk_widget_set_size_request (label, 500, -1);
     gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
     gtk_label_set_line_wrap_mode (GTK_LABEL (label), PANGO_WRAP_WORD_CHAR);
-#if GTK_CHECK_VERSION (3, 14, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif
@@ -417,8 +417,8 @@ progress_widget_new (CajaProgressInfo *info)
                         0);
 
     label = gtk_label_new ("details");
-#if GTK_CHECK_VERSION (3, 14, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif

--- a/src/caja-autorun-software.c
+++ b/src/caja-autorun-software.c
@@ -233,7 +233,7 @@ present_autorun_for_software_dialog (GMount *mount)
     icon_info = caja_icon_info_lookup (icon, icon_size);
     pixbuf = caja_icon_info_get_pixbuf_at_size (icon_info, icon_size);
     image = gtk_image_new_from_pixbuf (pixbuf);
-#if GTK_CHECK_VERSION (3, 14, 0)
+#if GTK_CHECK_VERSION (3, 0, 0)
     gtk_widget_set_halign (image, GTK_ALIGN_CENTER);
     gtk_widget_set_valign (image, GTK_ALIGN_START);
 #else

--- a/src/caja-connect-server-dialog.c
+++ b/src/caja-connect-server-dialog.c
@@ -891,8 +891,8 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
     str = g_strdup_printf ("<b>%s</b>", _("Server Details"));
     gtk_label_set_markup (GTK_LABEL (label), str);
     g_free (str);
-#if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif
@@ -918,7 +918,11 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
 
     /* first row: server entry + port spinbutton */
     label = gtk_label_new_with_mnemonic (_("_Server:"));
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
+#else
+    gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
     gtk_container_add (GTK_CONTAINER (grid), label);
     gtk_widget_show (label);
 
@@ -959,8 +963,8 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
 
     /* port */
     label = gtk_label_new_with_mnemonic (_("_Port:"));
-#if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif
@@ -981,11 +985,14 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
 
     /* second row: type combobox */
     label = gtk_label_new (_("Type:"));
-#if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
-    gtk_container_add (GTK_CONTAINER (grid), label);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_container_add (GTK_CONTAINER (grid), label);
+#else
     gtk_table_attach (GTK_TABLE (table), label,
     		  0, 1,
     		  1, 2,
@@ -1069,11 +1076,14 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
 
     /* third row: share entry */
     label = gtk_label_new (_("Share:"));
-#if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
-    gtk_container_add (GTK_CONTAINER (grid), label);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_container_add (GTK_CONTAINER (grid), label);
+#else
     gtk_table_attach (GTK_TABLE (table), label,
     		  0, 1,
     		  2, 3,
@@ -1096,11 +1106,14 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
 
     /* fourth row: folder entry */
     label = gtk_label_new (_("Folder:"));
-#if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
-    gtk_container_add (GTK_CONTAINER (grid), label);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_container_add (GTK_CONTAINER (grid), label);
+#else
     gtk_table_attach (GTK_TABLE (table), label,
     		  0, 1,
     		  3, 4,
@@ -1126,8 +1139,8 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
     str = g_strdup_printf ("<b>%s</b>", _("User Details"));
     gtk_label_set_markup (GTK_LABEL (label), str);
     g_free (str);
-#if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif
@@ -1157,11 +1170,14 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
 
     /* first row: domain entry */
     label = gtk_label_new (_("Domain Name:"));
-#if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
-    gtk_container_add (GTK_CONTAINER (grid), label);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_container_add (GTK_CONTAINER (grid), label);
+#else
     gtk_table_attach (GTK_TABLE (table), label,
     		  0, 1,
     		  0, 1,
@@ -1184,11 +1200,14 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
 
     /* second row: username entry */
     label = gtk_label_new (_("User Name:"));
-#if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
-    gtk_container_add (GTK_CONTAINER (grid), label);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_container_add (GTK_CONTAINER (grid), label);
+#else
     gtk_table_attach (GTK_TABLE (table), label,
     		  0, 1,
     		  1, 2,
@@ -1211,11 +1230,14 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
 
     /* third row: password entry */
     label = gtk_label_new (_("Password:"));
-#if GTK_CHECK_VERSION (3, 0, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
-    gtk_container_add (GTK_CONTAINER (grid), label);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_container_add (GTK_CONTAINER (grid), label);
+#else
     gtk_table_attach (GTK_TABLE (table), label,
                       0, 1,
                       2, 3,

--- a/src/caja-image-properties-page.c
+++ b/src/caja-image-properties-page.c
@@ -149,9 +149,9 @@ append_label (GtkWidget *vbox,
 
     label = gtk_label_new (NULL);
     gtk_label_set_markup (GTK_LABEL (label), str);
-#if GTK_CHECK_VERSION (3, 14, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
-    gtk_widget_set_valign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
+    gtk_label_set_yalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0, 0);
 #endif

--- a/src/caja-location-bar.c
+++ b/src/caja-location-bar.c
@@ -251,6 +251,9 @@ style_set_handler (GtkWidget *widget, GtkStyle *previous_style)
     PangoLayout *layout;
     int width, width2;
     int xpad;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gint margin_start, margin_end;
+#endif
 
     layout = gtk_label_get_layout (GTK_LABEL(widget));
 
@@ -263,8 +266,14 @@ style_set_handler (GtkWidget *widget, GtkStyle *previous_style)
     pango_layout_get_pixel_size (layout, &width2, NULL);
     width = MAX (width, width2);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+    margin_start = gtk_widget_get_margin_start (widget);
+    margin_end = gtk_widget_get_margin_end (widget);
+    xpad = margin_start + margin_end;
+#else
     gtk_misc_get_padding (GTK_MISC (widget),
                           &xpad, NULL);
+#endif
 
     width += 2 * xpad;
 
@@ -429,9 +438,9 @@ caja_location_bar_init (CajaLocationBar *bar)
     label = gtk_label_new (LOCATION_LABEL);
     gtk_container_add   (GTK_CONTAINER (event_box), label);
     gtk_label_set_justify (GTK_LABEL (label), GTK_JUSTIFY_RIGHT);
-#if GTK_CHECK_VERSION (3, 14, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_END);
-    gtk_widget_set_valign (label, GTK_ALIGN_CENTER);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 1.0);
+    gtk_label_set_yalign (GTK_LABEL (label), 0.5);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 1, 0.5);
 #endif

--- a/src/caja-notebook.c
+++ b/src/caja-notebook.c
@@ -407,12 +407,20 @@ build_tab_label (CajaNotebook *nb, CajaWindowSlot *slot)
     label = gtk_label_new (NULL);
     gtk_label_set_ellipsize (GTK_LABEL (label), PANGO_ELLIPSIZE_END);
     gtk_label_set_single_line_mode (GTK_LABEL (label), TRUE);
-#if GTK_CHECK_VERSION (3, 14, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+    gtk_label_set_yalign (GTK_LABEL (label), 0.5);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_widget_set_margin_start (label, 0);
+    gtk_widget_set_margin_end (label, 0);
+    gtk_widget_set_margin_top (label, 0);
+    gtk_widget_set_margin_bottom (label, 0);
+#else
     gtk_misc_set_padding (GTK_MISC (label), 0, 0);
+#endif
     gtk_box_pack_start (GTK_BOX (hbox), label, TRUE, TRUE, 0);
     gtk_widget_show (label);
 

--- a/src/caja-x-content-bar.c
+++ b/src/caja-x-content-bar.c
@@ -310,7 +310,9 @@ caja_x_content_bar_init (CajaXContentBar *bar)
     gtk_label_set_ellipsize (GTK_LABEL (bar->priv->label), PANGO_ELLIPSIZE_END);
 #if GTK_CHECK_VERSION (3, 0, 0)
     gtk_orientable_set_orientation (GTK_ORIENTABLE (bar), GTK_ORIENTATION_HORIZONTAL);
-    gtk_widget_set_halign (bar->priv->label, GTK_ALIGN_START);
+#endif
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (bar->priv->label), 0.0);
 #else
     gtk_misc_set_alignment (GTK_MISC (bar->priv->label), 0.0, 0.5);
 #endif

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -1231,7 +1231,7 @@ select_pattern (FMDirectoryView *view)
 					   "*.png, file\?\?.txt, pict*.\?\?\?");
 	gtk_label_set_markup (GTK_LABEL (example), example_pattern);
 	g_free (example_pattern);
-#if GTK_CHECK_VERSION (3, 14, 0)
+#if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_widget_set_halign (example, GTK_ALIGN_START);
 #else
 	gtk_misc_set_alignment (GTK_MISC (example), 0.0, 0.5);
@@ -1407,8 +1407,8 @@ action_save_search_as_callback (GtkAction *action,
 #endif
 
 		label = gtk_label_new_with_mnemonic (_("Search _name:"));
-#if GTK_CHECK_VERSION (3, 14, 0)
-		gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+		gtk_label_set_xalign (GTK_LABEL (label), 0.0);
 #else
 		gtk_misc_set_alignment (GTK_MISC(label), 0.0, 0.5);
 #endif
@@ -1435,8 +1435,8 @@ action_save_search_as_callback (GtkAction *action,
 
 		gtk_widget_show (entry);
 		label = gtk_label_new_with_mnemonic (_("_Folder:"));
-#if GTK_CHECK_VERSION (3, 14, 0)
-		gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+		gtk_label_set_xalign (GTK_LABEL (label), 0.0);
 #else
 		gtk_misc_set_alignment (GTK_MISC(label), 0.0, 0.5);
 #endif

--- a/src/file-manager/fm-ditem-page.c
+++ b/src/file-manager/fm-ditem-page.c
@@ -362,8 +362,8 @@ build_table (GtkWidget *container,
         label = gtk_label_new (label_text);
         gtk_label_set_use_markup (GTK_LABEL (label), TRUE);
         g_free (label_text);
-#if GTK_CHECK_VERSION (3, 14, 0)
-        gtk_widget_set_halign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+        gtk_label_set_xalign (GTK_LABEL (label), 0.0);
 #else
         gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
 #endif

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -2549,9 +2549,9 @@ create_column_editor (FMListView *view)
     label = gtk_label_new (NULL);
     gtk_label_set_markup (GTK_LABEL (label), str);
     gtk_label_set_line_wrap (GTK_LABEL (label), FALSE);
-#if GTK_CHECK_VERSION (3, 14, 0)
-    gtk_widget_set_halign (label, GTK_ALIGN_START);
-    gtk_widget_set_valign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_label_set_xalign (GTK_LABEL (label), 0);
+    gtk_label_set_yalign (GTK_LABEL (label), 0);
 #else
     gtk_misc_set_alignment (GTK_MISC (label), 0, 0);
 #endif

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -1464,8 +1464,8 @@ attach_label (GtkTable *table,
 		eel_gtk_label_make_bold (GTK_LABEL (label_field));
 	}
 #endif
-#if GTK_CHECK_VERSION (3, 14, 0)
-	gtk_widget_set_halign (label_field, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+	gtk_label_set_xalign (GTK_LABEL (label_field), 0);
 #else
 	gtk_misc_set_alignment (GTK_MISC (label_field), right_aligned ? 1 : 0, 0.5);
 #endif


### PR DESCRIPTION
@monsta 
@lukefromdc 
Please test.
Here a review is needed.
Most changes correct only deprecated gtk_misc_set_alignment for labels from pevious fix.
But i fixes also deprecated gtk_misc_{set/get}_padding in a few files.
Hope that i didn't break anything:)