### PR TITLE
GtkApplication: Disable session management when root/not in MATE

### DIFF
--- a/cut-n-paste-code/libegg/eggsmclient.c
+++ b/cut-n-paste-code/libegg/eggsmclient.c
@@ -53,6 +53,16 @@ G_DEFINE_TYPE (EggSMClient, egg_sm_client, G_TYPE_OBJECT)
 static EggSMClient *global_client;
 static EggSMClientMode global_client_mode = EGG_SM_CLIENT_MODE_NORMAL;
 
+#if ENABLE_LIBUNIQUE == (0)
+static gboolean
+running_in_mate (void)
+{
+    return (g_strcmp0 (g_getenv ("XDG_CURRENT_DESKTOP"), "MATE") == 0)
+        || (g_strcmp0 (g_getenv ("XDG_SESSION_DESKTOP"), "MATE") == 0)
+        || (g_strcmp0 (g_getenv ("DESKTOP_SESSION"), "MATE") == 0);
+}
+#endif
+
 static void
 egg_sm_client_init (EggSMClient *client)
 {
@@ -351,6 +361,16 @@ egg_sm_client_get (void)
          */
         if (!global_client)
             global_client = g_object_new (EGG_TYPE_SM_CLIENT, NULL);
+        /*FIXME
+        /*Disabling when root/not in MATE in GtkApplication builds
+        /*as egg_sm_client_set_mode must be called prior to start of main loop
+        /*to stop caja restart but this is diffcult in GtkApplication
+        */
+#if ENABLE_LIBUNIQUE == (0)
+		if (geteuid () == 0 || !running_in_mate ()){
+        global_client = g_object_new (EGG_TYPE_SM_CLIENT, NULL);
+        }
+#endif
     }
 
     return global_client;

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -348,8 +348,6 @@ smclient_quit_cb (EggSMClient   *client,
 static void
 caja_application_smclient_initialize (CajaApplication *self)
 {
-    egg_sm_client_set_mode (EGG_SM_CLIENT_MODE_NORMAL);
-
     g_signal_connect (self->smclient, "save_state",
                           G_CALLBACK (smclient_save_state_cb),
                           self);
@@ -364,8 +362,6 @@ void
 caja_application_smclient_startup (CajaApplication *self)
 {
     g_assert (self->smclient == NULL);
-
-    egg_sm_client_set_mode (EGG_SM_CLIENT_MODE_DISABLED);
     self->smclient = egg_sm_client_get ();
 }
 
@@ -3249,12 +3245,6 @@ caja_application_startup (GApplication *app)
     }
 
     instance = g_application_get_default ();
-
-    /* Always hold in if autostarted to avoid restart loop          */
-    /* Otherwise follow preferences/running in mate/running as root */
-    if (exit_with_last_window == FALSE || self->priv->autostart == TRUE){
-        g_application_hold (G_APPLICATION (instance));
-    }
 
     do_upgrades_once (self);
 }


### PR DESCRIPTION
Limit session management to non-root sessions within MATE to stop restart loops in root sessions and inablity to kill off Caja in non-mate sessions such as XFCE. Also remove the autostarted hold-in previously used to stop restart loops.

egg_sm_client_set_mode only works when called before the main loop starts, thus it cannot be used in GtkApplication startup functions or otherwise later in the program.

Note that this commit restores the Caja 3.16 and earlier restart loop in normal mate sessions if a user disables icons on the desktop, then sets exit_with_last_window. The combination is the default for root/not in mate sessions though, so without the ability to set "no restart" later than the start of the main loop, session management outside of MATE and in root sessions has to be disabled.

Fixes https://github.com/mate-desktop/caja/issues/481