### PR TITLE
fix loading multiple python extensions (regression since 1.9.3)

### DIFF
--- a/libcaja-private/caja-module.c
+++ b/libcaja-private/caja-module.c
@@ -154,11 +154,13 @@ static void
 add_module_objects (CajaModule *module)
 {
     GObject *object = NULL;
+    gchar *filename = NULL;
     const GType *types = NULL;
     int num_types = 0;
     int i;
 
     module->list_types (&types, &num_types);
+    filename = g_path_get_basename (module->path);
 
     for (i = 0; i < num_types; i++)
     {
@@ -167,9 +169,8 @@ add_module_objects (CajaModule *module)
             break;
         }
         object = caja_module_add_type (types[i]);
+        caja_extension_register (filename, object);
     }
-    gchar *filename = g_path_get_basename (module->path);
-    caja_extension_register (filename, object);
 }
 
 static CajaModule *


### PR DESCRIPTION
My extension management code (GSoC2014) caused a regression that stops multiple Python extensions from loading correctly. This issue was reported as [issue 3](https://github.com/mate-desktop/python-caja/issues/22) on the python-caja tracker. This commit fixes the immediate problem. 