### PR TITLE
fix font color issues in GTK+2 build

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -355,8 +355,6 @@ eel_background_ensure_realized (EelBackground *self)
 
     free_background_surface (self);
 
-    /* Calls mate_bg_set_color, which sets "ignore-pending-change" to false,
-       and queues emission of changed signal if it's still false */
     set_image_properties (self);
 
     window = gtk_widget_get_window (self->details->widget);
@@ -364,12 +362,6 @@ eel_background_ensure_realized (EelBackground *self)
         						window, width, height,
         						self->details->is_desktop);
     self->details->unset_root_surface = self->details->is_desktop;
-
-    /* We got the surface and everything, so we don't care about a change
-       that is pending (unless things actually change after this time) */
-    g_object_set_data (G_OBJECT (self->details->bg),
-                       "ignore-pending-change",
-                       GINT_TO_POINTER (TRUE));
 
     self->details->bg_entire_width = width;
     self->details->bg_entire_height = height;

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -4663,10 +4663,6 @@ realize (GtkWidget *widget)
     /* Set up DnD.  */
     caja_icon_dnd_init (container);
 
-#if !GTK_CHECK_VERSION(3, 0, 0)
-    setup_label_gcs (container);
-#endif
-
     hadj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (widget));
     g_signal_connect (hadj, "value_changed",
                       G_CALLBACK (handle_hadjustment_changed), widget);

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -9588,7 +9588,7 @@ setup_label_gcs (CajaIconContainer *container)
                           "frame_text", &frame_text,
                           NULL);
 
-    if (frame_text || !caja_icon_container_get_is_desktop (container))
+    if (frame_text || !eel_background_is_set (background))
     {
         setup_gc_with_fg (container, LABEL_COLOR,
                           eel_gdk_color_to_rgb (&style->text[GTK_STATE_NORMAL]));


### PR DESCRIPTION
@raveit65 @bl0ckeduser @alexandervdm @XRevan86

Hopefully this should fix all the font color issues for good. Please test it if you can. GTK+3 build shouldn't be affected by these changes due to ```#if```'s, so it should be enough to test GTK+2 build.

Please check whether **icon view** always has the right font color, and no regressions occur:
- desktop:
  - desktop font color should be white with black shadow, no matter which background color, gradient, or a wallpaper is chosen (https://github.com/mate-desktop/caja/issues/105 shouldn't happen);

- Caja window:
  - when no custom background is set and you switch between light and dark themes, font color should be black with light themes and white with dark themes (https://github.com/mate-desktop/caja/issues/81 shouldn't happen);

  - when custom background (either solid color or some pattern) is set, font color should be black with light background and white with dark background (the problem described in https://github.com/mate-desktop/caja/pull/501#issuecomment-172861877 shouldn't happen);

  - random changes of font color (https://github.com/mate-desktop/caja/issues/438) should not happen, no matter which theme or background is set. There are various steps to reproduce described in that report, for me the most reliable one (reproducible 100%) is described at https://github.com/mate-desktop/caja/issues/438#issuecomment-169078577.