### PR TITLE
Add a separator when concatenating strings in icon text accessible

### DIFF
--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -3564,6 +3564,8 @@ caja_icon_canvas_item_accessible_factory_create_accessible (GObject *for_object)
     }
     if (item->details->additional_text)
     {
+        if (item_text->len > 0)
+            g_string_append_c (item_text, ' ');
         g_string_append (item_text, item->details->additional_text);
     }
     item->details->text_util = gail_text_util_new ();


### PR DESCRIPTION
This makes the string exposed to ATK more sensible, instead of having unrelated words coupled together.