### PR TITLE
restore DBus interface initialization

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -2334,6 +2334,9 @@ caja_application_startup (GApplication *app)
      */
     G_APPLICATION_CLASS (caja_application_parent_class)->startup (app);
 
+    /* Start the File Manager DBus Interface */
+    fdb_manager = caja_freedesktop_dbus_new (app);
+
     /* Initialize preferences. This is needed so that proper
      * defaults are available before any preference peeking
      * happens.


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/caja/issues/771

Copied from 1.16 code. Not sure if it should be placed at that point or somewhere below in the code, so feel free to move it if there's a reason for it.