### PR TITLE
Fixes for background drawing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl ===========================================================================
 
 m4_define(glib_minver,                 2.36.0)
 m4_define(gio_minver,                  2.26.0)
-m4_define(mate_desktop_minver,         1.17.0)
+m4_define(mate_desktop_minver,         1.17.3)
 m4_define(pango_minver,                1.1.2)
 m4_define(gtk_minver,                  3.14.0)
 m4_define(xml_minver,                  2.4.7)

--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -53,6 +53,7 @@ static guint signals[LAST_SIGNAL] = { 0 };
 struct EelBackgroundDetails
 {
     GtkWidget *widget;
+    GtkWidget *front_widget;
     MateBG *bg;
     char *color;
 
@@ -78,6 +79,10 @@ struct EelBackgroundDetails
     /* activity status */
     gboolean is_active;
 };
+
+#if GTK_CHECK_VERSION (3, 22, 0)
+static GList *desktop_bg_objects = NULL;
+#endif
 
 static void
 free_fade (EelBackground *self)
@@ -124,9 +129,16 @@ eel_background_finalize (GObject *object)
     }
 
     free_background_surface (self);
-
     free_fade (self);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+    if (self->details->is_desktop)
+    {
+        desktop_bg_objects = g_list_remove (desktop_bg_objects,
+                                            G_OBJECT (self));
+    }
+
+#endif
     G_OBJECT_CLASS (eel_background_parent_class)->finalize (object);
 }
 
@@ -358,11 +370,15 @@ void
 eel_background_draw (GtkWidget *widget,
                      cairo_t   *cr)
 {
-    int width, height;
-    GdkWindow *window = gtk_widget_get_window (widget);
-    GdkRGBA color;
-
     EelBackground *self = eel_get_widget_background (widget);
+    GdkRGBA color;
+    int width, height;
+
+    if (self->details->fade != NULL &&
+        mate_bg_crossfade_is_started (self->details->fade))
+    {
+        return;
+    }
 
     drawable_get_adjusted_size (self, &width, &height);
 
@@ -372,7 +388,8 @@ eel_background_draw (GtkWidget *widget,
 
     cairo_save (cr);
 
-    if (self->details->bg_surface != NULL) {
+    if (self->details->bg_surface != NULL)
+    {
         cairo_set_source_surface (cr, self->details->bg_surface, 0, 0);
         cairo_pattern_set_extend (cairo_get_source (cr), CAIRO_EXTEND_REPEAT);
     } else {
@@ -468,7 +485,7 @@ on_fade_finished (MateBGCrossfade *fade,
 
 static gboolean
 fade_to_surface (EelBackground   *self,
-                 GdkWindow       *window,
+                 GtkWidget       *widget,
                  cairo_surface_t *surface)
 {
     if (self->details->fade == NULL ||
@@ -479,7 +496,22 @@ fade_to_surface (EelBackground   *self,
 
     if (!mate_bg_crossfade_is_started (self->details->fade))
     {
+#if GTK_CHECK_VERSION (3, 22, 0)
+        mate_bg_crossfade_start_widget (self->details->fade, widget);
+#else
+        GdkWindow *window;
+
+        if (EEL_IS_CANVAS (widget))
+        {
+            window = gtk_layout_get_bin_window (GTK_LAYOUT (widget));
+        }
+        else
+        {
+            window = gtk_widget_get_window (widget);
+        }
+
         mate_bg_crossfade_start (self->details->fade, window);
+#endif
         if (self->details->is_desktop)
         {
             g_signal_connect (self->details->fade,
@@ -494,9 +526,7 @@ fade_to_surface (EelBackground   *self,
 static void
 eel_background_set_up_widget (EelBackground *self)
 {
-    GdkWindow *window;
     GtkWidget *widget = self->details->widget;
-    GdkRGBA color;
 
     gboolean in_fade = FALSE;
 
@@ -504,41 +534,48 @@ eel_background_set_up_widget (EelBackground *self)
         return;
 
     eel_background_ensure_realized (self);
-    color = self->details->default_color;
-    make_color_inactive (self, &color);
 
     if (self->details->bg_surface == NULL)
         return;
 
-    if (EEL_IS_CANVAS (widget)) {
-        window = gtk_layout_get_bin_window (GTK_LAYOUT (widget));
-    } else {
-        window = gtk_widget_get_window (widget);
-    }
+    gtk_widget_queue_draw (widget);
 
     if (self->details->fade != NULL)
-        in_fade = fade_to_surface (self, window, self->details->bg_surface);
+        in_fade = fade_to_surface (self, widget, self->details->bg_surface);
 
     if (!in_fade)
     {
-        cairo_pattern_t *pattern;
-        pattern = cairo_pattern_create_for_surface (self->details->bg_surface);
-        gdk_window_set_background_pattern (window, pattern);
-        cairo_pattern_destroy (pattern);
+        GdkWindow *window;
 
-
-        if (self->details->is_desktop)
+        if (EEL_IS_CANVAS (widget))
         {
-            set_root_surface (self, window, gtk_widget_get_screen (widget));
+            window = gtk_layout_get_bin_window (GTK_LAYOUT (widget));
         }
         else
         {
-
-            gdk_window_set_background_rgba (window, &color);
-
+            window = gtk_widget_get_window (widget);
         }
 
-        gdk_window_invalidate_rect (window, NULL, TRUE);
+        if (self->details->is_desktop)
+        {
+#if !GTK_CHECK_VERSION (3, 22, 0)
+            if (self->details->bg_surface != NULL)
+            {
+                cairo_pattern_t *pattern =
+                  cairo_pattern_create_for_surface (self->details->bg_surface);
+                gdk_window_set_background_pattern (window, pattern);
+                cairo_pattern_destroy (pattern);
+            }
+            else
+            {
+                GdkRGBA color = self->details->default_color;
+                make_color_inactive (self, &color);
+                gdk_window_set_background_rgba (window, &color);
+            }
+            gdk_window_invalidate_rect (window, NULL, TRUE);
+#endif
+            set_root_surface (self, window, gtk_widget_get_screen (widget));
+        }
     }
 }
 
@@ -552,8 +589,6 @@ background_changed_cb (EelBackground *self)
 
     eel_background_unrealize (self);
     eel_background_set_up_widget (self);
-
-    gtk_widget_queue_draw (self->details->widget);
 
     return FALSE;
 }
@@ -577,12 +612,10 @@ widget_queue_background_change (GtkWidget *widget,
  * EelBackgroundStyle so that it will match the chosen GTK+ theme.
  */
 static void
-widget_style_set_cb (GtkWidget *widget,
-                     GtkStyle  *previous_style,
-                     gpointer   user_data)
+widget_style_updated_cb (GtkWidget *widget,
+                         gpointer   user_data)
 {
-    if (previous_style != NULL)
-        widget_queue_background_change (widget, user_data);
+    widget_queue_background_change (widget, user_data);
 }
 
 static void
@@ -692,7 +725,9 @@ on_widget_destroyed (GtkWidget *widget,
     }
 
     free_fade (self);
+
     self->details->widget = NULL;
+    self->details->front_widget = NULL;
 }
 
 /* Gets the background attached to a widget.
@@ -701,9 +736,8 @@ on_widget_destroyed (GtkWidget *widget,
    this will create one. To change the widget's background, you can
    just call eel_background methods on the widget.
 
-   If the widget is a canvas, nothing more needs to be done.  For
-   normal widgets, you need to call eel_background_draw() from your
-   draw/expose handler to draw the background.
+   You need to call eel_background_draw() from your draw event handler to
+   draw the background.
 
    Later, we might want a call to find out if we already have a background,
    or a way to share the same background among multiple widgets; both would
@@ -712,22 +746,41 @@ on_widget_destroyed (GtkWidget *widget,
 EelBackground *
 eel_get_widget_background (GtkWidget *widget)
 {
+    EelBackground *self;
+    gpointer data;
+#if GTK_CHECK_VERSION (3, 22, 0)
+    GList *l;
+#endif
 
     g_return_val_if_fail (GTK_IS_WIDGET (widget), NULL);
 
     /* Check for an existing background. */
-    gpointer data = g_object_get_data (G_OBJECT (widget), "eel_background");
+    data = g_object_get_data (G_OBJECT (widget), "eel_background");
     if (data != NULL)
     {
         g_assert (EEL_IS_BACKGROUND (data));
         return data;
     }
+#if GTK_CHECK_VERSION (3, 22, 0)
+    /* Check for an existing desktop window background. */
+    for (l = desktop_bg_objects; l != NULL; l = l->next)
+    {
+        g_assert (EEL_IS_BACKGROUND (l->data));
+        self = EEL_BACKGROUND (l->data);
+        if (widget == self->details->widget)
+        {
+            return self;
+        }
+    }
+#endif
+
+    self = eel_background_new ();
+    self->details->widget = widget;
+    self->details->front_widget = widget;
 
     /* Store the background in the widget's data. */
-    EelBackground *self = eel_background_new ();
     g_object_set_data_full (G_OBJECT (widget), "eel_background",
                             self, g_object_unref);
-    self->details->widget = widget;
 
     g_signal_connect_object (widget, "destroy",
                              G_CALLBACK (on_widget_destroyed), self, 0);
@@ -736,8 +789,8 @@ eel_get_widget_background (GtkWidget *widget)
     g_signal_connect_object (widget, "unrealize",
                              G_CALLBACK (widget_unrealize_cb), self, 0);
 
-    g_signal_connect_object (widget, "style_set",
-                             G_CALLBACK (widget_style_set_cb), self, 0);
+    g_signal_connect_object (widget, "style-updated",
+                             G_CALLBACK (widget_style_updated_cb), self, 0);
 
     /* Arrange to get the signal whenever the background changes. */
     g_signal_connect_object (self, "appearance_changed",
@@ -828,14 +881,32 @@ eel_background_reset (EelBackground *self)
 
 void
 eel_background_set_desktop (EelBackground *self,
-                            GtkWidget     *widget,
                             gboolean       is_desktop)
 {
     self->details->is_desktop = is_desktop;
 
-    if (gtk_widget_get_realized (widget) && is_desktop)
+    if (is_desktop)
     {
-        widget_realized_setup (widget, self);
+#if GTK_CHECK_VERSION (3, 22, 0)
+        self->details->widget =
+          gtk_widget_get_toplevel (self->details->front_widget);
+
+        desktop_bg_objects = g_list_prepend (desktop_bg_objects,
+                                             G_OBJECT (self));
+
+#endif
+        if (gtk_widget_get_realized (self->details->widget))
+        {
+            widget_realized_setup (self->details->widget, self);
+        }
+    }
+    else
+    {
+#if GTK_CHECK_VERSION (3, 22, 0)
+        desktop_bg_objects = g_list_remove (desktop_bg_objects,
+                                            G_OBJECT (self));
+        self->details->widget = self->details->front_widget;
+#endif
     }
 }
 
@@ -853,6 +924,7 @@ eel_background_set_active (EelBackground *self,
     {
         self->details->is_active = is_active;
         set_image_properties (self);
+        gtk_widget_queue_draw (self->details->widget);
     }
 }
 

--- a/eel/eel-background.h
+++ b/eel/eel-background.h
@@ -83,7 +83,6 @@ void                        eel_bg_set_placement                 (EelBackground 
 /* Should be TRUE for desktop background */
 gboolean		    eel_background_is_desktop 		 (EelBackground   *self);
 void			    eel_background_set_desktop 		 (EelBackground   *self,
-        							  GtkWidget       *widget,
         							  gboolean         is_desktop);
 
 /* Calls to interrogate the current state of a background. */

--- a/libcaja-private/caja-directory-background.c
+++ b/libcaja-private/caja-directory-background.c
@@ -382,8 +382,7 @@ caja_connect_desktop_background_to_settings (CajaIconContainer *icon_container)
 
     background = eel_get_widget_background (GTK_WIDGET (icon_container));
 
-    eel_background_set_desktop (background,
-                                GTK_WIDGET (icon_container), TRUE);
+    eel_background_set_desktop (background, TRUE);
 
     g_signal_connect_object (background, "settings_changed",
                              G_CALLBACK (desktop_background_changed_cb), NULL, 0);

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -185,8 +185,6 @@ static void          end_renaming_mode                              (CajaIconCon
         gboolean               commit);
 static CajaIcon *get_icon_being_renamed                         (CajaIconContainer *container);
 static void          finish_adding_new_icons                        (CajaIconContainer *container);
-static void          update_label_color                             (EelBackground         *background,
-        CajaIconContainer *icon_container);
 static inline void   icon_get_bounding_box                          (CajaIcon          *icon,
         int                   *x1_return,
         int                   *y1_return,
@@ -4520,6 +4518,18 @@ size_allocate (GtkWidget *widget,
     }
 }
 
+static gboolean
+draw (GtkWidget *widget, cairo_t *cr)
+{
+    if (!CAJA_ICON_CONTAINER (widget)->details->is_desktop)
+    {
+        eel_background_draw (widget, cr);
+    }
+
+    return GTK_WIDGET_CLASS (caja_icon_container_parent_class)->draw (widget,
+                                                                      cr);
+}
+
 static void
 realize (GtkWidget *widget)
 {
@@ -4529,12 +4539,14 @@ realize (GtkWidget *widget)
     GTK_WIDGET_CLASS (caja_icon_container_parent_class)->realize (widget);
 
     container = CAJA_ICON_CONTAINER (widget);
+#if !GTK_CHECK_VERSION (3, 22, 0)
     /* Ensure that the desktop window is native so the background
        set on it is drawn by X. */
     if (container->details->is_desktop)
     {
         gdk_x11_window_get_xid (gtk_layout_get_bin_window (GTK_LAYOUT (widget)));
     }
+#endif
     /* Set up DnD.  */
     caja_icon_dnd_init (container);
 
@@ -6507,6 +6519,7 @@ caja_icon_container_class_init (CajaIconContainerClass *class)
 
     widget_class = GTK_WIDGET_CLASS (class);
     widget_class->size_allocate = size_allocate;
+    widget_class->draw = draw;
     widget_class->realize = realize;
     widget_class->unrealize = unrealize;
     widget_class->button_press_event = button_press_event;

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -4529,15 +4529,12 @@ realize (GtkWidget *widget)
     GTK_WIDGET_CLASS (caja_icon_container_parent_class)->realize (widget);
 
     container = CAJA_ICON_CONTAINER (widget);
-     /* Unless GTK 3.21 or later is in use and the desktop must be transparent*/
-#if !GTK_CHECK_VERSION (3, 22, 0)
     /* Ensure that the desktop window is native so the background
        set on it is drawn by X. */
     if (container->details->is_desktop)
     {
         gdk_x11_window_get_xid (gtk_layout_get_bin_window (GTK_LAYOUT (widget)));
     }
-#endif
     /* Set up DnD.  */
     caja_icon_dnd_init (container);
 
@@ -6072,14 +6069,12 @@ popup_menu (GtkWidget *widget)
     return TRUE;
 }
 
-#if !GTK_CHECK_VERSION (3, 22, 0)
 static void
 draw_canvas_background (EelCanvas *canvas,
                         cairo_t   *cr)
 {
     /* Don't chain up to the parent to avoid clearing and redrawing */
 }
-#endif
 
 static void
 grab_notify_cb  (GtkWidget        *widget,
@@ -6525,9 +6520,7 @@ caja_icon_container_class_init (CajaIconContainerClass *class)
     gtk_widget_class_set_accessible_type (widget_class, caja_icon_container_accessible_get_type ());
 
     canvas_class = EEL_CANVAS_CLASS (class);
-#if !GTK_CHECK_VERSION (3, 22, 0)
     canvas_class->draw_background = draw_canvas_background;
-#endif
     class->start_interactive_search = caja_icon_container_start_interactive_search;
 
     gtk_widget_class_install_style_property (widget_class,

--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -30,6 +30,7 @@
 #include <X11/Xatom.h>
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
+#include <eel/eel-background.h>
 #include <eel/eel-vfs-extensions.h>
 #include <libcaja-private/caja-file-utilities.h>
 #include <libcaja-private/caja-icon-names.h>
@@ -249,6 +250,17 @@ realize (GtkWidget *widget)
                           G_CALLBACK (caja_desktop_window_screen_size_changed), window);
 }
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+static gboolean
+draw (GtkWidget *widget,
+      cairo_t   *cr)
+{
+    eel_background_draw (widget, cr);
+
+    return GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->draw (widget, cr);
+}
+#endif
+
 static char *
 real_get_title (CajaWindow *window)
 {
@@ -271,6 +283,9 @@ caja_desktop_window_class_init (CajaDesktopWindowClass *klass)
     wclass->realize = realize;
     wclass->unrealize = unrealize;
     wclass->map = map;
+#if GTK_CHECK_VERSION (3, 22, 0)
+    wclass->draw = draw;
+#endif
     nclass->window_type = CAJA_WINDOW_DESKTOP;
     nclass->get_title = real_get_title;
     nclass->get_icon = real_get_icon;

--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -35,127 +35,16 @@
 #include <libcaja-private/caja-icon-names.h>
 #include <gio/gio.h>
 #include <glib/gi18n.h>    
-#if GTK_CHECK_VERSION (3, 22, 0)
-#define MATE_DESKTOP_USE_UNSTABLE_API
-#include <libmate-desktop/mate-bg.h>
-#endif
 
 struct CajaDesktopWindowDetails
 {
     gulong size_changed_id;
 
     gboolean loaded;
-#if GTK_CHECK_VERSION (3, 22, 0)
-    gboolean composited;
-    cairo_surface_t *surface;
-#endif
 };
 
 G_DEFINE_TYPE (CajaDesktopWindow, caja_desktop_window,
                CAJA_TYPE_SPATIAL_WINDOW);
-
-#if GTK_CHECK_VERSION (3, 22, 0)
-
-static void
-background_changed (CajaDesktopWindow *window)
-{
-    GdkScreen *screen = gdk_screen_get_default ();
-
-    if (window->details->surface) {
-        cairo_surface_destroy (window->details->surface);
-    }
-
-    window->details->surface = mate_bg_get_surface_from_root (screen);
-    gtk_widget_queue_draw (GTK_WIDGET (window));
-}
-
-static GdkFilterReturn
-filter_func (GdkXEvent             *xevent,
-             GdkEvent              *event,
-             CajaDesktopWindow *window)
-{
-    XEvent *xev = (XEvent *) xevent;
-    GdkAtom gdkatom;
-
-    if (xev->type != PropertyNotify) {
-        return GDK_FILTER_CONTINUE;
-    }
-
-    gdkatom = gdk_atom_intern_static_string ("_XROOTPMAP_ID");
-    if (xev->xproperty.atom != gdk_x11_atom_to_xatom (gdkatom)) {
-        return GDK_FILTER_CONTINUE;
-    }
-
-    background_changed (window);
-
-    return GDK_FILTER_CONTINUE;
-}
-
-static void
-caja_desktop_window_composited_changed (GtkWidget *widget)
-{
-    CajaDesktopWindow *window = CAJA_DESKTOP_WINDOW (widget);
-    GdkScreen *screen = gdk_screen_get_default ();
-    gboolean composited = gdk_screen_is_composited (screen);
-    GdkWindow *root;
-
-    if (window->details->composited == composited) {
-        return;
-    }
-
-    window->details->composited = composited;
-    root = gdk_screen_get_root_window (screen);
-
-    if (composited) {
-        gdk_window_remove_filter (root, (GdkFilterFunc) filter_func, window);
-
-        if (window->details->surface) {
-            cairo_surface_destroy (window->details->surface);
-            window->details->surface = NULL;
-        }
-    } else {
-        gint events = gdk_window_get_events (root);
-
-        gdk_window_set_events (root, events | GDK_PROPERTY_CHANGE_MASK);
-        gdk_window_add_filter (root, (GdkFilterFunc) filter_func, window);
-        background_changed (window);
-    }
-}
-
-static gboolean
-caja_desktop_window_draw (GtkWidget *widget,
-                              cairo_t   *cr)
-{
-    CajaDesktopWindow *window = CAJA_DESKTOP_WINDOW (widget);
-
-    if (window->details->surface) {
-        cairo_set_source_surface (cr, window->details->surface, 0, 0);
-        cairo_paint (cr);
-    }
-
-    return GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->draw (widget, cr);
-}
-
-static void
-caja_desktop_window_finalize (GObject *obj)
-{
-    CajaDesktopWindow *window = CAJA_DESKTOP_WINDOW (obj);
-
-    if (window->details->composited == FALSE) {
-        GdkScreen *screen = gdk_screen_get_default ();
-        GdkWindow *root = gdk_screen_get_root_window (screen);
-
-        gdk_window_remove_filter (root, (GdkFilterFunc) filter_func, window);
-    }
-
-    if (window->details->surface) {
-        cairo_surface_destroy (window->details->surface);
-        window->details->surface = NULL;
-    }
-
-    G_OBJECT_CLASS (caja_desktop_window_parent_class)->finalize (obj);
-}
-#endif  /* GTK_CHECK_VERSION (3, 22, 0) */
 
 static void
 caja_desktop_window_init (CajaDesktopWindow *window)
@@ -170,11 +59,6 @@ caja_desktop_window_init (CajaDesktopWindow *window)
 
     context = gtk_widget_get_style_context (GTK_WIDGET (window));
     gtk_style_context_add_class (context, "caja-desktop-window");
-
-#if GTK_CHECK_VERSION (3, 22, 0)
-    window->details->composited = TRUE;
-    caja_desktop_window_composited_changed (GTK_WIDGET (window));
-#endif
 
     gtk_window_move (GTK_WINDOW (window), 0, 0);
 
@@ -281,13 +165,6 @@ map (GtkWidget *widget)
     /* Chain up to realize our children */
     GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->map (widget);
     gdk_window_lower (gtk_widget_get_window (widget));
-#if GTK_CHECK_VERSION (3, 22, 0)
-    GdkWindow *window;
-    GdkRGBA transparent = { 0, 0, 0, 0 };
-
-    window = gtk_widget_get_window (widget);
-    gdk_window_set_background_rgba (window, &transparent);
-#endif
 }
 
 static void
@@ -353,21 +230,12 @@ realize (GtkWidget *widget)
 {
     CajaDesktopWindow *window;
     CajaDesktopWindowDetails *details;
-#if GTK_CHECK_VERSION (3, 22, 0)
-    GdkVisual *visual;
-#endif
     window = CAJA_DESKTOP_WINDOW (widget);
     details = window->details;
 
     /* Make sure we get keyboard events */
     gtk_widget_set_events (widget, gtk_widget_get_events (widget)
                            | GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK);
-#if GTK_CHECK_VERSION (3, 22, 0)
-    visual = gdk_screen_get_rgba_visual (gtk_widget_get_screen (widget));
-    if (visual) {
-        gtk_widget_set_visual (widget, visual);
-    }
-#endif
     /* Do the work of realizing. */
     GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->realize (widget);
 
@@ -399,19 +267,10 @@ caja_desktop_window_class_init (CajaDesktopWindowClass *klass)
 {
     GtkWidgetClass *wclass = GTK_WIDGET_CLASS (klass);
     CajaWindowClass *nclass = CAJA_WINDOW_CLASS (klass);
-#if GTK_CHECK_VERSION (3, 22, 0)
-    GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-    object_class->finalize = caja_desktop_window_finalize;
-#endif
 
     wclass->realize = realize;
     wclass->unrealize = unrealize;
     wclass->map = map;
-#if GTK_CHECK_VERSION (3, 22, 0)
-    wclass->composited_changed = caja_desktop_window_composited_changed;
-    wclass->draw = caja_desktop_window_draw;
-#endif
     nclass->window_type = CAJA_WINDOW_DESKTOP;
     nclass->get_title = real_get_title;
     nclass->get_icon = real_get_icon;

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -38,9 +38,7 @@
 #include <gdk/gdkx.h>
 #include <glib/gi18n.h>
 #include <libcaja-private/caja-desktop-icon-file.h>
-#if !GTK_CHECK_VERSION (3, 22, 0)
 #include <libcaja-private/caja-directory-background.h>
-#endif
 #include <libcaja-private/caja-directory-notify.h>
 #include <libcaja-private/caja-file-changes-queue.h>
 #include <libcaja-private/caja-file-operations.h>

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -61,9 +61,7 @@
 #include <libcaja-private/caja-desktop-directory.h>
 #include <libcaja-private/caja-extensions.h>
 #include <libcaja-private/caja-search-directory.h>
-#if !GTK_CHECK_VERSION (3, 22, 0)
 #include <libcaja-private/caja-directory-background.h>
-#endif
 #include <libcaja-private/caja-directory.h>
 #include <libcaja-private/caja-dnd.h>
 #include <libcaja-private/caja-file-attributes.h>
@@ -419,9 +417,7 @@ EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, can_zoom_in)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, can_zoom_out)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, clear)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, file_changed)
-#if !GTK_CHECK_VERSION (3, 22, 0)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, get_background_widget)
-#endif
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, get_selection)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, get_selection_for_file_transfer)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, get_item_count)
@@ -3616,7 +3612,6 @@ fm_directory_view_can_zoom_out (FMDirectoryView *view)
 		 can_zoom_out, (view));
 }
 
-#if !GTK_CHECK_VERSION (3, 22, 0)
 GtkWidget *
 fm_directory_view_get_background_widget (FMDirectoryView *view)
 {
@@ -3642,7 +3637,6 @@ real_set_is_active (FMDirectoryView *view,
 	bg = fm_directory_view_get_background (view);
 	eel_background_set_active (bg, is_active);
 }
-#endif
 
 static void
 fm_directory_view_set_is_active (FMDirectoryView *view,
@@ -7670,11 +7664,9 @@ real_merge_menus (FMDirectoryView *view)
 
 	ui = caja_ui_string_get ("caja-directory-view-ui.xml");
 	view->details->dir_merge_id = gtk_ui_manager_add_ui_from_string (ui_manager, ui, -1, NULL);
-#if !GTK_CHECK_VERSION (3, 22, 0)
 	g_signal_connect_object (fm_directory_view_get_background (view), "settings_changed",
 				 G_CALLBACK (schedule_update_menus), G_OBJECT (view),
 				 G_CONNECT_SWAPPED);
-#endif
 	view->details->scripts_invalid = TRUE;
 	view->details->templates_invalid = TRUE;
 }
@@ -11028,9 +11020,7 @@ fm_directory_view_class_init (FMDirectoryViewClass *klass)
 	klass->merge_menus = real_merge_menus;
 	klass->unmerge_menus = real_unmerge_menus;
 	klass->update_menus = real_update_menus;
-#if !GTK_CHECK_VERSION (3, 22, 0)
 	klass->set_is_active = real_set_is_active;
-#endif
 	/* Function pointers that subclasses must override */
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, add_file);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, bump_zoom_level);
@@ -11038,9 +11028,7 @@ fm_directory_view_class_init (FMDirectoryViewClass *klass)
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, can_zoom_out);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, clear);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, file_changed);
-#if !GTK_CHECK_VERSION (3, 22, 0)
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, get_background_widget);
-#endif
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, get_selection);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, get_selection_for_file_transfer);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, get_item_count);

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -30,9 +30,7 @@
 #include "fm-desktop-icon-view.h"
 #include "fm-error-reporting.h"
 #include <stdlib.h>
-#if !GTK_CHECK_VERSION (3, 22, 0)
 #include <eel/eel-background.h>
-#endif
 #include <eel/eel-glib-extensions.h>
 #include <eel/eel-gtk-extensions.h>
 #include <eel/eel-gtk-macros.h>
@@ -45,9 +43,7 @@
 #include <glib/gi18n.h>
 #include <gio/gio.h>
 #include <libcaja-private/caja-clipboard-monitor.h>
-#if !GTK_CHECK_VERSION (3, 22, 0)
 #include <libcaja-private/caja-directory-background.h>
-#endif
 #include <libcaja-private/caja-directory.h>
 #include <libcaja-private/caja-dnd.h>
 #include <libcaja-private/caja-file-utilities.h>
@@ -1273,7 +1269,6 @@ fm_icon_view_begin_loading (FMDirectoryView *view)
 
     /* kill any sound preview process that is ongoing */
     preview_audio (icon_view, NULL, FALSE);
-#if !GTK_CHECK_VERSION (3, 22, 0)
     /* FIXME bugzilla.gnome.org 45060: Should use methods instead
      * of hardcoding desktop knowledge in here.
      */
@@ -1296,7 +1291,6 @@ fm_icon_view_begin_loading (FMDirectoryView *view)
 
         caja_connect_background_to_file_metadata (icon_container, file, default_action);
     }
-#endif
 
     /* Set up the zoom level from the metadata. */
     if (fm_directory_view_supports_zooming (FM_DIRECTORY_VIEW (icon_view)))
@@ -1503,7 +1497,6 @@ fm_icon_view_can_zoom_out (FMDirectoryView *view)
            > CAJA_ZOOM_LEVEL_SMALLEST;
 }
 
-#if !GTK_CHECK_VERSION (3, 22, 0)
 static GtkWidget *
 fm_icon_view_get_background_widget (FMDirectoryView *view)
 {
@@ -1511,7 +1504,6 @@ fm_icon_view_get_background_widget (FMDirectoryView *view)
 
     return GTK_WIDGET (get_icon_container (FM_ICON_VIEW (view)));
 }
-#endif
 
 static gboolean
 fm_icon_view_is_empty (FMDirectoryView *view)
@@ -3173,9 +3165,7 @@ fm_icon_view_class_init (FMIconViewClass *klass)
     fm_directory_view_class->clear = fm_icon_view_clear;
     fm_directory_view_class->end_loading = fm_icon_view_end_loading;
     fm_directory_view_class->file_changed = fm_icon_view_file_changed;
-#if !GTK_CHECK_VERSION (3, 22, 0)
     fm_directory_view_class->get_background_widget = fm_icon_view_get_background_widget;
-#endif
     fm_directory_view_class->get_selected_icon_locations = fm_icon_view_get_selected_icon_locations;
     fm_directory_view_class->get_selection = fm_icon_view_get_selection;
     fm_directory_view_class->get_selection_for_file_transfer = fm_icon_view_get_selection;

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -47,9 +47,7 @@
 #include <libcaja-private/caja-column-chooser.h>
 #include <libcaja-private/caja-column-utilities.h>
 #include <libcaja-private/caja-debug-log.h>
-#if !GTK_CHECK_VERSION (3, 22, 0)
 #include <libcaja-private/caja-directory-background.h>
-#endif
 #include <libcaja-private/caja-dnd.h>
 #include <libcaja-private/caja-file-dnd.h>
 #include <libcaja-private/caja-file-utilities.h>
@@ -2119,13 +2117,11 @@ fm_list_view_file_changed (FMDirectoryView *view, CajaFile *file, CajaDirectory 
     }
 }
 
-#if !GTK_CHECK_VERSION (3, 22, 0)
 static GtkWidget *
 fm_list_view_get_background_widget (FMDirectoryView *view)
 {
     return GTK_WIDGET (view);
 }
-#endif
 
 static void
 fm_list_view_get_selection_foreach_func (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
@@ -3290,9 +3286,7 @@ fm_list_view_class_init (FMListViewClass *class)
     fm_directory_view_class->click_policy_changed = fm_list_view_click_policy_changed;
     fm_directory_view_class->clear = fm_list_view_clear;
     fm_directory_view_class->file_changed = fm_list_view_file_changed;
-#if !GTK_CHECK_VERSION (3, 22, 0)
     fm_directory_view_class->get_background_widget = fm_list_view_get_background_widget;
-#endif
     fm_directory_view_class->get_selection = fm_list_view_get_selection;
     fm_directory_view_class->get_selection_for_file_transfer = fm_list_view_get_selection_for_file_transfer;
     fm_directory_view_class->get_item_count = fm_list_view_get_item_count;


### PR DESCRIPTION
This fixes directory background drawing in #506, fixes compiz-reloaded/compiz#40 (desktop background issues with Compiz 0.8.x) and fixes background fading.
Caja now draws the desktop background again and the gap in code between GTK+ 3.22 and previous versions is removed.
Other parts of the change: mate-desktop/mate-desktop#249, mate-desktop/mate-settings-daemon#169.