### PR TITLE
search: add tag support (xattr::xdg.tags)

### DIFF
--- a/libcaja-private/caja-query.h
+++ b/libcaja-private/caja-query.h
@@ -57,6 +57,10 @@ void           caja_query_set_text           (CajaQuery *query, const char *text
 char *         caja_query_get_location       (CajaQuery *query);
 void           caja_query_set_location       (CajaQuery *query, const char *uri);
 
+GList *        caja_query_get_tags           (CajaQuery *query);
+void           caja_query_set_tags           (CajaQuery *query, GList *tags);
+void           caja_query_add_tag            (CajaQuery *query, const char *tag);
+
 GList *        caja_query_get_mime_types     (CajaQuery *query);
 void           caja_query_set_mime_types     (CajaQuery *query, GList *mime_types);
 void           caja_query_add_mime_type      (CajaQuery *query, const char *mime_type);


### PR DESCRIPTION
This PR add the ability to search files by tags. The tags are stored in extended attributes under `user.xdg.tags`
There is already a plugin ([xattr-tags](https://github.com/mate-desktop/caja-extensions/pull/25)) merged in the official caja-extensions repo to display the tags of the files as a column in the file list. I've another plugin on the oven to be able to add and remove tags from caja.

![caja-search](https://cloud.githubusercontent.com/assets/718207/23688202/b351dd86-0391-11e7-9466-bc4b606a0df2.png)

And here is a video demo:
https://felipebarriga.cl/owncloud/s/3b04UY9TL05584C

**How to Test**
```
$ touch file_with_tag.txt
$ setfattr --name=user.xdg.tags --value="foo,bar" file_with_tag.txt
```
Note: you can install setfattr:
- debian/ubuntu: `# apt-get install attr`
- archlinux: `# pacman -S attr`
