### PR TITLE
new feature: Add size on disk along with size of files

### DIFF
--- a/libcaja-private/caja-column-utilities.c
+++ b/libcaja-private/caja-column-utilities.c
@@ -54,6 +54,14 @@ get_builtin_columns (void)
                                            NULL));
     columns = g_list_append (columns,
                              g_object_new (CAJA_TYPE_COLUMN,
+                                           "name", "size_on_disk",
+                                           "attribute", "size_on_disk",
+                                           "label", _("Size on Disk"),
+                                           "description", _("The size on disk of the file."),
+                                           "xalign", 1.0,
+                                           NULL));
+    columns = g_list_append (columns,
+                             g_object_new (CAJA_TYPE_COLUMN,
                                            "name", "type",
                                            "attribute", "type",
                                            "label", _("Type"),

--- a/libcaja-private/caja-desktop-directory-file.c
+++ b/libcaja-private/caja-desktop-directory-file.c
@@ -413,7 +413,8 @@ desktop_directory_file_get_deep_counts (CajaFile *file,
                                         guint *directory_count,
                                         guint *file_count,
                                         guint *unreadable_directory_count,
-                                        goffset *total_size)
+                                        goffset *total_size,
+                                        goffset *total_size_on_disk)
 {
     CajaDesktopDirectoryFile *desktop_file;
     CajaRequestStatus status;
@@ -425,6 +426,7 @@ desktop_directory_file_get_deep_counts (CajaFile *file,
                                         file_count,
                                         unreadable_directory_count,
                                         total_size,
+                                        total_size_on_disk,
                                         TRUE);
 
     if (file_count)

--- a/libcaja-private/caja-desktop-icon-file.c
+++ b/libcaja-private/caja-desktop-icon-file.c
@@ -117,7 +117,8 @@ desktop_icon_file_get_deep_counts (CajaFile *file,
                                    guint *directory_count,
                                    guint *file_count,
                                    guint *unreadable_directory_count,
-                                   goffset *total_size)
+                                   goffset *total_size,
+                                   goffset *total_size_on_disk)
 {
     if (directory_count != NULL)
     {
@@ -134,6 +135,10 @@ desktop_icon_file_get_deep_counts (CajaFile *file,
     if (total_size != NULL)
     {
         *total_size = 0;
+    }
+    if (total_size_on_disk != NULL)
+    {
+        *total_size_on_disk = 0;
     }
 
     return CAJA_REQUEST_DONE;

--- a/libcaja-private/caja-directory-async.c
+++ b/libcaja-private/caja-directory-async.c
@@ -2991,6 +2991,12 @@ deep_count_one (DeepCountState *state,
     {
         file->details->deep_size += g_file_info_get_size (info);
     }
+    /* Count the disk size. */
+    if (!is_seen_inode && g_file_info_has_attribute (info, G_FILE_ATTRIBUTE_STANDARD_ALLOCATED_SIZE))
+    {
+        file->details->deep_size_on_disk +=
+            g_file_info_get_attribute_uint64 (info, G_FILE_ATTRIBUTE_STANDARD_ALLOCATED_SIZE);
+    }
 }
 
 static void
@@ -3170,6 +3176,7 @@ deep_count_load (DeepCountState *state, GFile *location)
                                      G_FILE_ATTRIBUTE_STANDARD_NAME ","
                                      G_FILE_ATTRIBUTE_STANDARD_TYPE ","
                                      G_FILE_ATTRIBUTE_STANDARD_SIZE ","
+                                     G_FILE_ATTRIBUTE_STANDARD_ALLOCATED_SIZE ","
                                      G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN ","
                                      G_FILE_ATTRIBUTE_STANDARD_IS_BACKUP ","
                                      G_FILE_ATTRIBUTE_ID_FILESYSTEM ","
@@ -3267,6 +3274,7 @@ deep_count_start (CajaDirectory *directory,
     file->details->deep_file_count = 0;
     file->details->deep_unreadable_count = 0;
     file->details->deep_size = 0;
+    file->details->deep_size_on_disk = 0;
     directory->details->deep_count_file = file;
 
     state = g_new0 (DeepCountState, 1);

--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -2585,7 +2585,8 @@ scan_dir (GFile *dir,
 	enumerator = g_file_enumerate_children (dir,
 						G_FILE_ATTRIBUTE_STANDARD_NAME","
 						G_FILE_ATTRIBUTE_STANDARD_TYPE","
-						G_FILE_ATTRIBUTE_STANDARD_SIZE,
+						G_FILE_ATTRIBUTE_STANDARD_SIZE","
+						G_FILE_ATTRIBUTE_STANDARD_ALLOCATED_SIZE,
 						G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
 						job->cancellable,
 						&error);
@@ -2707,7 +2708,8 @@ scan_file (GFile *file,
 	error = NULL;
 	info = g_file_query_info (file,
 				  G_FILE_ATTRIBUTE_STANDARD_TYPE","
-				  G_FILE_ATTRIBUTE_STANDARD_SIZE,
+				  G_FILE_ATTRIBUTE_STANDARD_SIZE","
+				  G_FILE_ATTRIBUTE_STANDARD_ALLOCATED_SIZE,
 				  G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
 				  job->cancellable,
 				  &error);

--- a/libcaja-private/caja-file-private.h
+++ b/libcaja-private/caja-file-private.h
@@ -72,6 +72,7 @@ struct CajaFileDetails
     eel_ref_str edit_name;
 
     goffset size; /* -1 is unknown */
+    goffset size_on_disk; /* -1 is unknown */
 
     int sort_order;
 
@@ -102,6 +103,7 @@ struct CajaFileDetails
     guint deep_file_count;
     guint deep_unreadable_count;
     goffset deep_size;
+    goffset deep_size_on_disk;
 
     GIcon *icon;
 

--- a/libcaja-private/caja-file.h
+++ b/libcaja-private/caja-file.h
@@ -63,7 +63,8 @@ typedef enum
     CAJA_FILE_SORT_BY_MTIME,
     CAJA_FILE_SORT_BY_ATIME,
     CAJA_FILE_SORT_BY_EMBLEMS,
-    CAJA_FILE_SORT_BY_TRASHED_TIME
+    CAJA_FILE_SORT_BY_TRASHED_TIME,
+    CAJA_FILE_SORT_BY_SIZE_ON_DISK
 } CajaFileSortType;
 
 typedef enum
@@ -175,6 +176,7 @@ char *                  caja_file_get_parent_uri                    (CajaFile   
 char *                  caja_file_get_parent_uri_for_display        (CajaFile                   *file);
 gboolean                caja_file_can_get_size                      (CajaFile                   *file);
 goffset                 caja_file_get_size                          (CajaFile                   *file);
+goffset                 caja_file_get_size_on_disk                  (CajaFile                   *file);
 time_t                  caja_file_get_mtime                         (CajaFile                   *file);
 GFileType               caja_file_get_file_type                     (CajaFile                   *file);
 char *                  caja_file_get_mime_type                     (CajaFile                   *file);
@@ -208,7 +210,8 @@ CajaRequestStatus   caja_file_get_deep_counts                   (CajaFile       
         guint                          *directory_count,
         guint                          *file_count,
         guint                          *unreadable_directory_count,
-        goffset               *total_size,
+        goffset                        *total_size,
+        goffset                        *total_size_on_disk,
         gboolean                        force);
 gboolean                caja_file_should_show_thumbnail             (CajaFile                   *file);
 gboolean                caja_file_should_show_directory_item_count  (CajaFile                   *file);
@@ -539,7 +542,8 @@ typedef struct
             guint                  *directory_count,
             guint                  *file_count,
             guint                  *unreadable_directory_count,
-            goffset       *total_size);
+            goffset                *total_size,
+            goffset                *total_size_on_disk);
     gboolean              (* get_date)               (CajaFile           *file,
             CajaDateType        type,
             time_t                 *date);

--- a/libcaja-private/caja-search-directory-file.c
+++ b/libcaja-private/caja-search-directory-file.c
@@ -117,7 +117,8 @@ search_directory_file_get_deep_counts (CajaFile *file,
                                        guint *directory_count,
                                        guint *file_count,
                                        guint *unreadable_directory_count,
-                                       goffset *total_size)
+                                       goffset *total_size,
+                                       goffset *total_size_on_disk)
 {
     CajaFile *dir_file;
     GList *file_list, *l;
@@ -157,6 +158,11 @@ search_directory_file_get_deep_counts (CajaFile *file,
     {
         /* FIXME: Maybe we want to calculate this? */
         *total_size = 0;
+    }
+    if (total_size_on_disk != NULL)
+    {
+        /* FIXME: Maybe we want to calculate this? */
+        *total_size_on_disk = 0;
     }
 
     caja_file_list_free (file_list);

--- a/libcaja-private/caja-vfs-file.c
+++ b/libcaja-private/caja-vfs-file.c
@@ -244,7 +244,8 @@ vfs_file_get_deep_counts (CajaFile *file,
                           guint *directory_count,
                           guint *file_count,
                           guint *unreadable_directory_count,
-                          goffset *total_size)
+                          goffset *total_size,
+                          goffset *total_size_on_disk)
 {
     GFileType type;
 
@@ -263,6 +264,10 @@ vfs_file_get_deep_counts (CajaFile *file,
     if (total_size != NULL)
     {
         *total_size = 0;
+    }
+    if (total_size_on_disk != NULL)
+    {
+        *total_size_on_disk = 0;
     }
 
     if (!caja_file_is_directory (file))
@@ -287,6 +292,10 @@ vfs_file_get_deep_counts (CajaFile *file,
         if (total_size != NULL)
         {
             *total_size = file->details->deep_size;
+        }
+        if (total_size_on_disk != NULL)
+        {
+            *total_size_on_disk = file->details->deep_size_on_disk;
         }
         return file->details->deep_counts_status;
     }

--- a/libcaja-private/org.mate.caja.gschema.xml
+++ b/libcaja-private/org.mate.caja.gschema.xml
@@ -38,6 +38,7 @@
     <value nick="atime" value="6"/>
     <value nick="emblems" value="7"/>
     <value nick="trash-time" value="8"/>
+    <value nick="size_on_disk" value="9"/>
   </enum>
 
   <enum id="org.mate.caja.ZoomLevel">

--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -99,6 +99,7 @@ static const char * const sort_order_values[] =
     "name",
     "directory",
     "size",
+    "size_on_disk",
     "type",
     "mtime",
     "atime",

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -136,6 +136,13 @@ static const SortCriterion sort_criteria[] =
         N_("Keep icons sorted by size in rows")
     },
     {
+        CAJA_FILE_SORT_BY_SIZE_ON_DISK,
+        "size_on_disk",
+        "Sort by Size on Disk",
+        N_("by Size on Disk"),
+        N_("Keep icons sorted by disk usage in rows")
+    },
+    {
         CAJA_FILE_SORT_BY_TYPE,
         "type",
         "Sort by Type",

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -183,6 +183,7 @@ get_default_sort_order (CajaFile *file, gboolean *reversed)
         "name",
         "uri",
         "size",
+        "size_on_disk",
         "type",
         "date_modified",
         "date_accessed",


### PR DESCRIPTION
Currently caja only display (and count) the size of files without considering the size of the file on the filesystem. If you work with sparse files (or multiple small files) you will found handy to check the space that the files are actually using on the disk. Sparse files can be created when you start a torrent and the client pre-allocate the space of the whole file.

In order to test this, you can create 2 files: one with 3 bytes and 1 big sparse file:
```
$ echo "fo" > 3_bytes_file.txt
$ dd of=sparse_file.txt bs=1k seek=3120000 count=0
$ echo "f" >> sparse_file.txt
```

**Note:** you need to use a filesystem that support sparse files (e.g.: ext2/3/4, btrfs)
**Note2:** It has been tested on NFS and works without issues.

Screenshots:
![size on disk](https://cloud.githubusercontent.com/assets/718207/24584183/8e3ab064-173b-11e7-99d9-b7fd829ad1e8.png)
![directory_size](https://cloud.githubusercontent.com/assets/718207/24584184/8e3ac996-173b-11e7-9a94-36734dc7257e.png)
![sparse_file](https://cloud.githubusercontent.com/assets/718207/24584185/8e3dce98-173b-11e7-8416-3b92f5a5f5b5.png)
![3_bytes_file](https://cloud.githubusercontent.com/assets/718207/24584182/8e3a8e2c-173b-11e7-94a7-3731a1ae8fd9.png)


