### PR TITLE
Fix broken rename in list (issue #741)

### DIFF
--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -2891,9 +2891,10 @@ fm_list_view_start_renaming_file (FMDirectoryView *view,
                                   NULL,
                                   list_view->details->file_name_column,
                                   TRUE, 0.0, 0.0);
-    gtk_tree_view_set_cursor (list_view->details->tree_view,
+    gtk_tree_view_set_cursor_on_cell (list_view->details->tree_view,
                               path,
                               list_view->details->file_name_column,
+                              GTK_CELL_RENDERER (list_view->details->file_name_cell),
                               TRUE);
 
     /* set cursor also triggers editing-started, where we save the editable widget */


### PR DESCRIPTION
This is a backport from nautilus 5b09cedf434b53a975074b346d511335fc735cba

  list-view: explicitly set cursor on file name cell renderer on rename

  The file name column has two cell renderers, one for the icon and another for
  the name string. Thus, gtk_tree_view_set_cursor() isn't enough to reliably
  start editing the file name cell since it will try to edit whatever is the
  currently focused cell in the column.

  https://bugzilla.gnome.org/show_bug.cgi?id=656128

Fixes https://github.com/mate-desktop/caja/issues/741