### PR TITLE
GTK3: stop warning spew from sidebar, pathbar

### DIFF
--- a/data/caja.css
+++ b/data/caja.css
@@ -62,3 +62,8 @@
    border-width: 0px;
    border-style: none;
 }
+
+/* Padding in slider buttons causes GTK errors in GTK 3.20 or later */
+.caja-navigation-window .slider-button {
+	padding: 0px;
+}

--- a/libcaja-private/caja-icon-info.c
+++ b/libcaja-private/caja-icon-info.c
@@ -469,7 +469,7 @@ caja_icon_info_lookup (GIcon *icon,
         gtk_icon_info = gtk_icon_theme_lookup_by_gicon (gtk_icon_theme_get_default (),
                         icon,
                         size,
-                        GTK_ICON_LOOKUP_GENERIC_FALLBACK);
+                        GTK_ICON_LOOKUP_FORCE_SIZE);
         if (gtk_icon_info != NULL)
         {
             pixbuf = gtk_icon_info_load_icon (gtk_icon_info, NULL);


### PR DESCRIPTION
The button underallocation warnings came from pathbar sliders picking up padding from themes, then being forced to render to a smaller size in the code.

The GTK_ICON_LOOKUP_GENERIC_FALLBACK warnings came from the sidebar icons, this flag is now a source of errors. Unfortunately NULL does not work, so set GTK_ICON_LOOKUP_FORCE_SIZE, which does not create errors and ensures the icon size we actually want in the sidebar is used anyway.

Stops all but two of the warnings listed in https://github.com/mate-desktop/caja/issues/561