### PR TITLE
force X11

### DIFF
--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -266,6 +266,8 @@ main (int argc, char *argv[])
 
 	g_set_prgname ("caja");
 
+	gdk_set_allowed_backends ("x11");
+
 	if (g_file_test (DATADIR "/applications/caja.desktop", G_FILE_TEST_EXISTS)) {
 		egg_set_desktop_file (DATADIR "/applications/caja.desktop");
 	}


### PR DESCRIPTION
This commit enables caja to draw desktop icons if used in a wayland session.