### PR TITLE
GtkApplication: Notify when ejected volumes safe to unplug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ m4_define(xml_minver,                  2.4.7)
 m4_define(exif_minver,                 0.6.14)
 m4_define(exempi_minver,               1.99.5)
 m4_define(gail_minver,                 0.16)
+m4_define(notify_minver,               0.7.0)
 
 
 dnl 1. If the library code has changed at all since last release, then increment revision.

--- a/libcaja-private/Makefile.am
+++ b/libcaja-private/Makefile.am
@@ -39,6 +39,7 @@ libcaja_private_la_LIBADD = \
 	$(top_builddir)/eel/libeel-2.la \
 	$(top_builddir)/libcaja-extension/libcaja-extension.la \
 	$(CORE_LIBS) \
+    -lnotify
 	$(NULL)
 
 libcaja_private_la_SOURCES = \

--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -200,6 +200,8 @@ caja_application_notify_unmount_show (const gchar *message)
     gchar **strings;
     strings = g_strsplit (message, "\n", 0);
 
+    if (!g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_SHOW_NOTIFICATIONS)) return;
+
     if (unmount_notify == NULL) {
         unmount_notify =
                         notify_notification_new (strings[0], strings[1],

--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -197,7 +197,7 @@ typedef struct {
 NotifyNotification *unmount_notify;
 #if ENABLE_LIBUNIQUE == (FALSE)
 void
-caja_application_notification_unmount_show (const gchar *message)
+caja_application_notify_unmount_show (const gchar *message)
 {
     gchar **strings;
     strings = g_strsplit (message, "\n", 0);
@@ -2100,7 +2100,7 @@ unmount_mount_callback (GObject *source_object,
 		g_error_free (error);
 	}
 #if ENABLE_LIBUNIQUE == (FALSE)
-	caja_application_notification_unmount_show ("It is now safe to remove the drive");
+	caja_application_notify_unmount_show ("It is now safe to remove the drive");
 #endif
 	eel_remove_weak_pointer (&data->parent_window);
 	g_object_unref (data->mount);
@@ -2121,7 +2121,7 @@ do_unmount (UnmountData *data)
 					      unmount_mount_callback,
 					      data);
 #if ENABLE_LIBUNIQUE == (FALSE)
-		caja_application_notification_unmount_show ("writing data to the drive-do not unplug");
+		caja_application_notify_unmount_show ("writing data to the drive-do not unplug");
 #endif
 	} else {
 		g_mount_unmount_with_operation (data->mount,

--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -55,9 +55,7 @@
 #include <gtk/gtk.h>
 #include <gio/gio.h>
 #include <glib.h>
-#if ENABLE_LIBUNIQUE == (FALSE)
 #include <libnotify/notify.h>
-#endif
 #include "caja-file-changes-queue.h"
 #include "caja-file-private.h"
 #include "caja-desktop-icon-file.h"
@@ -195,7 +193,7 @@ typedef struct {
 #define COPY_FORCE _("Copy _Anyway")
 
 NotifyNotification *unmount_notify;
-#if ENABLE_LIBUNIQUE == (FALSE)
+
 void
 caja_application_notify_unmount_show (const gchar *message)
 {
@@ -220,7 +218,7 @@ caja_application_notify_unmount_show (const gchar *message)
     notify_notification_show (unmount_notify, NULL);
     g_strfreev (strings);
 }
-#endif
+
 static void
 mark_desktop_file_trusted (CommonJob *common,
 			   GCancellable *cancellable,
@@ -2099,9 +2097,9 @@ unmount_mount_callback (GObject *source_object,
 	if (error != NULL) {
 		g_error_free (error);
 	}
-#if ENABLE_LIBUNIQUE == (FALSE)
+
 	caja_application_notify_unmount_show ("It is now safe to remove the drive");
-#endif
+
 	eel_remove_weak_pointer (&data->parent_window);
 	g_object_unref (data->mount);
 	g_free (data);
@@ -2120,9 +2118,9 @@ do_unmount (UnmountData *data)
 					      NULL,
 					      unmount_mount_callback,
 					      data);
-#if ENABLE_LIBUNIQUE == (FALSE)
+
 		caja_application_notify_unmount_show ("writing data to the drive-do not unplug");
-#endif
+
 	} else {
 		g_mount_unmount_with_operation (data->mount,
 						0,

--- a/libcaja-private/caja-file-operations.h
+++ b/libcaja-private/caja-file-operations.h
@@ -138,5 +138,6 @@ void caja_file_mark_desktop_file_trusted (GFile           *file,
         CajaOpCallback done_callback,
         gpointer          done_callback_data);
 
+void caja_application_notify_unmount_show (const gchar *message);
 
 #endif /* CAJA_FILE_OPERATIONS_H */

--- a/libcaja-private/caja-global-preferences.h
+++ b/libcaja-private/caja-global-preferences.h
@@ -59,6 +59,7 @@ G_BEGIN_DECLS
 
 /* Desktop options */
 #define CAJA_PREFERENCES_DESKTOP_IS_HOME_DIR		"desktop-is-home-dir"
+#define CAJA_PREFERENCES_SHOW_NOTIFICATIONS             "show-notifications"
 
 /* Display  */
 #define CAJA_PREFERENCES_SHOW_HIDDEN_FILES  		"show-hidden-files"

--- a/libcaja-private/org.mate.caja.gschema.xml
+++ b/libcaja-private/org.mate.caja.gschema.xml
@@ -241,6 +241,11 @@
       <summary>Whether to show file sizes with IEC units</summary>
       <description>If set to true, file sizes are shown using IEC (base 1024) units with "KiB" style suffixes, instead of default with SI units.</description>
     </key>
+    <key name="show-notifications" type="b">
+      <default>true</default>
+      <summary>Whether to show desktop notifications</summary>
+      <description>If set to true, caja will show desktop notifications for eject events</description>
+    </key>
   </schema>
 
   <schema id="org.mate.caja.icon-view" path="/org/mate/caja/icon-view/" gettext-domain="caja">

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,6 +41,7 @@ LDADD = \
 	$(EXIF_LIBS) \
 	$(EXEMPI_LIBS) \
 	$(POPT_LIBS) \
+    -lnotify
 	$(NULL)
 
 dbus_freedesktop_built_sources =			\

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -159,35 +159,7 @@ struct _CajaApplicationPriv {
     gboolean force_desktop;
     gboolean autostart;
     gchar *geometry;
-    NotifyNotification *unmount_notify;
 };
-
-void
-caja_application_notify_unmount_show (CajaApplication *application,
-                                          const gchar *message)
-{
-    gchar **strings;
-
-    strings = g_strsplit (message, "\n", 0);
-
-    if (application->priv->unmount_notify == NULL) {
-        application->priv->unmount_notify =
-                        notify_notification_new (strings[0], strings[1],
-                                                 "media-removable");
-
-        notify_notification_set_hint (application->priv->unmount_notify,
-                                      "transient", g_variant_new_boolean (TRUE));
-        notify_notification_set_urgency (application->priv->unmount_notify,
-                                         NOTIFY_URGENCY_CRITICAL);
-    } else {
-        notify_notification_update (application->priv->unmount_notify,
-                                    strings[0], strings[1],
-                                    "media-removable");
-    }
-
-    notify_notification_show (application->priv->unmount_notify, NULL);
-    g_strfreev (strings);
-}
 
 #else
 G_DEFINE_TYPE (CajaApplication, caja_application, G_TYPE_OBJECT);

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -70,6 +70,7 @@
 #include <eel/eel-stock-dialogs.h>
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
+#include <libnotify/notify.h>
 #include <libcaja-private/caja-debug-log.h>
 #include <libcaja-private/caja-file-utilities.h>
 #include <libcaja-private/caja-global-preferences.h>
@@ -90,7 +91,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <libnotify/notify.h>
 #else
 enum {
 	COMMAND_0, /* unused: 0 is an invalid command */
@@ -1458,6 +1458,9 @@ caja_application_startup (CajaApplication *application,
 
         /* Load session info if availible */
         caja_application_load_session (application);
+
+        /* Initialize notifications for eject operations */
+        notify_init (GETTEXT_PACKAGE);
 
         /* load accelerator map, and register save callback */
         accel_map_filename = caja_get_accel_map_file ();
@@ -3207,7 +3210,7 @@ caja_application_startup (GApplication *app)
     /* attach menu-provider module callback */
     menu_provider_init_callback ();
     
-    /* Initialize the UI handler singleton for file operations */
+    /* Initialize notifications for eject operations */
     notify_init (GETTEXT_PACKAGE);  
 
     /* Watch for unmounts so we can close open windows */

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -38,9 +38,6 @@
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
-#if ENABLE_LIBUNIQUE == (FALSE)
-#include <caja-application.h>
-#endif
 #include <libcaja-private/caja-debug-log.h>
 #include <libcaja-private/caja-dnd.h>
 #include <libcaja-private/caja-bookmark.h>
@@ -56,13 +53,11 @@
 #include <libcaja-private/caja-window-info.h>
 #include <libcaja-private/caja-window-slot-info.h>
 #include <gio/gio.h>
+#include <libnotify/notify.h>
 
 #include "caja-bookmark-list.h"
 #include "caja-places-sidebar.h"
 #include "caja-window.h"
-#if ENABLE_LIBUNIQUE == (FALSE)
-#include <libnotify/notify.h>
-#endif
 #define EJECT_BUTTON_XPAD 6
 #define ICON_CELL_XPAD 6
 
@@ -2246,12 +2241,9 @@ drive_eject_cb (GObject *source_object,
         }
         g_error_free (error);
     }
-#if ENABLE_LIBUNIQUE == (FALSE)
     else {
-        CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
         caja_application_notify_unmount_show ("It is now safe to remove the drive");
     }
-#endif
 }
 
 static void
@@ -2283,12 +2275,10 @@ volume_eject_cb (GObject *source_object,
         }
         g_error_free (error); 
     }
-#if ENABLE_LIBUNIQUE == (FALSE)
+
     else {
-        CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
         caja_application_notify_unmount_show ("It is now safe to remove the drive");
     }
-#endif
 }
 
 static void
@@ -2320,12 +2310,10 @@ mount_eject_cb (GObject *source_object,
         }
         g_error_free (error);
     }
-#if ENABLE_LIBUNIQUE == (FALSE)
+
     else {
-        CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
         caja_application_notify_unmount_show ("It is now safe to remove the drive");
     }
-#endif
 }
 
 static void
@@ -2357,10 +2345,8 @@ do_eject (GMount *mount,
         g_drive_eject_with_operation (drive, 0, mount_op, NULL, drive_eject_cb,
                                       g_object_ref (sidebar->window));
     }
-#if ENABLE_LIBUNIQUE == (FALSE)
-    CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
+
     caja_application_notify_unmount_show ("writing data to the drive-do not unplug");
-#endif
     g_object_unref (mount_op);
 }
 

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -38,6 +38,9 @@
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
+#if ENABLE_LIBUNIQUE == (FALSE)
+#include <caja-application.h>
+#endif
 #include <libcaja-private/caja-debug-log.h>
 #include <libcaja-private/caja-dnd.h>
 #include <libcaja-private/caja-bookmark.h>
@@ -57,7 +60,9 @@
 #include "caja-bookmark-list.h"
 #include "caja-places-sidebar.h"
 #include "caja-window.h"
-
+#if ENABLE_LIBUNIQUE == (FALSE)
+#include <libnotify/notify.h>
+#endif
 #define EJECT_BUTTON_XPAD 6
 #define ICON_CELL_XPAD 6
 
@@ -2241,6 +2246,12 @@ drive_eject_cb (GObject *source_object,
         }
         g_error_free (error);
     }
+#if ENABLE_LIBUNIQUE == (FALSE)
+    else {
+        CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
+        caja_application_notify_unmount_show (app, "It is now safe to remove the drive");
+    }
+#endif
 }
 
 static void
@@ -2270,8 +2281,14 @@ volume_eject_cb (GObject *source_object,
                                    NULL);
             g_free (primary);
         }
-        g_error_free (error);
+        g_error_free (error); 
     }
+#if ENABLE_LIBUNIQUE == (FALSE)
+    else {
+        CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
+        caja_application_notify_unmount_show (app, "It is now safe to remove the drive");
+    }
+#endif
 }
 
 static void
@@ -2303,6 +2320,12 @@ mount_eject_cb (GObject *source_object,
         }
         g_error_free (error);
     }
+#if ENABLE_LIBUNIQUE == (FALSE)
+    else {
+        CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
+        caja_application_notify_unmount_show (app, "It is now safe to remove the drive");
+    }
+#endif
 }
 
 static void
@@ -2311,9 +2334,11 @@ do_eject (GMount *mount,
           GDrive *drive,
           CajaPlacesSidebar *sidebar)
 {
+
     GMountOperation *mount_op;
 
     mount_op = gtk_mount_operation_new (GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (sidebar))));
+
     if (mount != NULL)
     {
         caja_window_info_set_initiated_unmount (sidebar->window, TRUE);
@@ -2332,6 +2357,10 @@ do_eject (GMount *mount,
         g_drive_eject_with_operation (drive, 0, mount_op, NULL, drive_eject_cb,
                                       g_object_ref (sidebar->window));
     }
+#if ENABLE_LIBUNIQUE == (FALSE)
+    CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
+    caja_application_notify_unmount_show (app, "writing data to the drive-do not unplug");
+#endif
     g_object_unref (mount_op);
 }
 

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -2249,7 +2249,7 @@ drive_eject_cb (GObject *source_object,
 #if ENABLE_LIBUNIQUE == (FALSE)
     else {
         CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
-        caja_application_notify_unmount_show (app, "It is now safe to remove the drive");
+        caja_application_notify_unmount_show ("It is now safe to remove the drive");
     }
 #endif
 }
@@ -2286,7 +2286,7 @@ volume_eject_cb (GObject *source_object,
 #if ENABLE_LIBUNIQUE == (FALSE)
     else {
         CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
-        caja_application_notify_unmount_show (app, "It is now safe to remove the drive");
+        caja_application_notify_unmount_show ("It is now safe to remove the drive");
     }
 #endif
 }
@@ -2323,7 +2323,7 @@ mount_eject_cb (GObject *source_object,
 #if ENABLE_LIBUNIQUE == (FALSE)
     else {
         CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
-        caja_application_notify_unmount_show (app, "It is now safe to remove the drive");
+        caja_application_notify_unmount_show ("It is now safe to remove the drive");
     }
 #endif
 }
@@ -2359,7 +2359,7 @@ do_eject (GMount *mount,
     }
 #if ENABLE_LIBUNIQUE == (FALSE)
     CajaApplication *app = CAJA_APPLICATION (g_application_get_default ());
-    caja_application_notify_unmount_show (app, "writing data to the drive-do not unplug");
+    caja_application_notify_unmount_show ("writing data to the drive-do not unplug");
 #endif
     g_object_unref (mount_op);
 }


### PR DESCRIPTION
Notify users when an external drive is still writing data on attempt to eject, and again when drive is safe to unmount. Notifications behave as they do in Nemo when ejecting/unmounting a flash drive. Tested with GTK 3.22 and a known slow flash drive.

This is in GtkApplication builds only, code is from Nemo. FIXME: build system does not limit libnotify dependency to GtkApplication builds and is rather improvised. Adding libnotify to CORE_MODULES via configure.ac did not work, and using Nemo's changes put -lnotify into CORE rather than ALL libs and that caused build failures on failure to link.

A better way to add libnotify to the linked libraries in "CORE" and to limit the dependency to GtkApplication builds during configuration would be nice, but this works as-is and mate-notification-daemon already depends on libnotify so no new dependencies are added to MATE as a whole