### PR TITLE
fix gtk2 desktop redraws

### DIFF
--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -353,6 +353,40 @@ eel_gtk_menu_tool_button_get_button (GtkMenuToolButton *tool_button)
     return button;
 }
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
+/* The standard gtk_adjustment_set_value ignores page size, which
+ * disagrees with the logic used by scroll bars, for example.
+ */
+void
+eel_gtk_adjustment_set_value (GtkAdjustment *adjustment,
+                              float value)
+{
+    float upper_page_start, clamped_value;
+
+    g_return_if_fail (GTK_IS_ADJUSTMENT (adjustment));
+
+    upper_page_start = MAX (gtk_adjustment_get_upper (adjustment) -
+                            gtk_adjustment_get_page_size (adjustment),
+                            gtk_adjustment_get_lower (adjustment));
+    clamped_value = CLAMP (value, gtk_adjustment_get_lower (adjustment), upper_page_start);
+    if (clamped_value != gtk_adjustment_get_value (adjustment))
+    {
+        gtk_adjustment_set_value (adjustment, clamped_value);
+        gtk_adjustment_value_changed (adjustment);
+    }
+}
+
+/* Clamp a value if the minimum or maximum has changed. */
+void
+eel_gtk_adjustment_clamp_value (GtkAdjustment *adjustment)
+{
+    g_return_if_fail (GTK_IS_ADJUSTMENT (adjustment));
+
+    eel_gtk_adjustment_set_value (adjustment,
+                                  gtk_adjustment_get_value (adjustment));
+}
+#endif
+
 /**
  * eel_gtk_label_make_bold.
  *

--- a/eel/eel-gtk-extensions.h
+++ b/eel/eel-gtk-extensions.h
@@ -63,7 +63,12 @@ GtkWidget *           eel_gtk_menu_tool_button_get_button             (GtkMenuTo
 
 /* GtkLabel */
 void                  eel_gtk_label_make_bold                         (GtkLabel             *label);
-
+#if !GTK_CHECK_VERSION (3, 0, 0)
+/* GtkAdjustment */
+void                  eel_gtk_adjustment_set_value                    (GtkAdjustment        *adjustment,
+        float                 value);
+void                  eel_gtk_adjustment_clamp_value                  (GtkAdjustment        *adjustment);
+#endif
 /* GtkTreeView */
 void                  eel_gtk_tree_view_set_activate_on_single_click  (GtkTreeView               *tree_view,
         gboolean                   should_activate);

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -641,8 +641,13 @@ caja_icon_container_scroll (CajaIconContainer *container,
     old_h_value = gtk_adjustment_get_value (hadj);
     old_v_value = gtk_adjustment_get_value (vadj);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
     gtk_adjustment_set_value (hadj, gtk_adjustment_get_value (hadj) + delta_x);
     gtk_adjustment_set_value (vadj, gtk_adjustment_get_value (vadj) + delta_y);
+#else
+    eel_gtk_adjustment_set_value (hadj, gtk_adjustment_get_value (hadj) + delta_x);
+    eel_gtk_adjustment_set_value (vadj, gtk_adjustment_get_value (vadj) + delta_y);
+#endif
 
     /* return TRUE if we did scroll */
     return gtk_adjustment_get_value (hadj) != old_h_value || gtk_adjustment_get_value (vadj) != old_v_value;
@@ -796,6 +801,7 @@ reveal_icon (CajaIconContainer *container,
         item_get_canvas_bounds (EEL_CANVAS_ITEM (icon->item), &bounds, TRUE);
     }
     if (bounds.y0 < gtk_adjustment_get_value (vadj)) {
+#if GTK_CHECK_VERSION (3, 0, 0)
         gtk_adjustment_set_value (vadj, bounds.y0);
     } else if (bounds.y1 > gtk_adjustment_get_value (vadj) + allocation.height) {
         gtk_adjustment_set_value (vadj, bounds.y1 - allocation.height);
@@ -808,6 +814,20 @@ reveal_icon (CajaIconContainer *container,
             gtk_adjustment_set_value (hadj, bounds.x0);
         } else {
             gtk_adjustment_set_value (hadj, bounds.x1 - allocation.width);
+#else
+        eel_gtk_adjustment_set_value (vadj, bounds.y0);
+    } else if (bounds.y1 > gtk_adjustment_get_value (vadj) + allocation.height) {
+        eel_gtk_adjustment_set_value (vadj, bounds.y1 - allocation.height);
+    }
+
+    if (bounds.x0 < gtk_adjustment_get_value (hadj)) {
+        eel_gtk_adjustment_set_value (hadj, bounds.x0);
+    } else if (bounds.x1 > gtk_adjustment_get_value (hadj) + allocation.width) {
+        if (bounds.x1 - allocation.width > bounds.x0) {
+            eel_gtk_adjustment_set_value (hadj, bounds.x0);
+        } else {
+            eel_gtk_adjustment_set_value (hadj, bounds.x1 - allocation.width);
+#endif
         }
     }
 }
@@ -1248,6 +1268,13 @@ caja_icon_container_update_scroll_region (CajaIconContainer *container)
     {
         gtk_adjustment_set_step_increment (vadj, step_increment);
     }
+#if !GTK_CHECK_VERSION (3, 0, 0)
+    /* Now that we have a new scroll region, clamp the
+     * adjustments so we are within the valid scroll area.
+     */
+    eel_gtk_adjustment_clamp_value (hadj);
+    eel_gtk_adjustment_clamp_value (vadj);
+#endif
 }
 
 static int
@@ -7499,12 +7526,21 @@ caja_icon_container_scroll_to_icon (CajaIconContainer  *container,
 
             if (caja_icon_container_is_layout_vertical (container)) {
                 if (caja_icon_container_is_layout_rtl (container)) {
+#if GTK_CHECK_VERSION (3, 0, 0)
                     gtk_adjustment_set_value (hadj, bounds.x1 - allocation.width);
                 } else {
                     gtk_adjustment_set_value (hadj, bounds.x0);
                 }
             } else {
                 gtk_adjustment_set_value (vadj, bounds.y0);
+#else
+                    eel_gtk_adjustment_set_value (hadj, bounds.x1 - allocation.width);
+                } else {
+                    eel_gtk_adjustment_set_value (hadj, bounds.x0);
+                }
+            } else {
+                eel_gtk_adjustment_set_value (vadj, bounds.y0);
+#endif
             }
         }
 


### PR DESCRIPTION
I just tested builds with gtk2/gtk3 and this fixes https://github.com/mate-desktop/caja/issues/659 for gtk2.
Gtk3 build is not affected, but just in case please test.
@monsta @lukefromdc @nokangaroo

I like to merge this before we make caja gtk3 only as we need this fix very urgent for 1.16 branch.