### PR TITLE
Stop gsignal warnings on window-close

### DIFF
--- a/libcaja-private/caja-desktop-link-monitor.c
+++ b/libcaja-private/caja-desktop-link-monitor.c
@@ -488,6 +488,7 @@ desktop_link_monitor_finalize (GObject *object)
                                           desktop_volumes_visible_changed,
                                           monitor);
 
+/*  These sources are already gone,  this just causes errors
     if (monitor->details->mount_id != 0)
     {
         g_source_remove (monitor->details->mount_id);
@@ -500,7 +501,7 @@ desktop_link_monitor_finalize (GObject *object)
     {
         g_source_remove (monitor->details->changed_id);
     }
-
+*/
     g_free (monitor->details);
 
     EEL_CALL_PARENT (G_OBJECT_CLASS, finalize, (object));

--- a/libcaja-private/caja-desktop-link.c
+++ b/libcaja-private/caja-desktop-link.c
@@ -460,8 +460,11 @@ desktop_link_finalize (GObject *object)
 
     if (link->details->signal_handler != 0)
     {
-        g_signal_handler_disconnect (link->details->signal_handler_obj,
-                                     link->details->signal_handler);
+        if (g_signal_handler_is_connected(link->details->signal_handler_obj,
+                                             link->details->signal_handler)){
+            g_signal_handler_disconnect (link->details->signal_handler_obj,
+                                             link->details->signal_handler);
+        }
     }
 
     if (link->details->icon_file != NULL)

--- a/src/caja-sidebar-title.c
+++ b/src/caja-sidebar-title.c
@@ -212,8 +212,11 @@ release_file (CajaSidebarTitle *sidebar_title)
 {
     if (sidebar_title->details->file_changed_connection != 0)
     {
-        g_signal_handler_disconnect (sidebar_title->details->file,
+        if (g_signal_handler_is_connected(G_OBJECT (sidebar_title->details->file),
+							  sidebar_title->details->file_changed_connection)){
+             g_signal_handler_disconnect (sidebar_title->details->file,
                                      sidebar_title->details->file_changed_connection);
+        }
         sidebar_title->details->file_changed_connection = 0;
     }
 

--- a/src/caja-window-menus.c
+++ b/src/caja-window-menus.c
@@ -98,8 +98,11 @@ bookmark_holder_new (CajaBookmark *bookmark,
 static void
 bookmark_holder_free (BookmarkHolder *bookmark_holder)
 {
+    if (g_signal_handler_is_connected(bookmark_holder->bookmark,
+                                      bookmark_holder->changed_handler_id)){
     g_signal_handler_disconnect (bookmark_holder->bookmark,
-                                 bookmark_holder->changed_handler_id);
+                                      bookmark_holder->changed_handler_id);
+    }
     g_object_unref (bookmark_holder->bookmark);
     g_free (bookmark_holder);
 }


### PR DESCRIPTION
based on https://github.com/mate-desktop/atril/commit/fda33fbeedc0aab64d9479850047d0817d0b38be
"Check if handler_id is connected before disconnect" from Atril