### PR TITLE
CSS: Load a different caja-desktop.css with GTK 3.14

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -35,6 +35,7 @@ cajadata_DATA = \
 	caja-suggested.placeholder \
 	caja.css \
     caja-desktop.css \
+    caja-desktop-3.14.css \
 	$(NULL)
 
 # app data file

--- a/data/caja-desktop-3.14.css
+++ b/data/caja-desktop-3.14.css
@@ -1,0 +1,29 @@
+/* Everything that themes must not override goes in this file */
+/* This is loaded with GTK_STYLE_PROVIDER_PRIORITY_APPLICATION and overrides themes */
+
+/* desktop mode */
+.caja-desktop.caja-canvas-item {
+    color: #ffffff;
+    text-shadow: 1px 1px alpha (#000000, 0.8);
+}
+
+.caja-desktop.caja-canvas-item:selected,
+.caja-desktop.caja-canvas-item:active,
+.caja-desktop.caja-canvas-item:hover {
+    text-shadow: none;
+}
+
+/* remove possible theme settings for borders on scrolledwindow with gtk+-3.20 */
+.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow,
+.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow.frame,
+.caja-desktop-window > grid.vertical > box.vertical > box.vertical > box.vertical > scrolledwindow > widget.view.caja-desktop {
+   border-width: 0px;
+   border-style: none;
+   border-radius: 0px;
+}
+
+/* This is not on the desktop but will cause errors if themes can override */
+/* Padding in slider buttons causes GTK errors in GTK 3.20 or later */
+.caja-navigation-window .slider-button {
+	padding: 0px;
+}

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -2226,8 +2226,12 @@ init_icons_and_styles (void)
 
 /* add our desktop CSS provider,  ensures the desktop background does not get covered */
     provider = gtk_css_provider_new ();
-    gtk_css_provider_load_from_path (provider,
-				CAJA_DATADIR G_DIR_SEPARATOR_S "caja-desktop.css", &error);
+
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_css_provider_load_from_path (provider, CAJA_DATADIR G_DIR_SEPARATOR_S "caja-desktop.css", &error);
+#else
+    gtk_css_provider_load_from_path (provider, CAJA_DATADIR G_DIR_SEPARATOR_S "caja-desktop-3.14.css", &error);
+#endif
 
     if (error != NULL) {
         g_warning ("Can't parse Caja' CSS custom description: %s\n", error->message);


### PR DESCRIPTION
In caja-desktop.css this line isn't compatible with GTK 3.14:

".caja-desktop:not(:selected):not(:active):not(.rubberband){"

It is needed for GTK 3.20/3.22 tough.

This PR checks the GTK version and loads the appropriate CSS.

This fixes desktop icons showing black text. That issue was
reproduced with Adwaita under LMDE with GTK 3.14.