### PR TITLE
Fix for duplicate Python extensions in management interface

### DIFF
--- a/libcaja-extension/caja-extension-types.h
+++ b/libcaja-extension/caja-extension-types.h
@@ -64,6 +64,7 @@ extern "C" {
     void caja_module_shutdown   (void);
     void caja_module_list_types (const GType **types,
                                  int          *num_types);
+    void caja_module_list_pyfiles (GList     **pyfiles);
 
 #ifdef __cplusplus
 }

--- a/libcaja-private/caja-extensions.c
+++ b/libcaja-private/caja-extensions.c
@@ -34,7 +34,7 @@ static GList *caja_extensions = NULL;
 
 
 static Extension *
-extension_new (gchar *filename, gboolean state, GObject *module)
+extension_new (gchar *filename, gboolean state, gboolean python, GObject *module)
 {
     Extension *ext;
     GKeyFile *extension_file;
@@ -50,7 +50,7 @@ extension_new (gchar *filename, gboolean state, GObject *module)
     ext->website = NULL;
     ext->state = state;
     ext->module = module;
-
+    
     extension_file = g_key_file_new ();
     extension_filename = g_strdup_printf(CAJA_DATADIR "/extensions/%s.caja-extension", filename);
     if (g_key_file_load_from_file (extension_file, extension_filename, G_KEY_FILE_NONE, NULL))
@@ -65,6 +65,12 @@ extension_new (gchar *filename, gboolean state, GObject *module)
     }
     g_key_file_free (extension_file);
     g_free (extension_filename);
+    
+    if (python)
+    {
+        ext->name = g_strconcat("Python: ", filename, NULL);
+        ext->description = "Python-caja extension";
+    }
 
     return ext;
 }
@@ -193,11 +199,16 @@ void
 caja_extension_register (gchar *filename, GObject *module)
 {
     gboolean ext_state = TRUE; // new extensions are enabled by default.
+    gboolean ext_python = FALSE;
     gchar *ext_filename;
     GList *l;
     
     ext_filename = g_strndup (filename, strlen(filename) - 3);
     ext_state = caja_extension_get_state (ext_filename);
+    
+    if (g_str_has_suffix (filename, ".py")) {
+        ext_python = TRUE;
+    }
 
     /* Do not attempt to register already registered extensions */
     for (l = caja_extensions; l != NULL; l = l->next)
@@ -208,7 +219,7 @@ caja_extension_register (gchar *filename, GObject *module)
         }
     }
 
-    Extension *ext = extension_new (ext_filename, ext_state, module);
+    Extension *ext = extension_new (ext_filename, ext_state, ext_python, module);
     caja_extensions = g_list_append (caja_extensions, ext);
 }
 

--- a/libcaja-private/caja-extensions.c
+++ b/libcaja-private/caja-extensions.c
@@ -192,13 +192,23 @@ caja_extensions_get_list (void)
 void
 caja_extension_register (gchar *filename, GObject *module)
 {
-    gboolean state = TRUE; // new extensions are enabled by default.
-    gchar *extname;
+    gboolean ext_state = TRUE; // new extensions are enabled by default.
+    gchar *ext_filename;
+    GList *l;
     
-    extname = g_strndup (filename, strlen(filename) - 3);
-    state = caja_extension_get_state (extname);
+    ext_filename = g_strndup (filename, strlen(filename) - 3);
+    ext_state = caja_extension_get_state (ext_filename);
 
-    Extension *ext = extension_new (extname, state, module);
+    /* Do not attempt to register already registered extensions */
+    for (l = caja_extensions; l != NULL; l = l->next)
+    {
+        Extension *r = l->data;
+        if (g_ascii_strcasecmp (r->filename, ext_filename) == 0) {
+            return;
+        }
+    }
+
+    Extension *ext = extension_new (ext_filename, ext_state, module);
     caja_extensions = g_list_append (caja_extensions, ext);
 }
 

--- a/libcaja-private/caja-module.c
+++ b/libcaja-private/caja-module.c
@@ -98,7 +98,7 @@ caja_module_load (GTypeModule *gmodule)
 
         return FALSE;
     }
-    
+
     g_module_symbol (module->library, 
                      "caja_module_list_pyfiles", 
                      (gpointer *)&module->list_pyfiles);
@@ -161,18 +161,17 @@ add_module_objects (CajaModule *module)
     GObject *object = NULL;
     GList *pyfiles = NULL;
     gchar *filename = NULL;
-    gboolean pymodule = FALSE;
     const GType *types = NULL;
     int num_types = 0;
     int i;
     
-
     module->list_types (&types, &num_types);
     filename = g_path_get_basename (module->path);
     
-    if (g_ascii_strcasecmp (filename, "libcaja-python.so") == 0) {
+    /* fetch extensions details loaded through python-caja module */
+    if (module->list_pyfiles)
+    {
         module->list_pyfiles(&pyfiles);
-        pymodule = TRUE;
     }
 
     for (i = 0; i < num_types; i++)
@@ -182,7 +181,7 @@ add_module_objects (CajaModule *module)
             break;
         }
         
-        if (pymodule)
+        if (module->list_pyfiles)
         {
             filename = g_strconcat(g_list_nth_data(pyfiles, i), ".py", NULL);
         }

--- a/libcaja-private/caja-module.c
+++ b/libcaja-private/caja-module.c
@@ -159,6 +159,7 @@ static void
 add_module_objects (CajaModule *module)
 {
     GObject *object = NULL;
+    GList *pyfiles = NULL;
     gchar *filename = NULL;
     gboolean pymodule = FALSE;
     const GType *types = NULL;


### PR DESCRIPTION
This commit fixes issue #520. Note that python-caja [pull-request 24](https://github.com/mate-desktop/python-caja/pull/24) is also required for this solution. 