### PR TITLE
Fix browsing/autorun media on insertion

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -1373,6 +1373,7 @@ mount_added_callback (GVolumeMonitor *monitor,
         caja_directory_force_reload (directory);
         caja_directory_unref (directory);
     }
+	caja_autorun (mount, autorun_show_window, application);
 }
 
 static CajaWindowSlot *


### PR DESCRIPTION
Fix https://github.com/mate-desktop/caja/issues/807

A one-liner, tested with GTK 3.22.16 and works. 
Looks like this was left out of Nautilus 3.0, as I didn't find it in Nemo either

Both browsing inserted flash drives and auto-opening GNOME MPV to play a video DVD worked.  Responded properly to the preference settings. 

Note that on first run, setting preferences back to "never prompt or start programs on media insertion" while the DVD was still in and GNOME MPV still open generated a segfault (in libgtk), but this was not repeated on any subsequent runs when letting the media player autostart, then setting the preferences back to "never..." with the disk either playing or stopped.