### PR TITLE
file: make caja_file_get_gicon return custom icons too

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -4123,6 +4123,11 @@ caja_file_get_gicon (CajaFile *file,
 		return NULL;
 	}
 
+	icon = get_custom_icon (file);
+	if (icon != NULL) {
+		return icon;
+	}
+
 	if (file->details->icon) {
 		icon = NULL;
 


### PR DESCRIPTION
Finally found the relevant upstream commit. This should fix https://github.com/mate-desktop/caja/issues/410 in Mint (using ```caja-folder-color-switcher``` package) and Ubuntu (using ```folder-color-caja``` package). Maybe some other distros have it, but I don't know.
If you don't have folder-color available, please just check that I didn't break anything, in particular, in the list view and the bookmarks (that's where ```caja_file_get_gicon``` function is used, according to grep).