### PR TITLE
GTK 3.20: Fix desktop window rendering in all WM's

### DIFF
--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -60,8 +60,10 @@ caja_desktop_window_init (CajaDesktopWindow *window)
     /* shouldn't really be needed given our semantic type
      * of _NET_WM_TYPE_DESKTOP, but why not
      */
+#if !GTK_CHECK_VERSION (3, 19, 0)     
     gtk_window_set_resizable (GTK_WINDOW (window),
                               FALSE);
+#endif
 
     g_object_set_data (G_OBJECT (window), "is_desktop_window",
                        GINT_TO_POINTER (1));
@@ -280,4 +282,3 @@ caja_desktop_window_loaded (CajaDesktopWindow *window)
 {
     return window->details->loaded;
 }
-


### PR DESCRIPTION
https://git.gnome.org/browse/gtk+/commit/?id=cdc580463e409a9b7e5f1480afa68d875ff3ff65 does not get along with
gtk_window_set_resizable false in a fullscreened, undecorated window. Put it behind a gtk3.18 and earlier only switch (don't risk breaking older GTK versions for now), and the desktop renders normally again. Tested and Works in Compiz, Marco, Mutter, and IceWM, didn't test any other WM's.