### PR TITLE
GTK3: port GtkStyle->GtkStyleContext

### DIFF
--- a/src/caja-history-sidebar.c
+++ b/src/caja-history-sidebar.c
@@ -74,8 +74,13 @@ enum
 static void  caja_history_sidebar_iface_init        (CajaSidebarIface         *iface);
 static void  sidebar_provider_iface_init                (CajaSidebarProviderIface *iface);
 static GType caja_history_sidebar_provider_get_type (void);
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void  caja_history_sidebar_style_set	        (GtkWidget *widget,
+        GtkStyleContext  *previous_style);
+#else
 static void  caja_history_sidebar_style_set	        (GtkWidget *widget,
         GtkStyle  *previous_style);
+#endif
 
 G_DEFINE_TYPE_WITH_CODE (CajaHistorySidebar, caja_history_sidebar, GTK_TYPE_SCROLLED_WINDOW,
                          G_IMPLEMENT_INTERFACE (CAJA_TYPE_SIDEBAR,
@@ -375,7 +380,11 @@ caja_history_sidebar_set_parent_window (CajaHistorySidebar *sidebar,
 
 static void
 caja_history_sidebar_style_set (GtkWidget *widget,
+#if GTK_CHECK_VERSION (3, 0, 0)
+                                GtkStyleContext  *previous_style)
+#else
                                 GtkStyle  *previous_style)
+#endif
 {
     CajaHistorySidebar *sidebar;
 

--- a/src/caja-information-panel.c
+++ b/src/caja-information-panel.c
@@ -81,8 +81,13 @@ static void     caja_information_panel_drag_data_received    (GtkWidget         
         guint                         info,
         guint                         time);
 static void     caja_information_panel_read_defaults         (CajaInformationPanel     *information_panel);
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void     caja_information_panel_style_set             (GtkWidget                    *widget,
+        GtkStyleContext              *previous_style);
+#else
 static void     caja_information_panel_style_set             (GtkWidget                    *widget,
         GtkStyle                     *previous_style);
+#endif
 static void     caja_information_panel_theme_changed         (GSettings   *settings,
                                                               const gchar *key,
                                                               gpointer     user_data);
@@ -1174,7 +1179,11 @@ title_changed_callback (CajaWindowInfo *window,
 
 /* ::style_set handler for the information_panel */
 static void
+#if GTK_CHECK_VERSION (3, 0, 0)
+caja_information_panel_style_set (GtkWidget *widget, GtkStyleContext *previous_style)
+#else
 caja_information_panel_style_set (GtkWidget *widget, GtkStyle *previous_style)
+#endif
 {
     CajaInformationPanel *information_panel;
 

--- a/src/caja-location-bar.c
+++ b/src/caja-location-bar.c
@@ -246,7 +246,11 @@ drag_data_get_callback (GtkWidget *widget,
    we are imitating here. */
 
 static void
+#if GTK_CHECK_VERSION (3, 0, 0)
+style_set_handler (GtkWidget *widget, GtkStyleContext *previous_style)
+#else
 style_set_handler (GtkWidget *widget, GtkStyle *previous_style)
+#endif
 {
     PangoLayout *layout;
     int width, width2;

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -140,8 +140,10 @@ static void     caja_path_bar_grab_notify              (GtkWidget       *widget,
         gboolean         was_grabbed);
 static void     caja_path_bar_state_changed            (GtkWidget       *widget,
         GtkStateType     previous_state);
+#if !GTK_CHECK_VERSION (3, 0, 0)
 static void     caja_path_bar_style_set                (GtkWidget       *widget,
         GtkStyle        *previous_style);
+#endif
 static void     caja_path_bar_screen_changed           (GtkWidget       *widget,
         GdkScreen       *previous_screen);
 static void     caja_path_bar_check_icon_theme         (CajaPathBar *path_bar);
@@ -401,7 +403,9 @@ caja_path_bar_class_init (CajaPathBarClass *path_bar_class)
 #endif
     widget_class->unmap = caja_path_bar_unmap;
     widget_class->size_allocate = caja_path_bar_size_allocate;
+#if !GTK_CHECK_VERSION (3, 0, 0)
     widget_class->style_set = caja_path_bar_style_set;
+#endif
     widget_class->screen_changed = caja_path_bar_screen_changed;
     widget_class->grab_notify = caja_path_bar_grab_notify;
     widget_class->state_changed = caja_path_bar_state_changed;
@@ -956,6 +960,7 @@ caja_path_bar_size_allocate (GtkWidget     *widget,
     }
 }
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 static void
 caja_path_bar_style_set (GtkWidget *widget,	GtkStyle  *previous_style)
 {
@@ -966,6 +971,7 @@ caja_path_bar_style_set (GtkWidget *widget,	GtkStyle  *previous_style)
 
     caja_path_bar_check_icon_theme (CAJA_PATH_BAR (widget));
 }
+#endif
 
 static void
 caja_path_bar_screen_changed (GtkWidget *widget,
@@ -980,7 +986,9 @@ caja_path_bar_screen_changed (GtkWidget *widget,
     {
         remove_settings_signal (CAJA_PATH_BAR (widget), previous_screen);
     }
+#if !GTK_CHECK_VERSION (3, 0, 0)
     caja_path_bar_check_icon_theme (CAJA_PATH_BAR (widget));
+#endif
 }
 
 static gboolean
@@ -1381,7 +1389,7 @@ settings_notify_cb (GObject    *object,
         change_icon_theme (path_bar);
     }
 }
-
+#if !GTK_CHECK_VERSION (3, 0, 0)
 static void
 caja_path_bar_check_icon_theme (CajaPathBar *path_bar)
 {
@@ -1397,7 +1405,7 @@ caja_path_bar_check_icon_theme (CajaPathBar *path_bar)
 
     change_icon_theme (path_bar);
 }
-
+#endif
 /* Public functions and their helpers */
 void
 caja_path_bar_clear_buttons (CajaPathBar *path_bar)

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -165,8 +165,14 @@ static void  open_selected_bookmark                    (CajaPlacesSidebar       
         GtkTreeModel                 *model,
         GtkTreePath                  *path,
         CajaWindowOpenFlags flags);
+
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void  caja_places_sidebar_style_set         (GtkWidget                    *widget,
+        GtkStyleContext              *previous_style);
+#else
 static void  caja_places_sidebar_style_set         (GtkWidget                    *widget,
         GtkStyle                     *previous_style);
+#endif
 static gboolean eject_or_unmount_bookmark              (CajaPlacesSidebar *sidebar,
         GtkTreePath *path);
 static gboolean eject_or_unmount_selection             (CajaPlacesSidebar *sidebar);
@@ -3477,7 +3483,11 @@ caja_places_sidebar_set_parent_window (CajaPlacesSidebar *sidebar,
 
 static void
 caja_places_sidebar_style_set (GtkWidget *widget,
+#if GTK_CHECK_VERSION (3, 0, 0)
+                               GtkStyleContext  *previous_style)
+#else
                                GtkStyle  *previous_style)
+#endif
 {
     CajaPlacesSidebar *sidebar;
 

--- a/src/caja-sidebar-title.c
+++ b/src/caja-sidebar-title.c
@@ -74,8 +74,13 @@ static GtkWidget *         sidebar_title_create_more_info_label (void);
 static void		   update_all 				(CajaSidebarTitle      *sidebar_title);
 static void		   update_more_info			(CajaSidebarTitle      *sidebar_title);
 static void		   update_title_font			(CajaSidebarTitle      *sidebar_title);
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void                style_set                            (GtkWidget             *widget,
+        							 GtkStyleContext       *previous_style);
+#else
 static void                style_set                            (GtkWidget             *widget,
         							 GtkStyle              *previous_style);
+#endif
 static guint		   get_best_icon_size 			(CajaSidebarTitle      *sidebar_title);
 
 enum
@@ -117,7 +122,13 @@ G_DEFINE_TYPE (CajaSidebarTitle, caja_sidebar_title, GTK_TYPE_BOX)
 G_DEFINE_TYPE (CajaSidebarTitle, caja_sidebar_title, GTK_TYPE_VBOX)
 #endif
 
-
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void
+style_set (GtkWidget *widget,
+           GtkStyleContext  *previous_style)
+{
+    CajaSidebarTitle *sidebar_title;
+#else
 static void
 style_set (GtkWidget *widget,
            GtkStyle  *previous_style)
@@ -125,7 +136,7 @@ style_set (GtkWidget *widget,
     CajaSidebarTitle *sidebar_title;
     PangoFontDescription *font_desc;
     GtkStyle *style;
-
+#endif
 
     g_return_if_fail (CAJA_IS_SIDEBAR_TITLE (widget));
 
@@ -135,6 +146,8 @@ style_set (GtkWidget *widget,
     update_title_font (sidebar_title);
 
     /* Update the fixed-size "more info" font */
+    /*Disable this in GTK3 as it does NOT work and instead blocks changing font size*/
+#if !GTK_CHECK_VERSION (3, 0, 0)
     style = gtk_widget_get_style (widget);
     font_desc = pango_font_description_copy (style->font_desc);
     if (pango_font_description_get_size (font_desc) < MORE_INFO_FONT_SIZE * PANGO_SCALE)
@@ -145,6 +158,7 @@ style_set (GtkWidget *widget,
     gtk_widget_modify_font (sidebar_title->details->more_info_label,
                             font_desc);
     pango_font_description_free (font_desc);
+#endif
 }
 
 static void
@@ -524,7 +538,12 @@ update_title_font (CajaSidebarTitle *sidebar_title)
 {
     int available_width, width;
     int max_fit_font_size, max_style_font_size;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GtkStyleContext *context;
+    GtkStateFlags    state;
+#else
     GtkStyle *style;
+#endif
     GtkAllocation allocation;
     PangoFontDescription *title_font, *tmp_font;
     PangoLayout *layout;
@@ -544,10 +563,13 @@ update_title_font (CajaSidebarTitle *sidebar_title)
     {
         return;
     }
-
+#if GTK_CHECK_VERSION (3, 0, 0)
+    context = gtk_widget_get_style_context (GTK_WIDGET (sidebar_title));
+    gtk_style_context_get (context, state, GTK_STYLE_PROPERTY_FONT, &title_font, NULL);
+#else
     style = gtk_widget_get_style (GTK_WIDGET (sidebar_title));
     title_font = pango_font_description_copy (style->font_desc);
-
+#endif
     max_style_font_size = pango_font_description_get_size (title_font) * 1.8 / PANGO_SCALE;
     if (max_style_font_size < MIN_TITLE_FONT_SIZE + 1)
     {

--- a/src/caja-zoom-control.c
+++ b/src/caja-zoom-control.c
@@ -289,7 +289,11 @@ set_label_size (CajaZoomControl *zoom_control)
 
 static void
 label_style_set_callback (GtkWidget *label,
+#if GTK_CHECK_VERSION (3, 0, 0)
+                          GtkStyleContext *style,
+#else
                           GtkStyle *style,
+#endif
                           gpointer user_data)
 {
     set_label_size (CAJA_ZOOM_CONTROL (user_data));


### PR DESCRIPTION
Port over all the remaining instances of GtkStyle I could find in Caja, keep caja-sidebar-title.c from fixes6 branch. Details below:

caja-sidebar-title.c Same file from https://github.com/lukefromdc/caja/tree/gtk3.21fixes6 GTK3: Ports update_title_font to GtkStyleContext and limit style_set function to calling update_title_font in GTK3 builds as latter function interferes with resizing fonts and does little else in GTK2.

caja-places-sidebar.c: Port caja_places_sidebar_style_set to GtkStyleContext in GTK3 builds

caja-pathbar.c: GtkStyleContext is already used to style the pathbar, so removed GtkStyle variables and unneeded caja_path_bar_style_set function

Note that this disables the most common call to caja_path_bar_check_icon_theme but icons update fine without it in GTK3. That being so, remove it and the call to it in caja_path_bar_screen_changed as well, so two functions not needed in GTK3 are removed. Theme and icon updating no change observed in testing

caja-information-panel.c: Port caja_information_panel_style_set to GtkStyleContext in GTK3 builds

caja-history-sidebar.c: port caja_history_sidebar_style_set GtkStyleContext in GTK3 builds

caja-location-bar.c: Port one variable in style_set_handler to GtkStyleContext in GTK3 builds

caja-zoom-control.c: label_style_set_callback to GtkStyleContext in GTK3 builds


Note that *previous_style is still used, unknown if this is having any effect or validity in GtkStyleContext. Not sure how to remove it but in this case it may simply be a variable name and thus valid anyway.

There is still an issue with icons in the places sidebar except information that only update after a theme change on restarting Caja, this is not new, predates any of these changes,can be observed with caja from Master over GTK 3.20, and is not affected by these commits. No other theme issues in tests with Gtk 3.16, 3.18, 3.20, or 3.21