### PR TITLE
deprecations and warnings

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -176,8 +176,7 @@ typedef struct {
 } TransferInfo;
 
 #define SECONDS_NEEDED_FOR_RELIABLE_TRANSFER_RATE 15
-#define NSEC_PER_SEC 1000000000
-#define NSEC_PER_MSEC 1000000
+#define NSEC_PER_MICROSEC 1000
 
 #define MAXIMUM_DISPLAYED_FILE_NAME_LENGTH 50
 
@@ -1405,12 +1404,12 @@ report_delete_progress (CommonJob *job,
 	int files_left;
 	double elapsed, transfer_rate;
 	int remaining_time;
-	guint64 now;
+	gint64 now;
 	char *files_left_s;
 
-	now = g_get_monotonic_time () * 1000;
+	now = g_get_monotonic_time ();
 	if (transfer_info->last_report_time != 0 &&
-	    ABS ((gint64)(transfer_info->last_report_time - now)) < 100 * NSEC_PER_MSEC) {
+	    ABS ((gint64)(transfer_info->last_report_time - now)) < 100 * NSEC_PER_MICROSEC) {
 		return;
 	}
 	transfer_info->last_report_time = now;
@@ -2878,10 +2877,10 @@ report_copy_progress (CopyMoveJob *copy_job,
 
 	is_move = copy_job->is_move;
 
-	now = g_get_monotonic_time () * 1000;
+	now = g_get_monotonic_time ();
 
 	if (transfer_info->last_report_time != 0 &&
-	    ABS ((gint64)(transfer_info->last_report_time - now)) < 100 * NSEC_PER_MSEC) {
+	    ABS ((gint64)(transfer_info->last_report_time - now)) < 100 * NSEC_PER_MICROSEC) {
 		return;
 	}
 	transfer_info->last_report_time = now;

--- a/libcaja-private/caja-icon-info.c
+++ b/libcaja-private/caja-icon-info.c
@@ -31,7 +31,7 @@ struct _CajaIconInfo
     GObject parent;
 
     gboolean sole_owner;
-    guint64 last_use_time;
+    gint64 last_use_time;
     GdkPixbuf *pixbuf;
 
     gboolean got_embedded_rect;
@@ -56,7 +56,7 @@ G_DEFINE_TYPE (CajaIconInfo,
 static void
 caja_icon_info_init (CajaIconInfo *icon)
 {
-    icon->last_use_time = g_get_monotonic_time () * 1000;
+    icon->last_use_time = g_get_monotonic_time ();
     icon->sole_owner = TRUE;
 }
 
@@ -79,7 +79,7 @@ pixbuf_toggle_notify (gpointer      info,
         g_object_remove_toggle_ref (object,
                                     pixbuf_toggle_notify,
                                     info);
-        icon->last_use_time = g_get_monotonic_time () * 1000;
+        icon->last_use_time = g_get_monotonic_time ();
         schedule_reap_cache ();
     }
 }
@@ -191,7 +191,7 @@ static GHashTable *loadable_icon_cache = NULL;
 static GHashTable *themed_icon_cache = NULL;
 static guint reap_cache_timeout = 0;
 
-#define NSEC_PER_SEC ((guint64)1000000000L)
+#define MICROSEC_PER_SEC ((guint64)1000000L)
 
 static guint time_now;
 
@@ -205,7 +205,7 @@ reap_old_icon (gpointer  key,
 
     if (icon->sole_owner)
     {
-        if (time_now - icon->last_use_time > 30 * NSEC_PER_SEC)
+        if (time_now - icon->last_use_time > 30 * MICROSEC_PER_SEC)
         {
             /* This went unused 30 secs ago. reap */
             return TRUE;
@@ -227,7 +227,7 @@ reap_cache (gpointer data)
 
     reapable_icons_left = TRUE;
 
-    time_now = g_get_monotonic_time () * 1000;
+    time_now = g_get_monotonic_time ();
 
     if (loadable_icon_cache)
     {

--- a/libcaja-private/caja-search-engine-simple.c
+++ b/libcaja-private/caja-search-engine-simple.c
@@ -367,6 +367,7 @@ caja_search_engine_simple_start (CajaSearchEngine *engine)
 {
     CajaSearchEngineSimple *simple;
     SearchThreadData *data;
+    GThread *thread;
 
     simple = CAJA_SEARCH_ENGINE_SIMPLE (engine);
 
@@ -382,9 +383,10 @@ caja_search_engine_simple_start (CajaSearchEngine *engine)
 
     data = search_thread_data_new (simple, simple->details->query);
 
-    g_thread_create (search_thread_func, data, FALSE, NULL);
-
+    thread = g_thread_new ("caja-search-simple", search_thread_func, data);
     simple->details->active_search = data;
+
+    g_thread_unref (thread);
 }
 
 static void

--- a/src/caja-spatial-window.c
+++ b/src/caja-spatial-window.c
@@ -77,6 +77,7 @@
 
 #if GTK_CHECK_VERSION (3, 0, 0)
 #define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
 #endif
 
 struct _CajaSpatialWindowDetails

--- a/src/caja-view-as-action.c
+++ b/src/caja-view-as-action.c
@@ -184,7 +184,11 @@ connect_proxy (GtkAction *action,
 
         view_as_combo_box = gtk_combo_box_text_new ();
 
+#if GTK_CHECK_VERSION(3,20,0)
+        gtk_widget_set_focus_on_click (view_as_combo_box, FALSE);
+#else
         gtk_combo_box_set_focus_on_click (GTK_COMBO_BOX (view_as_combo_box), FALSE);
+#endif
         gtk_box_pack_end (GTK_BOX (view_as_menu_vbox), view_as_combo_box, TRUE, FALSE, 0);
         gtk_widget_show (view_as_combo_box);
         g_signal_connect_object (view_as_combo_box, "changed",


### PR DESCRIPTION
I know GMutex/GThread API is already fixed in caja, but this way it fixes a Wimplicit-function-declaration build warning in caja-search-engine-simple
@monsta @lukefromdc @flexiondotorg 
Please test and review.