### PR TITLE
IconCanvasItem: fix overlapping filenames on hover

### DIFF
--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -1049,7 +1049,6 @@ prepare_pango_layout_for_draw (CajaIconCanvasItem *item,
         pango_layout_set_height (layout, -1);
     }
     else if (needs_highlight ||
-             details->is_prelit ||
              details->is_highlighted_as_keyboard_focus ||
              details->entire_text ||
              container->details->label_position == CAJA_ICON_LABEL_POSITION_BESIDE)


### PR DESCRIPTION
Just a little fix for another annoying issue.

taken from: https://git.gnome.org/browse/nautilus/commit/?id=308f4ce