### PR TITLE
a11y: fix accessibility implementation for CajaIconCanvasItemAccessible

### DIFF
--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -3992,21 +3992,6 @@ eel_canvas_item_accessible_ref_state_set (AtkObject *accessible)
     return state_set;
 }
 
-static GType eel_canvas_item_accessible_get_type (void);
-
-typedef struct _EelCanvasItemAccessible EelCanvasItemAccessible;
-typedef struct _EelCanvasItemAccessibleClass EelCanvasItemAccessibleClass;
-
-struct _EelCanvasItemAccessible
-{
-    GtkAccessible parent;
-};
-
-struct _EelCanvasItemAccessibleClass
-{
-    GtkAccessibleClass parent_class;
-};
-
 G_DEFINE_TYPE_WITH_CODE (EelCanvasItemAccessible,
                          eel_canvas_item_accessible,
                          ATK_TYPE_GOBJECT_ACCESSIBLE,

--- a/eel/eel-canvas.h
+++ b/eel/eel-canvas.h
@@ -558,6 +558,21 @@ extern "C" {
         GtkContainerAccessibleClass parent_class;
     };
 
+    GType eel_canvas_item_accessible_get_type (void);
+
+    typedef struct _EelCanvasItemAccessible EelCanvasItemAccessible;
+    typedef struct _EelCanvasItemAccessibleClass EelCanvasItemAccessibleClass;
+
+    struct _EelCanvasItemAccessible
+    {
+        GtkAccessible parent;
+    };
+
+    struct _EelCanvasItemAccessibleClass
+    {
+        GtkAccessibleClass parent_class;
+    };
+
 #ifdef __cplusplus
 }
 #endif

--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -3436,16 +3436,16 @@ caja_icon_canvas_item_accessible_text_interface_init (AtkTextIface *iface)
 }
 
 typedef struct {
-	AtkGObjectAccessible parent;
+	EelCanvasItemAccessible parent;
 } CajaIconCanvasItemAccessible;
 
 typedef struct {
-	AtkGObjectAccessibleClass parent_class;
+	EelCanvasItemAccessibleClass parent_class;
 } CajaIconCanvasItemAccessibleClass;
 
 G_DEFINE_TYPE_WITH_CODE (CajaIconCanvasItemAccessible,
 			 caja_icon_canvas_item_accessible,
-			 ATK_TYPE_GOBJECT_ACCESSIBLE,
+			 eel_canvas_item_accessible_get_type (),
 			 G_IMPLEMENT_INTERFACE (ATK_TYPE_IMAGE,
 						caja_icon_canvas_item_accessible_image_interface_init)
 			 G_IMPLEMENT_INTERFACE (ATK_TYPE_TEXT,


### PR DESCRIPTION
Fix CajaIconCanvasItemAccessible inheritance to properly inherit from
EelCanvasItemAccessible.  This fixes the ATK state machinery in
CajaIconCanvasItemAccessible, and adds AtkComponent support which
provides several useful features.

Part of https://github.com/mate-desktop/caja/issues/245 (the "0 items" part)

Based off https://git.gnome.org/browse/nautilus/commit/?id=6c5baeb7626eda6629fc6642c9eb513ef8bc5c8e
See https://bugzilla.gnome.org/show_bug.cgi?id=677509