### PR TITLE
GTK3: Fix last pathbar warning

### DIFF
--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -139,6 +139,12 @@ caja_window_init (CajaWindow *window)
     GtkWidget *statusbar;
 
 #if GTK_CHECK_VERSION (3, 0, 0)
+#if GTK_CHECK_VERSION (3, 20, 0)
+    static const gchar css_custom[] =
+      "#caja-extra-view-widget {"
+      "  background-color: " EXTRA_VIEW_WIDGETS_BACKGROUND ";"
+      "}";
+#else
     static const gchar css_custom[] =
       "#statusbar-no-border {"
       "  -GtkStatusbar-shadow-type: none;"
@@ -146,7 +152,7 @@ caja_window_init (CajaWindow *window)
       "#caja-extra-view-widget {"
       "  background-color: " EXTRA_VIEW_WIDGETS_BACKGROUND ";"
       "}";
-
+#endif
     GError *error = NULL;
     GtkCssProvider *provider = gtk_css_provider_new ();
     gtk_css_provider_load_from_data (provider, css_custom, -1, &error);


### PR DESCRIPTION
Replace size request code with padding code borrowed from Nemo. For some reason gtk_widget_set_margin_start(or end) does not throw GTK warnings when called on GTK_WIDGET(button_date->label) while  gtk_widget_set_size_request does throw warnings. Neither generates a build warning.