### PR TITLE
Pathbar buttons do not work with long filenames

### DIFF
--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -1354,12 +1354,9 @@ get_type_icon_info (ButtonData *button_data)
                                                 CAJA_PATH_BAR_ICON_SIZE);
 
     case NORMAL_BUTTON:
-        if (button_data->is_base_dir)
-        {
-            return caja_file_get_icon (button_data->file,
-                                       CAJA_PATH_BAR_ICON_SIZE,
-                                       CAJA_FILE_ICON_FLAGS_NONE);
-        }
+        return caja_file_get_icon (button_data->file,
+                                   CAJA_PATH_BAR_ICON_SIZE,
+                                   CAJA_FILE_ICON_FLAGS_NONE);
 
     default:
         return NULL;


### PR DESCRIPTION
If the file path does not fit into the pathbar, the last part of the path is cut off; clicking on the right arrow button does not display the rest of the path. Only when the window is maximized, or the togglebutton is clicked, the full path is displayed.

I see that an issue has already been opened, but you guys said to always create a pull request.
