### PR TITLE
Fix for Issue 801

### DIFF
--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -2499,15 +2499,13 @@ fm_icon_view_scroll_event (GtkWidget *widget,
 
             /* transform vertical integer smooth scroll events into horizontal events */
             if (scroll_event_copy->direction == GDK_SCROLL_SMOOTH && scroll_event_copy->delta_x == 0) {
-                if (scroll_event_copy->delta_y == 1.0) {
+                if (scroll_event_copy->delta_y > 0) {
                     scroll_event_copy->direction = GDK_SCROLL_DOWN;
-                } else if (scroll_event_copy->delta_y == -1.0) {
+                } else if (scroll_event_copy->delta_y < 0) {
                     scroll_event_copy->direction = GDK_SCROLL_UP;
                 }
             }
-            if ((scroll_event_copy->direction == GDK_SCROLL_UP) || (scroll_event_copy->delta_x == -1.0))
-
-
+            if ((scroll_event_copy->direction == GDK_SCROLL_UP) || (scroll_event_copy->delta_x < 0))
             {
                 scroll_event_copy->direction = GDK_SCROLL_LEFT;
             }


### PR DESCRIPTION
I propose this for testing. This fixes the issue on my system.

https://github.com/mate-desktop/caja/issues/801

Changed delta scroll detection from `== 1.0` and `== -1.0` to ` > 0` and
`< 0` respectively as the delta values are not always exact. They are
some fraction.