### PR TITLE
Fix mousewheel scrolling in compact view

### DIFF
--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -2507,16 +2507,15 @@ fm_icon_view_scroll_event (GtkWidget *widget,
 
             scroll_event_copy = (GdkEventScroll *) event_copy;
 
-           /* transform vertical integer smooth scroll events into horizontal events */
-           if (scroll_event_copy->direction == GDK_SCROLL_SMOOTH &&
-               scroll_event_copy->delta_x == 0) {
-                   if (scroll_event_copy->delta_y == 1.0) {
-                       scroll_event_copy->direction = GDK_SCROLL_DOWN;
-                           } else if (scroll_event_copy->delta_y == -1.0) {
-                               scroll_event_copy->direction = GDK_SCROLL_UP;
-                               }
-                           }
-            if (scroll_event_copy->direction == GDK_SCROLL_UP)
+            /* transform vertical integer smooth scroll events into horizontal events */
+            if (scroll_event_copy->direction == GDK_SCROLL_SMOOTH && scroll_event_copy->delta_x == 0) {
+                if (scroll_event_copy->delta_y == 1.0) {
+                    scroll_event_copy->direction = GDK_SCROLL_DOWN;
+                } else if (scroll_event_copy->delta_y == -1.0) {
+                    scroll_event_copy->direction = GDK_SCROLL_UP;
+                }
+            }
+            if ((scroll_event_copy->direction == GDK_SCROLL_UP) || (scroll_event_copy->delta_x == -1.0))
             {
                 scroll_event_copy->direction = GDK_SCROLL_LEFT;
             }

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -2495,9 +2495,9 @@ fm_icon_view_scroll_event (GtkWidget *widget,
     icon_view = FM_ICON_VIEW (widget);
 
     if (icon_view->details->compact &&
-            (scroll_event->direction == GDK_SCROLL_UP ||
-             scroll_event->direction == GDK_SCROLL_DOWN))
-    {
+        (scroll_event->direction == GDK_SCROLL_UP ||
+        scroll_event->direction == GDK_SCROLL_DOWN ||
+        scroll_event->direction == GDK_SCROLL_SMOOTH)) {
         ret = fm_directory_view_handle_scroll_event (FM_DIRECTORY_VIEW (icon_view), scroll_event);
         if (!ret)
         {
@@ -2506,6 +2506,16 @@ fm_icon_view_scroll_event (GtkWidget *widget,
             event_copy = gdk_event_copy ((GdkEvent *) scroll_event);
 
             scroll_event_copy = (GdkEventScroll *) event_copy;
+
+           /* transform vertical integer smooth scroll events into horizontal events */
+           if (scroll_event_copy->direction == GDK_SCROLL_SMOOTH &&
+               scroll_event_copy->delta_x == 0) {
+                   if (scroll_event_copy->delta_y == 1.0) {
+                       scroll_event_copy->direction = GDK_SCROLL_DOWN;
+                           } else if (scroll_event_copy->delta_y == -1.0) {
+                               scroll_event_copy->direction = GDK_SCROLL_UP;
+                               }
+                           }
             if (scroll_event_copy->direction == GDK_SCROLL_UP)
             {
                 scroll_event_copy->direction = GDK_SCROLL_LEFT;

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -2493,7 +2493,7 @@ fm_icon_view_scroll_event (GtkWidget *widget,
     gboolean ret;
 
     icon_view = FM_ICON_VIEW (widget);
-
+#if GTK_CHECK_VERSION (3, 0, 0)
     if (icon_view->details->compact &&
         (scroll_event->direction == GDK_SCROLL_UP ||
         scroll_event->direction == GDK_SCROLL_DOWN ||
@@ -2516,6 +2516,23 @@ fm_icon_view_scroll_event (GtkWidget *widget,
                 }
             }
             if ((scroll_event_copy->direction == GDK_SCROLL_UP) || (scroll_event_copy->delta_x == -1.0))
+
+#else
+
+   if (icon_view->details->compact &&
+            (scroll_event->direction == GDK_SCROLL_UP ||
+             scroll_event->direction == GDK_SCROLL_DOWN))
+    {
+        ret = fm_directory_view_handle_scroll_event (FM_DIRECTORY_VIEW (icon_view), scroll_event);
+        if (!ret)
+        {
+            /* in column-wise layout, re-emit vertical mouse scroll events as horizontal ones,
+             * if they don't bump zoom */
+            event_copy = gdk_event_copy ((GdkEvent *) scroll_event);
+
+            scroll_event_copy = (GdkEventScroll *) event_copy;
+            if (scroll_event_copy->direction == GDK_SCROLL_UP)
+#endif
             {
                 scroll_event_copy->direction = GDK_SCROLL_LEFT;
             }


### PR DESCRIPTION
Apply Nautilus commit https://github.com/GNOME/nautilus/commit/0832acdb4371fc7de957303e220e899c8fdcdf5c

This causes vertical scroll wheel movement from the mouse to scroll the COMPACT view horizontally, the direction the scrollbars run in compact view. Previously there was no mousewheel scroll in compact view at all. NOT sure if we want to do this, Nemo does and has had some complaints by users wanting to turn it off. Should be possible to add a dconf key for that if people think that's necessary-or we could just leave this as-is.