### PR TITLE
GTK3: fix pathbar pango and "preferred width/height"warnings

### DIFF
--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -560,6 +560,7 @@ caja_path_bar_get_preferred_width (GtkWidget *widget,
     gint child_height;
     gint height;
     gint child_min, child_nat;
+    gint slider_width;
 
     path_bar = CAJA_PATH_BAR (widget);
 
@@ -586,12 +587,20 @@ caja_path_bar_get_preferred_width (GtkWidget *widget,
     /* Theoretically, the slider could be bigger than the other button.  But we're
      * not going to worry about that now.
      */
-    path_bar->slider_width = MIN (height * 2 / 3 + 5, height);
+    gtk_widget_get_preferred_width (path_bar->down_slider_button,
+                                    &slider_width,
+                                    NULL);
+    gtk_widget_get_preferred_width (path_bar->up_slider_button,
+                                    &slider_width,
+                                    NULL);
+
 
     if (path_bar->button_list) {
-    	*minimum += (path_bar->spacing + path_bar->slider_width) * 2;
-    	*natural += (path_bar->spacing + path_bar->slider_width) * 2;
+        *minimum += (path_bar->spacing + slider_width) * 2;
+        *natural += (path_bar->spacing + slider_width) * 2;
     }
+    /*Let's keep the rest of this as it was */
+    path_bar->slider_width = slider_width;
 }
 
 static void

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -1603,8 +1603,11 @@ set_label_size_request (ButtonData *button_data)
     PangoLayout *layout;
     gint width, height, bold_width, bold_height;
     gchar *markup;
+    GtkWidget *label;
     
-    layout = gtk_widget_create_pango_layout (button_data->label, dir_name);
+    /*This is needed because button_data->label is not a GtkWidget*/
+    label = gtk_label_new(dir_name);
+    layout = gtk_widget_create_pango_layout (label, dir_name);
     pango_layout_get_pixel_size (layout, &width, &height);
   
     markup = g_markup_printf_escaped ("<b>%s</b>", dir_name);
@@ -1613,11 +1616,16 @@ set_label_size_request (ButtonData *button_data)
 
     pango_layout_get_pixel_size (layout, &bold_width, &bold_height);
 
+    /*Fixme-this works but throws runtime warnings about not being a GtkWidget*/
     gtk_widget_set_size_request (button_data->label,
         			 MAX (width, bold_width),
         			 MAX (height, bold_height));
     
     g_object_unref (layout);
+    /*recommended approach to freeing a never-packed GtkWidget*/
+    g_object_ref_sink(G_OBJECT(label));
+    gtk_widget_destroy (label);
+    g_object_unref (label);
 }
 
 #else /* GTK_CHECK_VERSION(3,0,0) */


### PR DESCRIPTION
Fix gtk_widget_create_pango_layout: assertion 'GTK_IS_WIDGET (widget)' failed warning and those descending from it. This does NOT fix the  gtk_widget_set_size_request: assertion 'GTK_IS_WIDGET (widget)' failed, which occurs because recent GTK3 versions warn that button_data is not a GtkWidget but still succeed in setting the size. Since GTK 3.22 will be the LAST version of GTK3 this won't break until GTK4 if ever. Taking this out caused the pathbar buttons to jump on bold text so it had to be retained.

Also fix those "allocating size of GtkButton <xxxx> without calling gtk_widget get preferred width/height()" warnings from caja-pathbar's slider buttons