### PR TITLE
Changing the resolution will cause the desktop icons to not be adaptively arranged

### DIFF
--- a/libcaja-private/Makefile.am
+++ b/libcaja-private/Makefile.am
@@ -38,7 +38,8 @@ libcaja_private_la_LIBADD = \
 	$(top_builddir)/eel/libeel-2.la \
 	$(top_builddir)/libcaja-extension/libcaja-extension.la \
 	$(CORE_LIBS) \
-    -lnotify
+    -lnotify \
+    -lxcb
 	$(NULL)
 
 libcaja_private_la_SOURCES = \

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -2105,6 +2105,7 @@ lay_down_icons_vertical_desktop (CajaIconContainer *container, GList *icons)
     int total, new_length, placed;
     CajaIcon *icon;
     int height, max_width, column_width, icon_width, icon_height;
+    int screen_height;
     int x, y, x1, x2, y1, y2;
     EelDRect icon_rect;
     GtkAllocation allocation;
@@ -2112,6 +2113,9 @@ lay_down_icons_vertical_desktop (CajaIconContainer *container, GList *icons)
     /* Get container dimensions */
     gtk_widget_get_allocation (GTK_WIDGET (container), &allocation);
     height = CANVAS_HEIGHT(container, allocation);
+    screen_height = gdk_screen_get_height (gtk_widget_get_screen(GTK_WIDGET(container)));
+    if (height > screen_height)
+        height = screen_height;
 
     /* Determine which icons have and have not been placed */
     placed_icons = NULL;

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -50,6 +50,7 @@
 #include <gtk/gtk.h>
 #include <gdk/gdkx.h>
 #include <glib/gi18n.h>
+#include <xcb/xcb.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -2105,7 +2106,7 @@ lay_down_icons_vertical_desktop (CajaIconContainer *container, GList *icons)
     int total, new_length, placed;
     CajaIcon *icon;
     int height, max_width, column_width, icon_width, icon_height;
-    int screen_height;
+    int i, screenNum;
     int x, y, x1, x2, y1, y2;
     EelDRect icon_rect;
     GtkAllocation allocation;
@@ -2113,9 +2114,15 @@ lay_down_icons_vertical_desktop (CajaIconContainer *container, GList *icons)
     /* Get container dimensions */
     gtk_widget_get_allocation (GTK_WIDGET (container), &allocation);
     height = CANVAS_HEIGHT(container, allocation);
-    screen_height = gdk_screen_get_height (gtk_widget_get_screen(GTK_WIDGET(container)));
-    if (height > screen_height)
-        height = screen_height;
+    xcb_connection_t *connection = xcb_connect (NULL, &screenNum);
+    const xcb_setup_t *setup = xcb_get_setup (connection);
+    xcb_screen_iterator_t iter = xcb_setup_roots_iterator (setup);
+    for (i = 0; i < screenNum; ++i) {
+        xcb_screen_next (&iter);
+    }
+    xcb_screen_t *screen = iter.data;
+    if (height > screen->height_in_pixels)
+        height = screen->height_in_pixels;
 
     /* Determine which icons have and have not been placed */
     placed_icons = NULL;

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -313,6 +313,13 @@ fm_desktop_icon_view_class_init (FMDesktopIconViewClass *class)
 }
 
 static void
+fm_desktop_icon_view_handle_size_changed (GdkScreen *screen,
+        FMDesktopIconView *desktop_icon_view)
+{
+    FM_ICON_VIEW_CLASS (fm_desktop_icon_view_parent_class)->clean_up (desktop_icon_view);
+}
+
+static void
 fm_desktop_icon_view_handle_middle_click (CajaIconContainer *icon_container,
         GdkEventButton *event,
         FMDesktopIconView *desktop_icon_view)
@@ -652,6 +659,8 @@ fm_desktop_icon_view_init (FMDesktopIconView *desktop_icon_view)
                                          CAJA_ICON_LAYOUT_T_B_R_L :
                                          CAJA_ICON_LAYOUT_T_B_L_R);
 
+    g_signal_connect_after (gtk_widget_get_screen(GTK_WIDGET(icon_container)), "size_changed",
+                            G_CALLBACK (fm_desktop_icon_view_handle_size_changed), desktop_icon_view);
     g_signal_connect_object (icon_container, "middle_click",
                              G_CALLBACK (fm_desktop_icon_view_handle_middle_click), desktop_icon_view, 0);
     g_signal_connect_object (desktop_icon_view, "realize",


### PR DESCRIPTION
After changing the screen desktop resolution, the icon
can not be completely display and automatic arrangement

Get the actual screen height, determine whether the screen
"smaller", and only this situation rearrange the icon
Add the "screen size change" event and call the
rearranged icon function

Test Methods:
Create vertical two-row desktop icons close to the upper
and lower boundaries of the screen, increase and decrease
the resolution, observe whether all the icons are displayed properly