### PR TITLE
Fix Gtk2 build issues with libunique and configure script error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,10 +240,12 @@ AC_ARG_ENABLE(libunique,
 msg_libunique=no
 if test "x$enable_libunique" != "xno"; then
     msg_libunique=yes
-    AM_CONDITIONAL([ENABLE_LIBUNIQUE], = "1")
+    AM_CONDITIONAL([ENABLE_LIBUNIQUE], true)
+    AC_DEFINE(ENABLE_LIBUNIQUE, 1, [define to enable libunique])
 else
     msg_libunique=no
-    AM_CONDITIONAL([ENABLE_LIBUNIQUE], = "0")
+    AM_CONDITIONAL([ENABLE_LIBUNIQUE], false)
+    AC_DEFINE(ENABLE_LIBUNIQUE, 0, [define to disable libunique])
 fi
 
 dnl =====

--- a/src/caja-application.h
+++ b/src/caja-application.h
@@ -27,6 +27,7 @@
 #ifndef CAJA_APPLICATION_H
 #define CAJA_APPLICATION_H
 
+#include <config.h>
 #include <gdk/gdk.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>


### PR DESCRIPTION
Please use this as a reference. Building gtk3 without libunique does not work (edit: *with this patch*, for me). Possibly fixes #655.