### PR TITLE
Backport rename label fix to 1.16

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -34,6 +34,7 @@ cajadata_DATA = \
 	caja-extras.placeholder  \
 	caja-suggested.placeholder \
 	caja.css \
+    caja-desktop.css \
 	$(NULL)
 
 # app data file

--- a/data/caja-desktop.css
+++ b/data/caja-desktop.css
@@ -1,0 +1,34 @@
+/* Everything that themes must not override goes in this file */
+/* This is loaded with GTK_STYLE_PROVIDER_PRIORITY_APPLICATION and overrides themes */
+
+.caja-desktop-window,
+.caja-desktop:not(:selected):not(:active):not(.rubberband){
+	background-color: transparent;
+}
+
+/* desktop mode */
+.caja-desktop.caja-canvas-item {
+    color: #ffffff;
+    text-shadow: 1px 1px alpha (#000000, 0.8);
+}
+
+.caja-desktop.caja-canvas-item:selected,
+.caja-desktop.caja-canvas-item:active,
+.caja-desktop.caja-canvas-item:hover {
+    text-shadow: none;
+}
+
+/* remove possible theme settings for borders on scrolledwindow with gtk+-3.20 */
+.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow,
+.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow.frame,
+.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow > widget.view.caja-desktop {
+   border-width: 0px;
+   border-style: none;
+   border-radius: 0px;
+}
+
+/* This is not on the desktop but will cause errors if themes can override */
+/* Padding in slider buttons causes GTK errors in GTK 3.20 or later */
+.caja-navigation-window .slider-button {
+	padding: 0px;
+}

--- a/data/caja.css
+++ b/data/caja.css
@@ -1,23 +1,8 @@
+/*Sane defaults for themes that do not specify them, themes can override these */
+/*This is loaded with GTK_STYLE_PROVIDER_PRIORITY_THEME so themes can override */
 
 .caja-canvas-item {
     border-radius: 3px;
-}
-
-.caja-desktop-window,
-.caja-desktop:not(:selected):not(:active):not(.rubberband){
-	background-color: transparent;
-}
-
-/* desktop mode */
-.caja-desktop.caja-canvas-item {
-    color: #ffffff;
-    text-shadow: 1px 1px alpha (#000000, 0.8);
-}
-
-.caja-desktop.caja-canvas-item:selected,
-.caja-desktop.caja-canvas-item:active,
-.caja-desktop.caja-canvas-item:hover {
-    text-shadow: none;
 }
 
 /* EelEditableLabel (icon labels) */
@@ -55,16 +40,4 @@
     text-shadow: none;
 }
 
-/* remove possible theme settings for borders on scrolledwindow with gtk+-3.20 */
-.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow,
-.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow.frame,
-.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow > widget.view.caja-desktop {
-   border-width: 0px;
-   border-style: none;
-   border-radius: 0px;
-}
 
-/* Padding in slider buttons causes GTK errors in GTK 3.20 or later */
-.caja-navigation-window .slider-button {
-	padding: 0px;
-}

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -1022,17 +1022,32 @@ init_css (void)
     GtkCssProvider *provider;
     GError *error = NULL;
 
+    /* add our custom CSS provider */
     provider = gtk_css_provider_new ();
     gtk_css_provider_load_from_path (provider,
 				CAJA_DATADIR G_DIR_SEPARATOR_S "caja.css", &error);
 
     if (error != NULL) {
-		g_warning ("Failed to load application css file: %s", error->message);
-		g_error_free (error);
+        g_warning ("Can't parse Caja' CSS custom description: %s\n", error->message);
+        g_error_free (error);
     } else {
-		gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
-				GTK_STYLE_PROVIDER (provider),
-				GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+        gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
+                               GTK_STYLE_PROVIDER (provider),
+                               GTK_STYLE_PROVIDER_PRIORITY_THEME);
+    }
+
+/* add our desktop CSS provider,  ensures the desktop background does not get covered */
+    provider = gtk_css_provider_new ();
+    gtk_css_provider_load_from_path (provider,
+				CAJA_DATADIR G_DIR_SEPARATOR_S "caja-desktop.css", &error);
+
+    if (error != NULL) {
+        g_warning ("Can't parse Caja' CSS custom description: %s\n", error->message);
+        g_error_free (error);
+    } else {
+        gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
+                               GTK_STYLE_PROVIDER (provider),
+                               GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 
     g_object_unref (provider);


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/caja/issues/688
Backport of https://github.com/mate-desktop/caja/commit/aa7af8673a3d894fc99a00d1a30ea57f44e3e1c5 to version 1.16

*Split caja.css. Much of it can load with GTK_STYLE_PROVIDER_PRIORITY_THEME to allow themes that support Caja to set their own style. CSS required for the desktop background to show and to keep the white text suitable for most backgrounds needs GTK_STYLE_PROVIDER_PRIORITY_APPLICATION so it is loaded separately from new file caja-desktop.css

*Move all css items that must not be overridden by themes (most of them are for the desktop) to caja-desktop.css and keep those that are only needed when themes do not set them at all in caja.css