### PR TITLE
 GTK3: port libunique ->GtkApplication

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,10 +45,10 @@ case "$with_gtk" in
   3.0) GTK_API_VERSION=3.0
        GTK_REQUIRED=3.0.0
        GAIL_API_VERSION=-3.0
-       LIBUNIQUE_VERSION=3.0
        ;;
 esac
 AC_SUBST([GTK_API_VERSION])
+AM_CONDITIONAL([WITH_GTK3],[test "$with_gtk" = "3.0"])
 
 dnl ===========================================================================
 
@@ -229,17 +229,19 @@ fi
 #============================================================================
 # libunique
 #============================================================================
-PKG_CHECK_MODULES(UNIQUE, unique-$LIBUNIQUE_VERSION)
+if test "$GTK_API_VERSION" = "2.0"; then
+    PKG_CHECK_MODULES(UNIQUE, unique-$LIBUNIQUE_VERSION)
 
-AC_SUBST([UNIQUE_CFLAGS])
-AC_SUBST([UNIQUE_LIBS])
+    AC_SUBST([UNIQUE_CFLAGS])
+    AC_SUBST([UNIQUE_LIBS])
 
-# this deprecated stuff should be removed from unique in most distros
-# but it's still not removed upstream in unique 1.x, so leaving it alone
-# just in case.
-UNIQUE_CFLAGS="$UNIQUE_CFLAGS -DG_CONST_RETURN=const"
+    # this deprecated stuff should be removed from unique in most distros
+    # but it's still not removed upstream in unique 1.x, so leaving it alone
+    # just in case.
+    UNIQUE_CFLAGS="$UNIQUE_CFLAGS -DG_CONST_RETURN=const"
 
-EXTRA_CORE_MODULES="$EXTRA_CORE_MODULES unique-$LIBUNIQUE_VERSION"
+    EXTRA_CORE_MODULES="$EXTRA_CORE_MODULES unique-$LIBUNIQUE_VERSION"
+fi
 
 
 # ==========================================================================

--- a/data/caja.desktop.in.in
+++ b/data/caja.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 _Name=Caja
 _GenericName=File Manager
-Exec=caja -n
+Exec=caja
 Icon=system-file-manager
 Terminal=false
 Type=Application

--- a/data/caja.desktop.in.in
+++ b/data/caja.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 _Name=Caja
 _GenericName=File Manager
-Exec=caja
+Exec=caja -n
 Icon=system-file-manager
 Terminal=false
 Type=Application

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -70,7 +70,97 @@ BUILT_SOURCES = \
 	caja-src-marshal.h \
 	$(dbus_freedesktop_built_sources) \
 	$(NULL)
-
+if WITH_GTK3
+caja_SOURCES = \
+	caja-actions.h \
+	caja-application.c \
+	caja-application.h \
+	caja-bookmark-list.c \
+	caja-bookmark-list.h \
+	caja-bookmarks-window.c \
+	caja-bookmarks-window.h \
+	caja-connect-server-dialog.c \
+	caja-connect-server-dialog.h \
+	caja-connect-server-dialog-nonmain.c \
+	caja-connect-server-operation.c	\
+	caja-connect-server-operation.h	\
+	caja-desktop-window.c \
+	caja-desktop-window.h \
+	caja-emblem-sidebar.c \
+	caja-emblem-sidebar.h \
+	caja-file-management-properties.c \
+	caja-file-management-properties.h \
+	caja-freedesktop-dbus.c \
+	caja-freedesktop-dbus.h \
+	caja-history-sidebar.c \
+	caja-history-sidebar.h \
+	caja-image-properties-page.c \
+	caja-image-properties-page.h \
+	caja-information-panel.c \
+	caja-information-panel.h \
+	caja-location-bar.c \
+	caja-location-bar.h \
+	caja-location-dialog.c \
+	caja-location-dialog.h \
+	caja-location-entry.c \
+	caja-location-entry.h \
+	caja-main.c \
+	caja-navigation-action.c \
+	caja-navigation-action.h \
+	caja-navigation-window-menus.c \
+	caja-navigation-window.c \
+	caja-navigation-window.h \
+	caja-navigation-window-pane.c \
+	caja-navigation-window-pane.h \
+	caja-navigation-window-slot.c \
+	caja-navigation-window-slot.h \
+	caja-notebook.c \
+	caja-notebook.h \
+	caja-notes-viewer.c \
+	caja-notes-viewer.h \
+	caja-pathbar.c \
+	caja-pathbar.h \
+	caja-places-sidebar.c \
+	caja-places-sidebar.h \
+	caja-property-browser.c \
+	caja-property-browser.h \
+	caja-query-editor.c \
+	caja-query-editor.h \
+	caja-search-bar.c \
+	caja-search-bar.h \
+	caja-self-check-functions.c \
+	caja-self-check-functions.h \
+	caja-side-pane.c \
+	caja-side-pane.h \
+	caja-sidebar-title.c \
+	caja-sidebar-title.h \
+	caja-spatial-window.c \
+	caja-spatial-window.h \
+	caja-trash-bar.c \
+	caja-trash-bar.h \
+	caja-view-as-action.c \
+	caja-view-as-action.h \
+	caja-window-bookmarks.c \
+	caja-window-bookmarks.h \
+	caja-window-manage-views.c \
+	caja-window-manage-views.h \
+	caja-window-menus.c \
+	caja-window-pane.c \
+	caja-window-pane.h \
+	caja-window-private.h \
+	caja-window-slot.c \
+	caja-window-slot.h \
+	caja-window-toolbars.c \
+	caja-window.c \
+	caja-window.h \
+	caja-x-content-bar.c \
+	caja-x-content-bar.h \
+	caja-zoom-action.c \
+	caja-zoom-action.h \
+	caja-zoom-control.c \
+	caja-zoom-control.h \
+	$(NULL)
+else
 caja_SOURCES = \
 	caja-actions.h \
 	caja-application.c \
@@ -161,6 +251,7 @@ caja_SOURCES = \
 	caja-zoom-control.c \
 	caja-zoom-control.h \
 	$(NULL)
+endif
 
 nodist_caja_SOURCES = \
 	$(BUILT_SOURCES) \

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -2833,7 +2833,6 @@ caja_application_local_command_line (GApplication *application,
     gboolean version = FALSE;
     gboolean browser_window = FALSE;
     gboolean kill_shell = FALSE;
-    gboolean autostart_mode = FALSE;
     const gchar *autostart_id;
     gboolean no_default_window = FALSE;
     gchar **remaining = NULL;
@@ -2885,7 +2884,7 @@ caja_application_local_command_line (GApplication *application,
 	 */
 	autostart_id = g_getenv ("DESKTOP_AUTOSTART_ID");
 	if (autostart_id != NULL && *autostart_id != '\0') {
-		autostart_mode = TRUE;
+		no_default_window = TRUE;
         }
 
 

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -3250,7 +3250,7 @@ caja_application_class_init (CajaApplicationClass *class)
     application_class->open = caja_application_open;
     application_class->local_command_line = caja_application_local_command_line;
 
-g_type_class_add_private (class, sizeof (CajaApplicationPriv));
+    g_type_class_add_private (class, sizeof (CajaApplicationPriv));
 }
 
 CajaApplication *
@@ -3261,14 +3261,14 @@ caja_application_new (void)
 
     if (!running_as_root ()){
         return g_object_new (CAJA_TYPE_APPLICATION,
-                    "application-id", "org.mate.caja",
+                    "application-id", "org.mate.Caja",
                     "register-session", TRUE,
                     "flags", G_APPLICATION_HANDLES_OPEN,
                      NULL);
     }
     else{
     return g_object_new (CAJA_TYPE_APPLICATION,
-                    "application-id", "org.mate.caja",
+                    "application-id", "org.mate.Caja",
                     "flags", G_APPLICATION_HANDLES_OPEN,
                      NULL);
    }

--- a/src/caja-application.h
+++ b/src/caja-application.h
@@ -29,7 +29,10 @@
 
 #include <gdk/gdk.h>
 #include <gio/gio.h>
+#include <gtk/gtk.h>
+#if !GTK_CHECK_VERSION (3, 0, 0)
 #include <unique/unique.h>
+#endif
 #include <libegg/eggsmclient.h>
 
 #define CAJA_DESKTOP_ICON_VIEW_IID "OAFIID:Caja_File_Manager_Desktop_Icon_View"
@@ -57,12 +60,21 @@ typedef struct CajaWindow CajaWindow;
 typedef struct _CajaSpatialWindow CajaSpatialWindow;
 #endif
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+typedef struct _CajaApplicationPriv CajaApplicationPriv;
+#else
 typedef struct CajaShell CajaShell;
+#endif
 
 typedef struct
 {
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GtkApplication parent;
+    CajaApplicationPriv *priv;
+#else
     GObject parent;
     UniqueApp* unique_app;
+#endif
     EggSMClient* smclient;
     GVolumeMonitor* volume_monitor;
     unsigned int automount_idle_id;
@@ -72,6 +84,17 @@ typedef struct
     GList *volume_queue;
 } CajaApplication;
 
+
+#if GTK_CHECK_VERSION (3, 0, 0)
+typedef struct
+{
+	GtkApplicationClass parent_class;
+} CajaApplicationClass;
+
+GType caja_application_get_type (void);
+
+CajaApplication *caja_application_application_new (void);
+#else
 typedef struct
 {
     GObjectClass parent_class;
@@ -89,7 +112,7 @@ void                 caja_application_startup           (CajaApplication *applic
 GList *              caja_application_get_window_list           (void);
 GList *              caja_application_get_spatial_window_list    (void);
 unsigned int         caja_application_get_n_windows            (void);
-
+#endif
 CajaWindow *     caja_application_get_spatial_window     (CajaApplication *application,
         CajaWindow      *requesting_window,
         const char      *startup_id,
@@ -98,15 +121,22 @@ CajaWindow *     caja_application_get_spatial_window     (CajaApplication *appli
         gboolean        *existing);
 
 CajaWindow *     caja_application_create_navigation_window     (CajaApplication *application,
+#if !GTK_CHECK_VERSION (3, 0, 0)
         const char          *startup_id,
+#endif
         GdkScreen           *screen);
-
+#if GTK_CHECK_VERSION(3, 0, 0)
+void caja_application_close_all_navigation_windows (CajaApplication *self);
+#else
 void caja_application_close_all_navigation_windows (void);
+#endif
 void caja_application_close_parent_windows     (CajaSpatialWindow *window);
 void caja_application_close_all_spatial_windows  (void);
+#if !GTK_CHECK_VERSION(3, 0, 0)
 void caja_application_open_desktop      (CajaApplication *application);
 void caja_application_close_desktop     (void);
 gboolean caja_application_save_accel_map    (gpointer data);
+#endif
 void caja_application_open_location (CajaApplication *application,
         GFile *location,
         GFile *selection,

--- a/src/caja-application.h
+++ b/src/caja-application.h
@@ -93,7 +93,7 @@ typedef struct
 
 GType caja_application_get_type (void);
 
-CajaApplication *caja_application_application_new (void);
+CajaApplication *caja_application_new (void);
 #else
 typedef struct
 {

--- a/src/caja-bookmarks-window.c
+++ b/src/caja-bookmarks-window.c
@@ -595,7 +595,9 @@ open_selected_bookmark (gpointer user_data, GdkScreen *screen)
     } else { /* window that opened bookmarks window has been closed */
         if (parent_is_browser_window || g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_ALWAYS_USE_BROWSER)) {
             window = caja_application_create_navigation_window (application,
+#if !GTK_CHECK_VERSION (3, 0, 0)
                      NULL,
+#endif
                      screen);
         }
         else

--- a/src/caja-connect-server-dialog-nonmain.c
+++ b/src/caja-connect-server-dialog-nonmain.c
@@ -83,7 +83,9 @@ caja_connect_server_dialog_display_location_async (CajaConnectServerDialog *self
 
     if (g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_ALWAYS_USE_BROWSER)) {
         window = caja_application_create_navigation_window (application,
+#if !GTK_CHECK_VERSION (3, 0, 0)
         						    NULL,
+#endif
         						    gtk_widget_get_screen (widget));
     } else {
     	window = caja_application_get_spatial_window (application,

--- a/src/caja-location-bar.c
+++ b/src/caja-location-bar.c
@@ -229,7 +229,11 @@ drag_data_received_callback (GtkWidget *widget,
 
         for (i = 1; names[i] != NULL; ++i)
         {
+#if GTK_CHECK_VERSION (3, 0, 0)
+            new_window = caja_application_create_navigation_window (application, screen);
+#else
             new_window = caja_application_create_navigation_window (application, NULL, screen);
+#endif
             location = g_file_new_for_uri (names[i]);
             caja_window_go_to (new_window, location);
             g_object_unref (location);

--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -390,7 +390,7 @@ main (int argc, char *argv[])
 
  	eel_debug_shut_down ();
 
-	return EXIT_SUCCESS;
+	return retval;
 }
 
 #else

--- a/src/caja-navigation-window-menus.c
+++ b/src/caja-navigation-window-menus.c
@@ -71,7 +71,7 @@ action_close_all_windows_callback (GtkAction *action,
 {
     CajaApplication *app;
 
-    app = g_application_get_default();
+    app = CAJA_APPLICATION (g_application_get_default ());
     caja_application_close_all_navigation_windows (app);
 }
 #else

--- a/src/caja-navigation-window-menus.c
+++ b/src/caja-navigation-window-menus.c
@@ -63,13 +63,25 @@
 
 static void                  schedule_refresh_go_menu                      (CajaNavigationWindow   *window);
 
+
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void
+action_close_all_windows_callback (GtkAction *action,
+                                   gpointer user_data)
+{
+    CajaApplication *app;
+
+    app = g_application_get_default();
+    caja_application_close_all_navigation_windows (app);
+}
+#else
 static void
 action_close_all_windows_callback (GtkAction *action,
                                    gpointer user_data)
 {
     caja_application_close_all_navigation_windows ();
 }
-
+#endif
 static gboolean
 should_open_in_new_tab (void)
 {
@@ -610,7 +622,9 @@ action_new_window_callback (GtkAction *action,
     current_window = CAJA_WINDOW (user_data);
     new_window = caja_application_create_navigation_window (
                      current_window->application,
+#if !GTK_CHECK_VERSION (3, 0, 0)
                      NULL,
+#endif
                      gtk_window_get_screen (GTK_WINDOW (current_window)));
     caja_window_go_home (new_window);
 }

--- a/src/caja-navigation-window.c
+++ b/src/caja-navigation-window.c
@@ -34,7 +34,9 @@
 #include "caja-actions.h"
 #include "caja-application.h"
 #include "caja-bookmarks-window.h"
+#if !GTK_CHECK_VERSION (3, 0, 0)
 #include "caja-main.h"
+#endif
 #include "caja-location-bar.h"
 #include "caja-query-editor.h"
 #include "caja-search-bar.h"

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -1895,7 +1895,9 @@ volume_mounted_cb (GVolume *volume,
 
                 cur = CAJA_WINDOW (sidebar->window);
                 new = caja_application_create_navigation_window (cur->application,
+#if !GTK_CHECK_VERSION (3, 0, 0)
                         NULL,
+#endif
                         gtk_window_get_screen (GTK_WINDOW (cur)));
                 caja_window_go_to (new, location);
             }
@@ -1978,7 +1980,9 @@ open_selected_bookmark (CajaPlacesSidebar   *sidebar,
 
             cur = CAJA_WINDOW (sidebar->window);
             new = caja_application_create_navigation_window (cur->application,
+#if !GTK_CHECK_VERSION (3, 0, 0)
                     NULL,
+#endif
                     gtk_window_get_screen (GTK_WINDOW (cur)));
             caja_window_go_to (new, location);
         }

--- a/src/caja-spatial-window.c
+++ b/src/caja-spatial-window.c
@@ -37,7 +37,9 @@
 #include "caja-desktop-window.h"
 #include "caja-bookmarks-window.h"
 #include "caja-location-dialog.h"
+#if !GTK_CHECK_VERSION (3, 0, 0)
 #include "caja-main.h"
+#endif
 #include "caja-query-editor.h"
 #include "caja-search-bar.h"
 #include "caja-window-manage-views.h"

--- a/src/caja-window-manage-views.c
+++ b/src/caja-window-manage-views.c
@@ -33,7 +33,9 @@
 #include "caja-location-bar.h"
 #include "caja-search-bar.h"
 #include "caja-pathbar.h"
+#if !GTK_CHECK_VERSION (3, 0, 0)
 #include "caja-main.h"
+#endif
 #include "caja-window-private.h"
 #include "caja-window-slot.h"
 #include "caja-navigation-window-slot.h"
@@ -601,7 +603,9 @@ caja_window_slot_open_location_full (CajaWindowSlot *slot,
     } else if (target_navigation) {
         target_window = caja_application_create_navigation_window
             (window->application,
+#if !GTK_CHECK_VERSION (3, 0, 0)
              NULL,
+#endif
              gtk_window_get_screen (GTK_WINDOW (window)));
     } else {
         target_window = caja_application_get_spatial_window
@@ -1195,7 +1199,9 @@ got_file_info_for_view_selection_callback (CajaFile *file,
     GFile *location;
     GMountOperation *mount_op;
     MountNotMountedData *data;
-
+#if GTK_CHECK_VERSION (3, 0, 0)
+    CajaApplication *app;
+#endif
     slot = callback_data;
     g_assert (CAJA_IS_WINDOW_SLOT (slot));
     g_assert (slot->determine_view_file == file);
@@ -1308,10 +1314,15 @@ got_file_info_for_view_selection_callback (CajaFile *file,
              * happens when a new window cannot display its initial URI.
              */
             /* if this is the only window, we don't want to quit, so we redirect it to home */
+#if GTK_CHECK_VERSION (3, 0, 0)
+            app = g_application_get_default();
+			
+            if (g_list_length (gtk_application_get_windows (GTK_APPLICATION (app))) == 1) {
+#else
             if (caja_application_get_n_windows () <= 1)
             {
                 g_assert (caja_application_get_n_windows () == 1);
-
+#endif
                 /* the user could have typed in a home directory that doesn't exist,
                    in which case going home would cause an infinite loop, so we
                    better test for that */
@@ -1342,6 +1353,7 @@ got_file_info_for_view_selection_callback (CajaFile *file,
                 /* Since this is a window, destroying it will also unref it. */
                 gtk_widget_destroy (GTK_WIDGET (window));
             }
+
         }
         else
         {

--- a/src/caja-window-manage-views.c
+++ b/src/caja-window-manage-views.c
@@ -1315,7 +1315,7 @@ got_file_info_for_view_selection_callback (CajaFile *file,
              */
             /* if this is the only window, we don't want to quit, so we redirect it to home */
 #if GTK_CHECK_VERSION (3, 0, 0)
-            app = g_application_get_default();
+            app = CAJA_APPLICATION (g_application_get_default ());
 			
             if (g_list_length (gtk_application_get_windows (GTK_APPLICATION (app))) == 1) {
 #else

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -32,7 +32,9 @@
 #include "caja-application.h"
 #include "caja-bookmarks-window.h"
 #include "caja-information-panel.h"
+#if !GTK_CHECK_VERSION (3, 0, 0)
 #include "caja-main.h"
+#endif
 #include "caja-window-manage-views.h"
 #include "caja-window-bookmarks.h"
 #include "caja-window-slot.h"
@@ -236,13 +238,8 @@ caja_window_init (CajaWindow *window)
     /* Register to menu provider extension signal managing menu updates */
     g_signal_connect_object (caja_signaller_get_current (), "popup_menu_changed",
                              G_CALLBACK (caja_window_load_extension_menus), window, G_CONNECT_SWAPPED);
-
+#if !GTK_CHECK_VERSION (3, 0, 0)
 /* Keep the main event loop alive as long as the window exists */
-#if GTK_CHECK_VERSION(3, 0, 0)
-    /* FIXME: port to GtkApplication with GTK3 */
-    //gtk_quit_add_destroy (1, GTK_WIDGET (window));
-    caja_main_event_loop_register (GTK_WIDGET (window));
-#else
     gtk_quit_add_destroy (1, GTK_OBJECT (window));
     caja_main_event_loop_register (GTK_OBJECT (window));
 #endif
@@ -1949,12 +1946,20 @@ caja_forget_history (void)
     CajaWindowSlot *slot;
     CajaNavigationWindowSlot *navigation_slot;
     GList *window_node, *l, *walk;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    CajaApplication *app;
 
+    app = g_application_get_default();
+#endif
     /* Clear out each window's back & forward lists. Also, remove
      * each window's current location bookmark from history list
      * so it doesn't get clobbered.
      */
+#if GTK_CHECK_VERSION (3, 0, 0)
+    for (window_node = gtk_application_get_windows (GTK_APPLICATION (app));
+#else
     for (window_node = caja_application_get_window_list ();
+#endif
             window_node != NULL;
             window_node = window_node->next)
     {
@@ -1997,7 +2002,11 @@ caja_forget_history (void)
     free_history_list ();
 
     /* Re-add each window's current location to history list. */
+#if GTK_CHECK_VERSION (3, 0, 0)
+    for (window_node = gtk_application_get_windows (GTK_APPLICATION (app));
+#else
     for (window_node = caja_application_get_window_list ();
+#endif
             window_node != NULL;
             window_node = window_node->next)
     {

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -1949,7 +1949,7 @@ caja_forget_history (void)
 #if GTK_CHECK_VERSION (3, 0, 0)
     CajaApplication *app;
 
-    app = g_application_get_default();
+    app = CAJA_APPLICATION (g_application_get_default ());
 #endif
     /* Clear out each window's back & forward lists. Also, remove
      * each window's current location bookmark from history list


### PR DESCRIPTION
Port GTK3 builds only to GtkApplication, keep GTK2 builds unchanged 

Based on cherrypicked nautilus commits from
https://github.com/GNOME/nautilus/commit/a8481ee4bd8d34e792d63598fa5efb47736f9de4
through
https://github.com/GNOME/nautilus/commit/a8481ee4bd8d34e792d63598fa5efb47736f9de4
and nautilus bigfix
https://github.com/GNOME/nautilus/commit/6ac24b5381c7a26f85b8c72662c9ac4a54269e26