### PR TITLE
Fix off-by-one error in caja-pathbar.c

### DIFF
--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -1426,7 +1426,9 @@ set_label_padding_size (ButtonData *button_data)
     pango_layout_get_pixel_size (layout, &bold_width, &bold_height);
 
     pad_left = (bold_width - width) / 2;
-    pad_right = (bold_width - width) / 2;
+    pad_right = (bold_width + 1 - width) / 2; /* this ensures rounding up - the
+    pixel size difference between bold and normal fonts is not always even and
+    will give an off-by-one error when dividing by 2 */
 
     gtk_widget_set_margin_start (GTK_WIDGET (button_data->label), pad_left);
     gtk_widget_set_margin_end (GTK_WIDGET (button_data->label), pad_right);


### PR DESCRIPTION
The pixel size difference between bold and normal fonts is not always even, so
it cannot be divided by 2. (Try not dividing by 2 and using padding only on the
right side).

And why use bold font at all? The buttons change when you click on them; that
should be enough. Or use CSS to change the font color to grey for inactive
buttons (use theme colors of course):
```
/* caja pathbar */
.caja-pathbar button label {
	color: #cbcbcb;
    /*font-weight: bold;*/
}

.caja-pathbar button:checked label {
    color: #ffffff;
}
```
This will work as long as you don't set different font-weights for button label
and button:checked label.
