### PR TITLE
fix scrolling and renaming in large folders

### DIFF
--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -557,6 +557,13 @@ eel_canvas_item_move (EelCanvasItem *item, double dx, double dy)
 
 }
 
+static void
+eel_canvas_queue_resize (EelCanvas *canvas)
+{
+    if (gtk_widget_is_drawable (GTK_WIDGET (canvas)))
+            gtk_widget_queue_resize (GTK_WIDGET (canvas));
+}
+
 /* Convenience function to reorder items in a group's child list.  This puts the
  * specified link after the "before" link. Returns TRUE if the list was changed.
  */
@@ -830,6 +837,7 @@ eel_canvas_item_show (EelCanvasItem *item)
         }
 
         redraw_and_repick_if_mapped (item);
+        eel_canvas_queue_resize (item->canvas);
     }
 }
 
@@ -854,6 +862,8 @@ eel_canvas_item_hide (EelCanvasItem *item)
 
         if (item->flags & EEL_CANVAS_ITEM_MAPPED)
             (* EEL_CANVAS_ITEM_GET_CLASS (item)->unmap) (item);
+
+        eel_canvas_queue_resize (item->canvas);
 
         /* No need to unrealize when we just want to hide */
     }
@@ -1832,6 +1842,9 @@ group_add (EelCanvasGroup *group, EelCanvasItem *item)
         if (!(item->flags & EEL_CANVAS_ITEM_MAPPED))
             (* EEL_CANVAS_ITEM_GET_CLASS (item)->map) (item);
     }
+
+    if (item->flags & EEL_CANVAS_ITEM_VISIBLE)
+            eel_canvas_queue_resize (EEL_CANVAS_ITEM (group)->canvas);
 }
 
 /* Removes an item from a group */
@@ -1846,11 +1859,15 @@ group_remove (EelCanvasGroup *group, EelCanvasItem *item)
     for (children = group->item_list; children; children = children->next)
         if (children->data == item)
         {
-            if (item->flags & EEL_CANVAS_ITEM_MAPPED)
+            if (item->flags & EEL_CANVAS_ITEM_MAPPED) {
                 (* EEL_CANVAS_ITEM_GET_CLASS (item)->unmap) (item);
+            }
 
             if (item->flags & EEL_CANVAS_ITEM_REALIZED)
                 (* EEL_CANVAS_ITEM_GET_CLASS (item)->unrealize) (item);
+
+            if (item->flags & EEL_CANVAS_ITEM_VISIBLE)
+                    eel_canvas_queue_resize (item->canvas);
 
             /* Unparent the child */
 

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -4518,6 +4518,67 @@ size_allocate (GtkWidget *widget,
     }
 }
 
+static GtkSizeRequestMode
+get_request_mode (GtkWidget *widget)
+{
+    /* Don't trade size at all, since we get whatever we get anyway. */
+    return GTK_SIZE_REQUEST_CONSTANT_SIZE;
+}
+
+    /* We need to implement these since the GtkScrolledWindow uses them
+    to guess whether to show scrollbars or not, and if we don't report
+    anything it'll tend to get it wrong causing double calls
+    to size_allocate (at different sizes) during its size allocation. */
+static void
+get_prefered_width (GtkWidget *widget,
+                    gint      *minimum_size,
+                    gint      *natural_size)
+{
+    EelCanvasGroup *root;
+    double x1, x2;
+    int cx1, cx2;
+    int width;
+
+    root = eel_canvas_root (EEL_CANVAS (widget));
+    eel_canvas_item_get_bounds (EEL_CANVAS_ITEM (root),
+                    &x1, NULL, &x2, NULL);
+    eel_canvas_w2c (EEL_CANVAS (widget), x1, 0, &cx1, NULL);
+    eel_canvas_w2c (EEL_CANVAS (widget), x2, 0, &cx2, NULL);
+
+    width = cx2 - cx1;
+    if (natural_size) {
+        *natural_size = width;
+    }
+    if (minimum_size) {
+        *minimum_size = width;
+    }
+}
+
+static void
+get_prefered_height (GtkWidget *widget,
+                     gint      *minimum_size,
+                     gint      *natural_size)
+{
+    EelCanvasGroup *root;
+    double y1, y2;
+    int cy1, cy2;
+    int height;
+
+    root = eel_canvas_root (EEL_CANVAS (widget));
+    eel_canvas_item_get_bounds (EEL_CANVAS_ITEM (root),
+                    NULL, &y1, NULL, &y2);
+    eel_canvas_w2c (EEL_CANVAS (widget), 0, y1, NULL, &cy1);
+    eel_canvas_w2c (EEL_CANVAS (widget), 0, y2, NULL, &cy2);
+
+    height = cy2 - cy1;
+    if (natural_size) {
+        *natural_size = height;
+    }
+    if (minimum_size) {
+        *minimum_size = height;
+    }
+}
+
 static gboolean
 draw (GtkWidget *widget, cairo_t *cr)
 {
@@ -6519,6 +6580,9 @@ caja_icon_container_class_init (CajaIconContainerClass *class)
 
     widget_class = GTK_WIDGET_CLASS (class);
     widget_class->size_allocate = size_allocate;
+    widget_class->get_request_mode = get_request_mode;
+    widget_class->get_preferred_width = get_prefered_width;
+    widget_class->get_preferred_height = get_prefered_height;
     widget_class->draw = draw;
     widget_class->realize = realize;
     widget_class->unrealize = unrealize;


### PR DESCRIPTION
fixes https://github.com/mate-desktop/caja/issues/755
First time it's a bit hard to reproduce the issue, see this posts.
https://github.com/mate-desktop/caja/issues/755#issuecomment-292500277
https://github.com/mate-desktop/caja/issues/755#issuecomment-293630213
https://www.dropbox.com/s/8ftp9gois751892/caja-issue.ogv?dl=0

Note, i added a cosmetic back port of a nemo commit in another branch (dev-experimental), which reduce the width of the gap between grid of items and vertical right scrollbar.
Taken from https://github.com/linuxmint/nemo/pull/1257
But this dynamically grid change the look and feel of the icon-view and isn't really needed to fix the issue.
Please vote here if you like this behaviour or not.