### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -1388,12 +1388,17 @@
 
 
 ========== pl.po ==========
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# matepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for nautilus.
+# Copyright © 2000-2010 the nautilus authors.
+# This file is distributed under the same license as the nautilus package.
+# Zbigniew Chyla <chyla@alice.ci.pwr.wroc.pl>, 2000-2003.
+# Artur Flinta <aflinta@at.kernel.pl>, 2003-2006.
+# Wadim Dziedzic <wdziedzic@aviary.pl>, 2006-2009.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2007-2009.
+# Wojciech Kapusta <wkapusta@aviary.pl>, 2009.
+# Piotr Drąg <piotrdrag@gmail.com>, 2009-2010.
+# Aviary.pl <gnomepl@aviary.pl>, 2006-2010.
+#
 
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.