### PR TITLE
rename labels: follow theme if available, else sane default

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -34,6 +34,7 @@ cajadata_DATA = \
 	caja-extras.placeholder  \
 	caja-suggested.placeholder \
 	caja.css \
+    caja-desktop.css \
 	$(NULL)
 
 # app data file

--- a/data/caja-desktop.css
+++ b/data/caja-desktop.css
@@ -1,3 +1,6 @@
+/* Everything that themes must not override goes in this file */
+/* This is loaded with GTK_STYLE_PROVIDER_PRIORITY_APPLICATION and overrides themes */
+
 .caja-desktop-window,
 .caja-desktop:not(:selected):not(:active):not(.rubberband){
 	background-color: transparent;
@@ -7,4 +10,25 @@
 .caja-desktop.caja-canvas-item {
     color: #ffffff;
     text-shadow: 1px 1px alpha (#000000, 0.8);
+}
+
+.caja-desktop.caja-canvas-item:selected,
+.caja-desktop.caja-canvas-item:active,
+.caja-desktop.caja-canvas-item:hover {
+    text-shadow: none;
+}
+
+/* remove possible theme settings for borders on scrolledwindow with gtk+-3.20 */
+.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow,
+.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow.frame,
+.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow > widget.view.caja-desktop {
+   border-width: 0px;
+   border-style: none;
+   border-radius: 0px;
+}
+
+/* This is not on the desktop but will cause errors if themes can override */
+/* Padding in slider buttons causes GTK errors in GTK 3.20 or later */
+.caja-navigation-window .slider-button {
+	padding: 0px;
 }

--- a/data/caja-desktop.css
+++ b/data/caja-desktop.css
@@ -1,0 +1,10 @@
+.caja-desktop-window,
+.caja-desktop:not(:selected):not(:active):not(.rubberband){
+	background-color: transparent;
+}
+
+/* desktop mode */
+.caja-desktop.caja-canvas-item {
+    color: #ffffff;
+    text-shadow: 1px 1px alpha (#000000, 0.8);
+}

--- a/data/caja.css
+++ b/data/caja.css
@@ -3,11 +3,6 @@
     border-radius: 3px;
 }
 
-.caja-desktop-window,
-.caja-desktop:not(:selected):not(:active):not(.rubberband){
-	background-color: transparent;
-}
-
 /* desktop mode */
 .caja-desktop.caja-canvas-item {
     color: #ffffff;

--- a/data/caja.css
+++ b/data/caja.css
@@ -1,18 +1,8 @@
+/*Sane defaults for themes that do not specify them, themes can override these */
+/*This is loaded with GTK_STYLE_PROVIDER_PRIORITY_THEME so themes can override */
 
 .caja-canvas-item {
     border-radius: 3px;
-}
-
-/* desktop mode */
-.caja-desktop.caja-canvas-item {
-    color: #ffffff;
-    text-shadow: 1px 1px alpha (#000000, 0.8);
-}
-
-.caja-desktop.caja-canvas-item:selected,
-.caja-desktop.caja-canvas-item:active,
-.caja-desktop.caja-canvas-item:hover {
-    text-shadow: none;
 }
 
 /* EelEditableLabel (icon labels) */
@@ -50,16 +40,4 @@
     text-shadow: none;
 }
 
-/* remove possible theme settings for borders on scrolledwindow with gtk+-3.20 */
-.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow,
-.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow.frame,
-.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow > widget.view.caja-desktop {
-   border-width: 0px;
-   border-style: none;
-   border-radius: 0px;
-}
 
-/* Padding in slider buttons causes GTK errors in GTK 3.20 or later */
-.caja-navigation-window .slider-button {
-	padding: 0px;
-}

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -2221,8 +2221,23 @@ init_icons_and_styles (void)
     } else {
         gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
                                GTK_STYLE_PROVIDER (provider),
+                               GTK_STYLE_PROVIDER_PRIORITY_THEME);
+    }
+
+/* add our desktop CSS provider,  ensures the desktop background does not get covered */
+    provider = gtk_css_provider_new ();
+    gtk_css_provider_load_from_path (provider,
+				CAJA_DATADIR G_DIR_SEPARATOR_S "caja-desktop.css", &error);
+
+    if (error != NULL) {
+        g_warning ("Can't parse Caja' CSS custom description: %s\n", error->message);
+        g_error_free (error);
+    } else {
+        gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
+                               GTK_STYLE_PROVIDER (provider),
                                GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
+
 
     g_object_unref (provider);
 


### PR DESCRIPTION
Split caja.css. Most of it can load with GTK_STYLE_PROVIDER_PRIORITY_THEME to allow themes that support Caja to set their own style. CSS required for the desktop background to show and to keep the white text suitable for most backgrounds needs GTK_STYLE_PROVIDER_PRIORITY_APPLICATION so it is loaded separately from new file caja-desktop.css

Note that BlackMATE requires reverting https://github.com/mate-desktop/mate-themes/commit/1147914097234d4d6fda9aff0353d7e698fd7667 and an adjustment is needed to ContrastHighInverse so the styles they provide are usable when fully applied. Tested with GTK 3.22 in every MATE theme plus Adwaita and Raleigh.