### PR TITLE
Fix accessible object inherritance when used with GTK >= 3.2

### DIFF
--- a/eel/eel-accessibility.c
+++ b/eel/eel-accessibility.c
@@ -63,6 +63,7 @@ eel_accessibility_set_up_label_widget_relation (GtkWidget *label, GtkWidget *wid
  *
  * Return value: the registered type, or 0 on failure.
  **/
+#if !GTK_CHECK_VERSION(3, 0, 0)
 GType
 eel_accessibility_create_derived_type (const char *type_name,
                                        GType existing_gobject_with_proxy,
@@ -113,7 +114,7 @@ eel_accessibility_create_derived_type (const char *type_name,
 
     return type;
 }
-
+#endif
 
 static GQuark
 get_quark_accessible (void)
@@ -207,6 +208,7 @@ eel_accessibility_destroy (gpointer data,
  *
  * Return value: @atk_object.
  **/
+#if !GTK_CHECK_VERSION(3, 0, 0)
 AtkObject *
 eel_accessibility_set_atk_object_return (gpointer   object,
         AtkObject *atk_object)
@@ -224,6 +226,7 @@ eel_accessibility_set_atk_object_return (gpointer   object,
 
     return atk_object;
 }
+#endif
 
 static GailTextUtil *
 get_simple_text (gpointer object)

--- a/eel/eel-accessibility.h
+++ b/eel/eel-accessibility.h
@@ -38,11 +38,13 @@ typedef void     (*EelAccessibilityClassInitFn)    (AtkObjectClass *klass);
 AtkObject    *eel_accessibility_get_atk_object        (gpointer              object);
 AtkObject    *eel_accessibility_for_object            (gpointer              object);
 gpointer      eel_accessibility_get_gobject           (AtkObject            *object);
+#if !GTK_CHECK_VERSION(3, 0, 0)
 AtkObject    *eel_accessibility_set_atk_object_return (gpointer              object,
         AtkObject            *atk_object);
 GType         eel_accessibility_create_derived_type   (const char           *type_name,
         GType                 existing_gobject_with_proxy,
         EelAccessibilityClassInitFn class_init);
+#endif
 void          eel_accessibility_set_name              (gpointer              object,
         const char           *name);
 void          eel_accessibility_set_description       (gpointer              object,

--- a/eel/eel-canvas.h
+++ b/eel/eel-canvas.h
@@ -38,6 +38,9 @@
 #define EEL_CANVAS_H
 
 #include <gtk/gtk.h>
+#if GTK_CHECK_VERSION(3, 0, 0)
+#include <gtk/gtk-a11y.h>
+#endif
 #include <gdk/gdk.h>
 #include <stdarg.h>
 
@@ -554,6 +557,23 @@ extern "C" {
     /* This is the inverse of eel_canvas_window_to_world() */
     void eel_canvas_world_to_window (EelCanvas *canvas,
                                      double worldx, double worldy, double *winx, double *winy);
+
+#if GTK_CHECK_VERSION(3, 0, 0)
+    GType eel_canvas_accessible_get_type (void);
+
+    typedef struct _EelCanvasAccessible EelCanvasAccessible;
+    typedef struct _EelCanvasAccessibleClass EelCanvasAccessibleClass;
+
+    struct _EelCanvasAccessible
+    {
+        GtkContainerAccessible parent;
+    };
+
+    struct _EelCanvasAccessibleClass
+    {
+        GtkContainerAccessibleClass parent_class;
+    };
+#endif
 
 #ifdef __cplusplus
 }

--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -2323,31 +2323,9 @@ static void
 eel_labeled_image_accessible_initialize (AtkObject *accessible,
         gpointer   widget)
 {
+    a11y_parent_class->initialize (accessible, widget);
 #if GTK_CHECK_VERSION(3, 0, 0)
-    a11y_parent_class->initialize (accessible, widget);
-
-    if (GTK_IS_CHECK_BUTTON (widget))
-    {
-        atk_object_set_role (accessible, ATK_ROLE_CHECK_BOX);
-    }
-    else if (GTK_IS_RADIO_BUTTON (widget))
-    {
-        atk_object_set_role (accessible, ATK_ROLE_RADIO_BUTTON);
-    }
-    else if (GTK_IS_TOGGLE_BUTTON (widget))
-    {
-        atk_object_set_role (accessible, ATK_ROLE_TOGGLE_BUTTON);
-    }
-    else if (GTK_IS_BUTTON (widget))
-    {
-        atk_object_set_role (accessible, ATK_ROLE_PUSH_BUTTON);
-    }
-    else
-    {
-        atk_object_set_role (accessible, ATK_ROLE_IMAGE);
-    }
-#else
-    a11y_parent_class->initialize (accessible, widget);
+    atk_object_set_role (accessible, ATK_ROLE_IMAGE);
 #endif
 }
 
@@ -2540,11 +2518,7 @@ eel_labeled_image_get_accessible (GtkWidget *widget)
 static void
 eel_labeled_image_button_class_init (GtkWidgetClass *klass)
 {
-#if GTK_CHECK_VERSION(3, 0, 0)
-    gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass),
-                                          eel_labeled_image_accessible_get_type ());
-
-#else
+#if !GTK_CHECK_VERSION(3, 0, 0)
     klass->get_accessible = eel_labeled_image_get_accessible;
 #endif
 }

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -44,6 +44,9 @@
 #include <eel/eel-art-extensions.h>
 #include <eel/eel-editable-label.h>
 #include <eel/eel-string.h>
+#if GTK_CHECK_VERSION(3, 0, 0)
+#include <eel/eel-canvas.h>
+#endif
 #include <eel/eel-canvas-rect-ellipse.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
@@ -181,6 +184,21 @@ typedef struct
 } CajaIconContainerAccessiblePrivate;
 
 static GType         caja_icon_container_accessible_get_type (void);
+
+#if GTK_CHECK_VERSION(3, 0, 0)
+typedef struct _CajaIconContainerAccessible CajaIconContainerAccessible;
+typedef struct _CajaIconContainerAccessibleClass CajaIconContainerAccessibleClass;
+
+struct _CajaIconContainerAccessible
+{
+    EelCanvasAccessible parent;
+};
+
+struct _CajaIconContainerAccessibleClass
+{
+    EelCanvasAccessibleClass parent_class;
+};
+#endif
 
 static void          activate_selected_items                        (CajaIconContainer *container);
 static void          activate_selected_items_alternate              (CajaIconContainer *container,
@@ -6272,6 +6290,7 @@ expose_event (GtkWidget      *widget,
 }
 #endif
 
+#if !GTK_CHECK_VERSION(3, 0, 0)
 static AtkObject *
 get_accessible (GtkWidget *widget)
 {
@@ -6287,6 +6306,7 @@ get_accessible (GtkWidget *widget)
 
     return eel_accessibility_set_atk_object_return (widget, accessible);
 }
+#endif
 
 static void
 grab_notify_cb  (GtkWidget        *widget,
@@ -6730,7 +6750,11 @@ caja_icon_container_class_init (CajaIconContainerClass *class)
     widget_class->motion_notify_event = motion_notify_event;
     widget_class->key_press_event = key_press_event;
     widget_class->popup_menu = popup_menu;
+#if GTK_CHECK_VERSION(3,2,0)
+    gtk_widget_class_set_accessible_type (widget_class, caja_icon_container_accessible_get_type ());
+#else
     widget_class->get_accessible = get_accessible;
+#endif
 #if GTK_CHECK_VERSION(3,0,0)
     widget_class->style_updated = style_updated;
 #else
@@ -10555,6 +10579,38 @@ caja_icon_container_accessible_finalize (GObject *object)
     G_OBJECT_CLASS (accessible_parent_class)->finalize (object);
 }
 
+#if GTK_CHECK_VERSION(3,2,0)
+static void
+caja_icon_container_accessible_init (CajaIconContainerAccessible *accessible)
+{
+}
+
+static void
+caja_icon_container_accessible_class_init (CajaIconContainerAccessibleClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+    AtkObjectClass *atk_class = ATK_OBJECT_CLASS (klass);
+
+    accessible_parent_class = g_type_class_peek_parent (klass);
+
+    gobject_class->finalize = caja_icon_container_accessible_finalize;
+
+    atk_class->get_n_children = caja_icon_container_accessible_get_n_children;
+    atk_class->ref_child = caja_icon_container_accessible_ref_child;
+    atk_class->initialize = caja_icon_container_accessible_initialize;
+
+    accessible_private_data_quark = g_quark_from_static_string ("icon-container-accessible-private-data");
+}
+
+G_DEFINE_TYPE_WITH_CODE (CajaIconContainerAccessible,
+                         caja_icon_container_accessible,
+                         eel_canvas_accessible_get_type (),
+                         G_IMPLEMENT_INTERFACE (ATK_TYPE_ACTION,
+                                                caja_icon_container_accessible_action_interface_init)
+                         G_IMPLEMENT_INTERFACE (ATK_TYPE_SELECTION,
+                                                caja_icon_container_accessible_selection_interface_init));
+
+#else
 static void
 caja_icon_container_accessible_class_init (AtkObjectClass *klass)
 {
@@ -10605,6 +10661,7 @@ caja_icon_container_accessible_get_type (void)
 
     return type;
 }
+#endif
 
 #if ! defined (CAJA_OMIT_SELF_CHECK)
 


### PR DESCRIPTION
Also disable eel accessibility code that is not needed.

Fixes https://github.com/mate-desktop/caja/issues/590