### PR TITLE
Support Back/Forward Mouse Buttons to navigate (gtk2 and gtk3)

### DIFF
--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -3057,6 +3057,12 @@ eel_canvas_button (GtkWidget *widget, GdkEventButton *event)
 
     canvas = EEL_CANVAS (widget);
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+    /* Don't handle extra mouse button events */
+    if (event->button > 5)
+        return FALSE;
+#endif
+
     /*
      * dispatch normally regardless of the event's window if an item has
      * has a pointer grab in effect

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -4770,6 +4770,9 @@ button_press_event (GtkWidget *widget,
 
     container = CAJA_ICON_CONTAINER (widget);
     container->details->button_down_time = event->time;
+#if !GTK_CHECK_VERSION(3, 0, 0)
+    clicked_on_icon = FALSE;
+#endif
 
     /* Forget about the old keyboard selection now that we've started mousing. */
     clear_keyboard_focus (container);
@@ -4781,8 +4784,15 @@ button_press_event (GtkWidget *widget,
         return TRUE;
     }
 
+#if GTK_CHECK_VERSION(3, 0, 0)
     /* Invoke the canvas event handler and see if an item picks up the event. */
     clicked_on_icon = GTK_WIDGET_CLASS (caja_icon_container_parent_class)->button_press_event (widget, event);
+#else
+    if (event->button < 6) { /* Don't let the eel canvas consume extra button events, see gnome bug 660006 */
+        /* Invoke the canvas event handler and see if an item picks up the event. */
+        clicked_on_icon = GTK_WIDGET_CLASS (caja_icon_container_parent_class)->button_press_event (widget, event);
+    }
+#endif
 
     /* Move focus to icon container, unless we're still renaming (to avoid exiting
      * renaming mode)

--- a/src/caja-navigation-window.c
+++ b/src/caja-navigation-window.c
@@ -568,7 +568,11 @@ caja_navigation_window_key_press_event (GtkWidget *widget,
     return GTK_WIDGET_CLASS (caja_navigation_window_parent_class)->key_press_event (widget, event);
 }
 
+#if !GTK_CHECK_VERSION(3, 0, 0)
+gboolean
+#else
 static gboolean
+#endif
 caja_navigation_window_button_press_event (GtkWidget *widget,
         GdkEventButton *event)
 {

--- a/src/caja-navigation-window.h
+++ b/src/caja-navigation-window.h
@@ -115,5 +115,9 @@ gboolean caja_navigation_window_is_in_temporary_navigation_bar (GtkWidget *widge
         CajaNavigationWindow *window);
 gboolean caja_navigation_window_is_in_temporary_search_bar (GtkWidget *widget,
         CajaNavigationWindow *window);
+#if !GTK_CHECK_VERSION(3, 0, 0)
+gboolean caja_window_button_press_event (GtkWidget *widget,
+        GdkEventButton *event);
+#endif
 
 #endif


### PR DESCRIPTION
mate-desktop #78 

https://bugzilla.gnome.org/show_bug.cgi?id=660006
https://github.com/GNOME/nautilus/commit/3deb33d449f293b8e2597ccd7cc3bacec7b40ca2
https://github.com/GNOME/nautilus/commit/ae375b34c28c157950069e8bae8e033f5c12a556

Fix works only on gtk3 because requires (but has no impact on gtk2):
https://bugzilla.gnome.org/show_bug.cgi?id=673441
https://github.com/GNOME/gtk/commit/45a5151f940399a0d53109b9ae36e6eed27c21f7