### PR TITLE
Add an option for asking confirmation before moving files to the trash

### DIFF
--- a/libcaja-private/caja-global-preferences.h
+++ b/libcaja-private/caja-global-preferences.h
@@ -55,6 +55,7 @@ G_BEGIN_DECLS
 
 /* Trash options */
 #define CAJA_PREFERENCES_CONFIRM_TRASH			"confirm-trash"
+#define CAJA_PREFERENCES_CONFIRM_MOVE_TO_TRASH	"confirm-move-to-trash"
 #define CAJA_PREFERENCES_ENABLE_DELETE			"enable-delete"
 
 /* Desktop options */

--- a/libcaja-private/org.mate.caja.gschema.xml
+++ b/libcaja-private/org.mate.caja.gschema.xml
@@ -94,6 +94,11 @@
       <summary>Whether to ask for confirmation when deleting files, or emptying Trash</summary>
       <description>If set to true, then Caja will ask for confirmation when  you attempt to delete files, or empty the Trash.</description>
     </key>
+    <key name="confirm-move-to-trash" type="b">
+      <default>false</default>
+      <summary>Whether to ask for confirmation when moving files to the Trash</summary>
+      <description>If set to true, then Caja will ask for confirmation when you attempt to move files to the Trash.</description>
+    </key>
     <key name="enable-delete" type="b">
       <default>false</default>
       <summary>Whether to enable immediate deletion</summary>

--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -63,6 +63,7 @@
 #define CAJA_FILE_MANAGEMENT_PROPERTIES_ALWAYS_USE_BROWSER_WIDGET "always_use_browser_checkbutton"
 #define CAJA_FILE_MANAGEMENT_PROPERTIES_ALWAYS_USE_LOCATION_ENTRY_WIDGET "always_use_location_entry_checkbutton"
 #define CAJA_FILE_MANAGEMENT_PROPERTIES_TRASH_CONFIRM_WIDGET "trash_confirm_checkbutton"
+#define CAJA_FILE_MANAGEMENT_PROPERTIES_TRASH_CONFIRM_TRASH_WIDGET "trash_confirm_trash_checkbutton"
 #define CAJA_FILE_MANAGEMENT_PROPERTIES_TRASH_DELETE_WIDGET "trash_delete_checkbutton"
 #define CAJA_FILE_MANAGEMENT_PROPERTIES_SHOW_HIDDEN_WIDGET "hidden_files_checkbutton"
 #define CAJA_FILE_MANAGEMENT_PROPERTIES_TREE_VIEW_FOLDERS_WIDGET "treeview_folders_checkbutton"
@@ -1100,6 +1101,9 @@ caja_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
     bind_builder_bool (builder, caja_preferences,
                        CAJA_FILE_MANAGEMENT_PROPERTIES_TRASH_CONFIRM_WIDGET,
                        CAJA_PREFERENCES_CONFIRM_TRASH);
+    bind_builder_bool (builder, caja_preferences,
+                       CAJA_FILE_MANAGEMENT_PROPERTIES_TRASH_CONFIRM_TRASH_WIDGET,
+                       CAJA_PREFERENCES_CONFIRM_MOVE_TO_TRASH);
 
     bind_builder_bool (builder, caja_preferences,
                        CAJA_FILE_MANAGEMENT_PROPERTIES_TRASH_DELETE_WIDGET,

--- a/src/caja-file-management-properties.ui
+++ b/src/caja-file-management-properties.ui
@@ -1119,6 +1119,21 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="trash_confirm_trash_checkbutton">
+                                <property name="label" translatable="yes">Ask before moving files to the _Trash</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkCheckButton" id="trash_delete_checkbutton">
                                 <property name="label" translatable="yes">I_nclude a Delete command that bypasses Trash</property>
                                 <property name="visible">True</property>
@@ -1130,7 +1145,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">1</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
Add an option to show a confirmation dialog when moving files to the
trash, like there is for deleting files directly or emptying the trash.

Closes #632.