### PR TITLE
avoid deprecated gdk_screen_get_width/height and gdk_screen_width/height

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -311,9 +311,13 @@ drawable_get_adjusted_size (EelBackground *self,
 {
     if (self->details->is_desktop)
     {
+        gint sc_width, sc_height;
         GdkScreen *screen = gtk_widget_get_screen (self->details->widget);
-        *width = gdk_screen_get_width (screen);
-        *height = gdk_screen_get_height (screen);
+
+        gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                                 &sc_width, &sc_height);
+        *width = sc_width;
+        *height = sc_height;
     }
     else
     {

--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -1051,6 +1051,7 @@ eel_editable_label_ensure_layout (EelEditableLabel *label,
             else
             {
                 gint wrap_width;
+                gint sc_width;
 
                 pango_layout_set_width (label->layout, -1);
                 pango_layout_get_extents (label->layout, NULL, &logical_rect);
@@ -1060,10 +1061,13 @@ eel_editable_label_ensure_layout (EelEditableLabel *label,
                 /* Try to guess a reasonable maximum width */
                 longest_paragraph = width;
 
+                gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+                                         NULL, NULL, &sc_width, NULL);
+
                 wrap_width = get_label_wrap_width (label);
                 width = MIN (width, wrap_width);
                 width = MIN (width,
-                             PANGO_SCALE * (gdk_screen_width () + 1) / 2);
+                             PANGO_SCALE * (sc_width + 1) / 2);
 
                 pango_layout_set_width (label->layout, width);
                 pango_layout_get_extents (label->layout, NULL, &logical_rect);
@@ -3047,6 +3051,7 @@ popup_position_func (GtkMenu   *menu,
     GtkWidget *widget;
     GtkRequisition req;
     GtkAllocation allocation;
+    gint sc_width, sc_height;
 
     label = EEL_EDITABLE_LABEL (user_data);
     widget = GTK_WIDGET (label);
@@ -3061,8 +3066,11 @@ popup_position_func (GtkMenu   *menu,
     *x += allocation.width / 2;
     *y += allocation.height;
 
-    *x = CLAMP (*x, 0, MAX (0, gdk_screen_width () - req.width));
-    *y = CLAMP (*y, 0, MAX (0, gdk_screen_height () - req.height));
+    gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+                             NULL, NULL, &sc_width, &sc_height);
+
+    *x = CLAMP (*x, 0, MAX (0, sc_width - req.width));
+    *y = CLAMP (*y, 0, MAX (0, sc_height - req.height));
 }
 
 static void

--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -86,6 +86,11 @@ eel_gtk_window_get_geometry_string (GtkWindow *window)
 static void
 sanity_check_window_position (int *left, int *top)
 {
+    gint sc_width, sc_height;
+
+    gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+                             NULL, NULL, &sc_width, &sc_height);
+
     g_assert (left != NULL);
     g_assert (top != NULL);
 
@@ -95,7 +100,7 @@ sanity_check_window_position (int *left, int *top)
      * isn't off the bottom of the screen, or so close to the bottom
      * that it might be obscured by the panel.
      */
-    *top = CLAMP (*top, 0, gdk_screen_height() - MINIMUM_ON_SCREEN_HEIGHT);
+    *top = CLAMP (*top, 0, sc_height - MINIMUM_ON_SCREEN_HEIGHT);
 
     /* FIXME bugzilla.eazel.com 669:
      * If window has negative left coordinate, set_uposition sends it
@@ -108,12 +113,17 @@ sanity_check_window_position (int *left, int *top)
      * the screen, or so close to the right edge that it might be
      * obscured by the panel.
      */
-    *left = CLAMP (*left, 0, gdk_screen_width() - MINIMUM_ON_SCREEN_WIDTH);
+    *left = CLAMP (*left, 0, sc_width - MINIMUM_ON_SCREEN_WIDTH);
 }
 
 static void
 sanity_check_window_dimensions (guint *width, guint *height)
 {
+    gint sc_width, sc_height;
+
+    gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+                             NULL, NULL, &sc_width, &sc_height);
+
     g_assert (width != NULL);
     g_assert (height != NULL);
 
@@ -122,8 +132,8 @@ sanity_check_window_dimensions (guint *width, guint *height)
      * be reached (might not be necessary with all window managers,
      * but seems reasonable anyway).
      */
-    *width = MIN (*width, gdk_screen_width());
-    *height = MIN (*height, gdk_screen_height());
+    *width = MIN (*width, sc_width);
+    *height = MIN (*height, sc_height);
 }
 
 /**

--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -168,8 +168,9 @@ eel_gtk_window_set_initial_geometry (GtkWindow *window,
         real_top = top;
 
         screen = gtk_window_get_screen (window);
-        screen_width  = gdk_screen_get_width  (screen);
-        screen_height = gdk_screen_get_height (screen);
+
+        gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                                 &screen_width, &screen_height);
 
         /* This is sub-optimal. GDK doesn't allow us to set win_gravity
          * to South/East types, which should be done if using negative

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -326,6 +326,7 @@ icon_set_position (CajaIcon *icon,
     int item_width, item_height;
     int height_above, width_left;
     int min_x, max_x, min_y, max_y;
+    int sc_width, sc_height;
 
     if (icon->x == x && icon->y == y)
     {
@@ -354,12 +355,16 @@ icon_set_position (CajaIcon *icon,
 
         For now, we have a cheesy workaround:
         */
+
+        gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+                                 NULL, NULL, &sc_width, &sc_height);
+
         container_x = 0;
         container_y = 0;
-        container_width = gdk_screen_width () - container_x
+        container_width = sc_width - container_x
                           - container->details->left_margin
                           - container->details->right_margin;
-        container_height = gdk_screen_height () - container_y
+        container_height = sc_height - container_y
                            - container->details->top_margin
                            - container->details->bottom_margin;
         pixels_per_unit = EEL_CANVAS (container)->pixels_per_unit;

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -5285,6 +5285,7 @@ caja_icon_container_search_position_func (CajaIconContainer *container,
     gint x, y;
     gint cont_x, cont_y;
     gint cont_width, cont_height;
+    gint sc_width, sc_height;
     GdkWindow *cont_window;
     GdkScreen *screen;
     GtkRequisition requisition;
@@ -5305,11 +5306,14 @@ caja_icon_container_search_position_func (CajaIconContainer *container,
     cont_width = gdk_window_get_width (cont_window);
     cont_height = gdk_window_get_height (cont_window);
 
+    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                             &sc_width, &sc_height);
+
     gtk_widget_get_preferred_size (search_dialog, &requisition, NULL);
 
-    if (cont_x + cont_width - requisition.width > gdk_screen_get_width (screen))
+    if (cont_x + cont_width - requisition.width > sc_width)
     {
-        x = gdk_screen_get_width (screen) - requisition.width;
+        x = sc_width - requisition.width;
     }
     else if (cont_x + cont_width - requisition.width < 0)
     {
@@ -5320,9 +5324,9 @@ caja_icon_container_search_position_func (CajaIconContainer *container,
         x = cont_x + cont_width - requisition.width;
     }
 
-    if (cont_y + cont_height > gdk_screen_get_height (screen))
+    if (cont_y + cont_height > sc_height)
     {
-        y = gdk_screen_get_height (screen) - requisition.height;
+        y = sc_height - requisition.height;
     }
     else if (cont_y + cont_height < 0)     /* isn't really possible ... */
     {
@@ -6068,6 +6072,7 @@ key_press_event (GtkWidget *widget,
         const char *new_text;
         gboolean retval;
         GdkScreen *screen;
+        gint sc_width, sc_height;
         gboolean text_modified;
         gulong popup_menu_id;
 
@@ -6085,9 +6090,13 @@ key_press_event (GtkWidget *widget,
 
         /* Move the entry off screen */
         screen = gtk_widget_get_screen (GTK_WIDGET (container));
+
+        gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                                 &sc_width, &sc_height);
+
         gtk_window_move (GTK_WINDOW (container->details->search_window),
-                         gdk_screen_get_width (screen) + 1,
-                         gdk_screen_get_height (screen) + 1);
+                         sc_width + 1,
+                         sc_height + 1);
         gtk_widget_show (container->details->search_window);
 
         /* Send the event to the window.  If the preedit_changed signal is emitted

--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -115,8 +115,8 @@ caja_desktop_window_screen_size_changed (GdkScreen             *screen,
 {
     int width_request, height_request;
 
-    width_request = gdk_screen_get_width (screen);
-    height_request = gdk_screen_get_height (screen);
+    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                             &width_request, &height_request);
 
     g_object_set (window,
                   "width_request", width_request,
@@ -131,8 +131,8 @@ caja_desktop_window_new (CajaApplication *application,
     CajaDesktopWindow *window;
     int width_request, height_request;
 
-    width_request = gdk_screen_get_width (screen);
-    height_request = gdk_screen_get_height (screen);
+    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                             &width_request, &height_request);
 
     window = CAJA_DESKTOP_WINDOW
              (gtk_widget_new (caja_desktop_window_get_type(),

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -516,7 +516,12 @@ caja_window_zoom_to_default (CajaWindow *window)
 static guint
 get_max_forced_height (GdkScreen *screen)
 {
-    return (gdk_screen_get_height (screen) * 90) / 100;
+    gint height;
+
+    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                             NULL, &height);
+
+    return (height * 90) / 100;
 }
 
 /* Code should never force the window wider than this size.
@@ -525,7 +530,12 @@ get_max_forced_height (GdkScreen *screen)
 static guint
 get_max_forced_width (GdkScreen *screen)
 {
-    return (gdk_screen_get_width (screen) * 90) / 100;
+    gint width;
+
+    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                             &width, NULL);
+
+    return (width * 90) / 100;
 }
 
 /* This must be called when construction of CajaWindow is finished,

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -119,8 +119,8 @@ icon_container_set_workarea (CajaIconContainer *icon_container,
 
     left = right = top = bottom = 0;
 
-    screen_width  = gdk_screen_get_width (screen);
-    screen_height = gdk_screen_get_height (screen);
+    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                             &screen_width, &screen_height);
 
     for (i = 0; i < n_items; i += 4)
     {
@@ -442,8 +442,10 @@ realized_callback (GtkWidget *widget, FMDesktopIconView *desktop_icon_view)
      */
     allocation.x = 0;
     allocation.y = 0;
-    allocation.width = gdk_screen_get_width (screen);
-    allocation.height = gdk_screen_get_height (screen);
+
+    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                             &allocation.width, &allocation.height);
+
     gtk_widget_size_allocate (GTK_WIDGET(get_icon_container(desktop_icon_view)),
                               &allocation);
 


### PR DESCRIPTION
avoid deprecated:

- gdk_screen_get_width/height

- gdk_screen_width/height