### PR TITLE
a11y: fix accessibility implementation for CajaIconCanvasItemAccessible

### DIFF
--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -4297,21 +4297,6 @@ eel_canvas_item_accessible_ref_state_set (AtkObject *accessible)
 }
 
 #if GTK_CHECK_VERSION(3, 0, 0)
-static GType eel_canvas_item_accessible_get_type (void);
-
-typedef struct _EelCanvasItemAccessible EelCanvasItemAccessible;
-typedef struct _EelCanvasItemAccessibleClass EelCanvasItemAccessibleClass;
-
-struct _EelCanvasItemAccessible
-{
-    GtkAccessible parent;
-};
-
-struct _EelCanvasItemAccessibleClass
-{
-    GtkAccessibleClass parent_class;
-};
-
 G_DEFINE_TYPE_WITH_CODE (EelCanvasItemAccessible,
                          eel_canvas_item_accessible,
                          ATK_TYPE_GOBJECT_ACCESSIBLE,
@@ -4370,6 +4355,12 @@ eel_canvas_item_accessible_get_type (void)
         if (!parent_atk_type)
         {
             return G_TYPE_INVALID;
+        }
+        else if (parent_atk_type == ATK_TYPE_NO_OP_OBJECT)
+        {
+            /* use at least AtkGObjectAccessible as basis if nothing else
+             * is advertized in the registry */
+            parent_atk_type = ATK_TYPE_GOBJECT_ACCESSIBLE;
         }
         g_type_query (parent_atk_type, &query);
         tinfo.class_init = (GClassInitFunc) eel_canvas_item_accessible_class_init;

--- a/eel/eel-canvas.h
+++ b/eel/eel-canvas.h
@@ -573,6 +573,21 @@ extern "C" {
     {
         GtkContainerAccessibleClass parent_class;
     };
+
+    GType eel_canvas_item_accessible_get_type (void);
+
+    typedef struct _EelCanvasItemAccessible EelCanvasItemAccessible;
+    typedef struct _EelCanvasItemAccessibleClass EelCanvasItemAccessibleClass;
+
+    struct _EelCanvasItemAccessible
+    {
+        GtkAccessible parent;
+    };
+
+    struct _EelCanvasItemAccessibleClass
+    {
+        GtkAccessibleClass parent_class;
+    };
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix CajaIconCanvasItemAccessible inheritance to properly inherit from EelCanvasItemAccessible.  This fixes the ATK state machinery in CajaIconCanvasItemAccessible, and adds AtkComponent support which provides several useful features.

See also https://bugzilla.gnome.org/show_bug.cgi?id=677509 and https://github.com/mate-desktop/caja/issues/706.
Partly based off https://git.gnome.org/browse/nautilus/commit/?id=6c5baeb7626eda6629fc6642c9eb513ef8bc5c8e