### PR TITLE
pathbar: improvements and deprecations

### DIFF
--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -90,7 +90,9 @@ struct _ButtonData
 
     GtkWidget *image;
     GtkWidget *label;
+#if !GTK_CHECK_VERSION (3, 0, 0)
     GtkWidget *alignment;
+#endif
     guint ignore_changes : 1;
     guint file_is_hidden : 1;
     guint fake_root : 1;
@@ -1589,7 +1591,7 @@ set_label_size_request (ButtonData *button_data)
 
     pango_layout_get_pixel_size (layout, &bold_width, &bold_height);
 
-    gtk_widget_set_size_request (button_data->alignment,
+    gtk_widget_set_size_request (button_data->label,
         			 MAX (width, bold_width),
         			 MAX (height, bold_height));
     
@@ -2059,11 +2061,9 @@ make_directory_button (CajaPathBar  *path_bar,
     case DEFAULT_LOCATION_BUTTON:
         button_data->label = gtk_label_new (NULL);
 #if GTK_CHECK_VERSION(3,0,0)
-        button_data->alignment = gtk_alignment_new (0.5, 0.5, 1.0, 1.0);
-        gtk_container_add (GTK_CONTAINER (button_data->alignment), button_data->label);
         child = gtk_hbox_new (FALSE, 2);
         gtk_box_pack_start (GTK_BOX (child), button_data->image, FALSE, FALSE, 0);
-        gtk_box_pack_start (GTK_BOX (child), button_data->alignment, FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (child), button_data->label, FALSE, FALSE, 0);
 #else
         label_alignment = gtk_alignment_new (0.5, 0.5, 1.0, 1.0);
         gtk_container_add (GTK_CONTAINER (label_alignment), button_data->label);
@@ -2076,11 +2076,9 @@ make_directory_button (CajaPathBar  *path_bar,
     default:
         button_data->label = gtk_label_new (NULL);
 #if GTK_CHECK_VERSION(3,0,0)
-        button_data->alignment = gtk_alignment_new (0.5, 0.5, 1.0, 1.0);
-        gtk_container_add (GTK_CONTAINER (button_data->alignment), button_data->label);
         child = gtk_hbox_new (FALSE, 2);
         gtk_box_pack_start (GTK_BOX (child), button_data->image, FALSE, FALSE, 0);
-        gtk_box_pack_start (GTK_BOX (child), button_data->alignment, FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX (child), button_data->label, FALSE, FALSE, 0);
 #else
         label_alignment = gtk_alignment_new (0.5, 0.5, 1.0, 1.0);
         gtk_container_add (GTK_CONTAINER (label_alignment), button_data->label);

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -159,15 +159,12 @@ static gboolean caja_path_bar_update_path              (CajaPathBar *path_bar,
         GFile           *file_path,
         gboolean         emit_signal);
 
+#if GTK_CHECK_VERSION(3,0,0)
 static GtkWidget *
 get_slider_button (CajaPathBar  *path_bar,
-                   GtkArrowType arrow_type)
+                   const gchar  *arrow_type)
 {
     GtkWidget *button;
-
-#if !GTK_CHECK_VERSION(3,0,0)
-    gtk_widget_push_composite_child ();
-#endif
 
     button = gtk_button_new ();
 #if GTK_CHECK_VERSION(3,20,0)
@@ -175,16 +172,33 @@ get_slider_button (CajaPathBar  *path_bar,
 #else
     gtk_button_set_focus_on_click (GTK_BUTTON (button), FALSE);
 #endif
+    gtk_container_add (GTK_CONTAINER (button),
+                       gtk_image_new_from_icon_name (arrow_type, GTK_ICON_SIZE_MENU));
+    gtk_container_add (GTK_CONTAINER (path_bar), button);
+    gtk_widget_show_all (button);
+
+    return button;
+}
+#else
+static GtkWidget *
+get_slider_button (CajaPathBar  *path_bar,
+                   GtkArrowType arrow_type)
+{
+    GtkWidget *button;
+
+    gtk_widget_push_composite_child ();
+
+    button = gtk_button_new ();
+    gtk_button_set_focus_on_click (GTK_BUTTON (button), FALSE);
     gtk_container_add (GTK_CONTAINER (button), gtk_arrow_new (arrow_type, GTK_SHADOW_OUT));
     gtk_container_add (GTK_CONTAINER (path_bar), button);
     gtk_widget_show_all (button);
 
-#if !GTK_CHECK_VERSION(3,0,0)
     gtk_widget_pop_composite_child ();
-#endif
 
     return button;
 }
+#endif
 
 static void
 update_button_types (CajaPathBar *path_bar)
@@ -338,8 +352,13 @@ caja_path_bar_init (CajaPathBar *path_bar)
     gtk_widget_set_redraw_on_allocate (GTK_WIDGET (path_bar), FALSE);
 
     path_bar->spacing = 3;
+#if GTK_CHECK_VERSION(3, 0, 0)
+    path_bar->up_slider_button = get_slider_button (path_bar, "pan-start-symbolic");
+    path_bar->down_slider_button = get_slider_button (path_bar, "pan-end-symbolic");
+#else
     path_bar->up_slider_button = get_slider_button (path_bar, GTK_ARROW_LEFT);
     path_bar->down_slider_button = get_slider_button (path_bar, GTK_ARROW_RIGHT);
+#endif
     path_bar->icon_size = CAJA_PATH_BAR_ICON_SIZE;
 
     p = caja_get_desktop_directory ();

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -355,6 +355,10 @@ caja_path_bar_init (CajaPathBar *path_bar)
 #if GTK_CHECK_VERSION(3, 0, 0)
     path_bar->up_slider_button = get_slider_button (path_bar, "pan-start-symbolic");
     path_bar->down_slider_button = get_slider_button (path_bar, "pan-end-symbolic");
+    gtk_style_context_add_class (gtk_widget_get_style_context (GTK_WIDGET (path_bar->up_slider_button)),
+                                 "slider-button");
+    gtk_style_context_add_class (gtk_widget_get_style_context (GTK_WIDGET (path_bar->down_slider_button)),
+                                 "slider-button");
 #else
     path_bar->up_slider_button = get_slider_button (path_bar, GTK_ARROW_LEFT);
     path_bar->down_slider_button = get_slider_button (path_bar, GTK_ARROW_RIGHT);

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -588,7 +588,7 @@ caja_path_bar_get_preferred_width (GtkWidget *widget,
      */
     path_bar->slider_width = MIN (height * 2 / 3 + 5, height);
 
-    if (path_bar->button_list && path_bar->button_list->next != NULL) {
+    if (path_bar->button_list) {
     	*minimum += (path_bar->spacing + path_bar->slider_width) * 2;
     	*natural += (path_bar->spacing + path_bar->slider_width) * 2;
     }
@@ -719,7 +719,7 @@ caja_path_bar_size_allocate (GtkWidget     *widget,
     GtkRequisition child_requisition;
     GtkAllocation widget_allocation;
 
-    need_sliders = FALSE;
+    need_sliders = TRUE;
     up_slider_offset = 0;
     down_slider_offset = 0;
     path_bar = CAJA_PATH_BAR (widget);

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -1703,12 +1703,20 @@ caja_path_bar_update_button_appearance (ButtonData *button_data)
             if (pixbuf != NULL)
             {
                 gtk_image_set_from_pixbuf (GTK_IMAGE (button_data->image), pixbuf);
+#if GTK_CHECK_VERSION(3,0,0)
+                gtk_style_context_add_class (gtk_widget_get_style_context (button_data->button),
+                                             "image-button");
+#endif
                 gtk_widget_show (GTK_WIDGET (button_data->image));
                 g_object_unref (pixbuf);
             }
             else
             {
                 gtk_widget_hide (GTK_WIDGET (button_data->image));
+#if GTK_CHECK_VERSION(3,0,0)
+                gtk_style_context_remove_class (gtk_widget_get_style_context (button_data->button),
+                                                "image-button");
+#endif
             }
         }
     }

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -936,7 +936,7 @@ caja_path_bar_size_allocate (GtkWidget     *widget,
             child_allocation.x -= path_bar->spacing;
             down_slider_offset = child_allocation.x - widget_allocation.x - path_bar->slider_width;
 #if GTK_CHECK_VERSION(3,0,0)
-            down_slider_offset = 0;
+            down_slider_offset = child_allocation.x - allocation->x - path_bar->slider_width;
 #else
             down_slider_offset = border_width;
 #endif
@@ -945,7 +945,7 @@ caja_path_bar_size_allocate (GtkWidget     *widget,
         {
             down_slider_offset = child_allocation.x - widget_allocation.x;
 #if GTK_CHECK_VERSION(3,0,0)
-            down_slider_offset = allocation->width - path_bar->slider_width;
+            down_slider_offset += child_allocation.width + path_bar->spacing;
 #else
             down_slider_offset = allocation->width - border_width - path_bar->slider_width;
 #endif
@@ -971,7 +971,6 @@ caja_path_bar_size_allocate (GtkWidget     *widget,
 
         gtk_widget_set_child_visible (path_bar->up_slider_button, TRUE);
         gtk_widget_show_all (path_bar->up_slider_button);
-
     }
     else
     {

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -2056,6 +2056,10 @@ make_directory_button (CajaPathBar  *path_bar,
 
     setup_button_type (button_data, path_bar, path);
     button_data->button = gtk_toggle_button_new ();
+#if GTK_CHECK_VERSION(3,0,0)
+    gtk_style_context_add_class (gtk_widget_get_style_context (button_data->button),
+                                 "text-button");
+#endif
 #if GTK_CHECK_VERSION(3,20,0)
     gtk_widget_set_focus_on_click (button_data->button, FALSE);
 #else


### PR DESCRIPTION
Beside from deprecation fixes and adding some style classes to the buttons, this is a very little design change.
I want to show the right slider(arrow) button every time.
This makes it possible to use a design what you know from nemo or nautilus with some themes, but without using the link button style class, using link buttons on pathbar is still broken since 3.16.
With using TOK or BlackMate themes it looks like this.
![bildschirmfoto zu 2016-07-12 10-54-03](https://cloud.githubusercontent.com/assets/961604/16761129/1c11d8be-481f-11e6-8f67-5b46ae1385a7.png)
Menta or Submarine themes will obtain this pathbar design
![bildschirmfoto zu 2016-07-12 10-54-30](https://cloud.githubusercontent.com/assets/961604/16761202/6f49cb86-481f-11e6-9ab8-0cc055f7bc38.png)
I hope you agree with making the slider button always visible.

@monsta @lukefromdc @flexiondotorg 
please test 

