### PR TITLE
Fix missed selector change for separating GTK3 and libunique options

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -704,6 +704,8 @@ check_required_directories (CajaApplication *application)
 #if ENABLE_LIBUNIQUE == (0)
         gtk_application_add_window (GTK_APPLICATION (application),
                                     GTK_WINDOW (dialog));
+#elif GTK_CHECK_VERSION (3, 0, 0)
+        caja_main_event_loop_register (GTK_WIDGET (dialog));
 #else
         caja_main_event_loop_register (GTK_OBJECT (dialog));
 #endif

--- a/src/caja-location-bar.c
+++ b/src/caja-location-bar.c
@@ -229,7 +229,7 @@ drag_data_received_callback (GtkWidget *widget,
 
         for (i = 1; names[i] != NULL; ++i)
         {
-#if GTK_CHECK_VERSION (3, 0, 0)
+#if ENABLE_LIBUNIQUE == (0)
             new_window = caja_application_create_navigation_window (application, screen);
 #else
             new_window = caja_application_create_navigation_window (application, NULL, screen);


### PR DESCRIPTION
One selector was not updated in caja-location-bar.c to follow use or nonuse of libunique in GTK3 builds. Fixing this revealed need for a 3-way selector in one place in caja-application.c

Needs GTK2 test build, GTK3 builds both with and without libunique worked