### PR TITLE
GTK 3.20-fix wrong desktop size 

### DIFF
--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -135,7 +135,12 @@ caja_desktop_window_new (CajaApplication *application,
                               "height_request", height_request,
                               "screen", screen,
                               NULL));
-
+    /* Stop wrong desktop window size in GTK 3.20*/
+    /* We don't want to set a default size, which the parent does, since this */
+    /* will cause the desktop window to open at the wrong size in gtk 3.20 */
+#if GTK_CHECK_VERSION (3, 19, 0) 
+    gtk_window_set_default_size (GTK_WINDOW (window), -1, -1);
+#endif
     /* Special sawmill setting*/
     gtk_window_set_wmclass (GTK_WINDOW (window), "desktop_window", "Caja");
 
@@ -280,4 +285,3 @@ caja_desktop_window_loaded (CajaDesktopWindow *window)
 {
     return window->details->loaded;
 }
-


### PR DESCRIPTION
Reset default size of desktop window to -1 in GTK 3.19/20 only. The combination of a non-resizable 
window with a default size is what causes the desktop to open wrong size.

based on https://github.com/GNOME/nautilus/commit/cf79068dc70c87e963e217e2e8ae149ee5ed1872

"desktop-window: avoid wrong size"

"gtk+ recently changed and unresizable windows now take into account
the default size set. We set the default size for normal resizable
windows in nautilus."

"However the desktop window is a no resizable window. What happens now
when setting a default size is that that size is used instead of the
widget request size, since window sizing now takes precedence over
widget sizing."

"To fix it, set the default size to -1 to override what the nautilus
window does by default, so we can avoid this misbehaviour."