### PR TITLE
Fix hashtable warnings on close

### DIFF
--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -792,8 +792,7 @@ eel_ref_str_get_unique (const char *string)
     if (unique_ref_strs == NULL)
     {
         unique_ref_strs =
-            eel_g_hash_table_new_free_at_exit (g_str_hash, g_str_equal,
-                                               "unique eel_ref_str");
+            g_hash_table_new(g_str_hash, g_str_equal);
     }
 
     res = g_hash_table_lookup (unique_ref_strs, string);

--- a/libcaja-private/caja-directory.c
+++ b/libcaja-private/caja-directory.c
@@ -357,11 +357,8 @@ caja_directory_get_internal (GFile *location, gboolean create)
     CajaDirectory *directory;
 
     /* Create the hash table first time through. */
-    if (directories == NULL)
-    {
-        directories = eel_g_hash_table_new_free_at_exit
-                      (g_file_hash, (GCompareFunc)g_file_equal, "caja-directory.c: directories");
-
+    if (directories == NULL) {
+        directories = g_hash_table_new (g_file_hash, (GCompareFunc) g_file_equal);
         add_preferences_callbacks ();
     }
 

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -552,8 +552,7 @@ modify_link_hash_table (CajaFile *file,
 
 	/* Create the hash table first time through. */
 	if (symbolic_links == NULL) {
-		symbolic_links = eel_g_hash_table_new_free_at_exit
-			(g_str_hash, g_str_equal, "caja-file.c: symbolic_links");
+		symbolic_links = g_hash_table_new (g_str_hash, g_str_equal);
 	}
 
 	target_uri = caja_file_get_symbolic_link_target_uri (file);


### PR DESCRIPTION
As in Nautilus, use g_hash_table_new rather than eel_g_hash_table_new_free_at_exit