### PR TITLE
Show "open with" menu for all index.theme files, open them in Pluma

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -6964,9 +6964,12 @@ caja_file_get_symbolic_link_target_uri (CajaFile *file)
 gboolean
 caja_file_is_caja_link (CajaFile *file)
 {
-	/* NOTE: I removed the historical link here, because i don't think we
-	   even detect that mimetype anymore */
-	return caja_file_is_mime_type (file, "application/x-desktop");
+    if (file->details->mime_type == NULL) {
+        return FALSE;
+        }
+    return g_content_type_equals (eel_ref_str_peek (file->details->mime_type),
+                                                   "application/x-desktop");
+	
 }
 
 /**

--- a/libcaja-private/caja-mime-actions.c
+++ b/libcaja-private/caja-mime-actions.c
@@ -860,9 +860,7 @@ get_default_executable_text_file_action (void)
 gboolean
 caja_mime_file_opens_in_view (CajaFile *file)
 {
-    return (caja_file_is_directory (file) ||
-            CAJA_IS_DESKTOP_ICON_FILE (file) ||
-            caja_file_is_caja_link (file));
+    return (caja_file_is_directory (file));
 }
 
 static ActivationAction
@@ -871,7 +869,7 @@ get_activation_action (CajaFile *file)
     ActivationAction action;
     char *activation_uri;
 
-    if (caja_file_is_launcher (file))
+    if (caja_file_is_caja_link (file))
     {
         return ACTIVATION_ACTION_LAUNCH_DESKTOP_FILE;
     }

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -4711,9 +4711,7 @@ reset_open_with_menu (FMDirectoryView *view, GList *selection)
 
 		file = CAJA_FILE (node->data);
 
-		other_applications_visible &=
-			(!caja_mime_file_opens_in_view (file) ||
-			 caja_file_is_directory (file));
+		other_applications_visible &= (!caja_file_is_directory (file));
 	}
 
 	default_app = NULL;

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -4978,7 +4978,6 @@ is_a_special_file (CajaFile *file)
 {
 	if (file == NULL ||
 	    CAJA_IS_DESKTOP_ICON_FILE (file) ||
-	    caja_file_is_caja_link (file) ||
 	    is_merged_trash_directory (file) ||
 	    is_computer_directory (file)) {
 		return TRUE;
@@ -4992,7 +4991,7 @@ should_show_open_with (FMPropertiesWindow *window)
 	CajaFile *file;
 
 	/* Don't show open with tab for desktop special icons (trash, etc)
-	 * or desktop files. We don't get the open-with menu for these anyway.
+	 * We don't get the open-with menu for these anyway.
 	 *
 	 * Also don't show it for folders. Changing the default app for folders
 	 * leads to all sort of hard to understand errors.


### PR DESCRIPTION
Fix for https://github.com/mate-desktop/caja/issues/91
also applies when user wants to edit .desktop files
This does not change left-click behavior, desktop files launch as before and index.theme files will still generate an error on left-click, but the right-click menu can now be used to open either filetype in Pluma