### PR TITLE
Open With dialog: force icon size

### DIFF
--- a/libcaja-private/caja-open-with-dialog.c
+++ b/libcaja-private/caja-open-with-dialog.c
@@ -526,7 +526,7 @@ get_pixbuf_for_icon (GIcon *icon)
                 *p = 0;
             }
             pixbuf = gtk_icon_theme_load_icon (gtk_icon_theme_get_default (),
-                                               icon_no_extension, 24, 0, NULL);
+                                               icon_no_extension, 24, GTK_ICON_LOOKUP_FORCE_SIZE, NULL);
             g_free (icon_no_extension);
         }
     }


### PR DESCRIPTION
A quick fix for https://github.com/mate-desktop/caja/issues/735. Tested with sqlitebrowser and icon themes: Mint-X, Menta, Mate-Faenza. I'd like some more testing in case I missed something.

In the long term we could probably migrate to GtkAppChooserWidget/GtkAppChooserDialog.