### PR TITLE
gtk 3.22: avoid deprecated gdk_screen_get_monitor... functions:

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -941,7 +941,12 @@ eel_background_is_dark (EelBackground *self)
 
     /* only check for the background on the 0th monitor */
     GdkScreen *screen = gdk_screen_get_default ();
+#if GTK_CHECK_VERSION (3, 22, 0)
+    GdkDisplay *display = gdk_screen_get_display (screen);
+    gdk_monitor_get_geometry (gdk_display_get_monitor (display, 0), &rect);
+#else
     gdk_screen_get_monitor_geometry (screen, 0, &rect);
+#endif
 
     return mate_bg_is_dark (self->details->bg, rect.width, rect.height);
 }

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -5294,15 +5294,25 @@ caja_icon_container_search_position_func (CajaIconContainer *container,
     GdkWindow *cont_window;
     GdkScreen *screen;
     GtkRequisition requisition;
+#if GTK_CHECK_VERSION (3, 22, 0)
+    GdkMonitor *monitor_num;
+#else
     gint monitor_num;
+#endif
     GdkRectangle monitor;
 
 
     cont_window = gtk_widget_get_window (GTK_WIDGET (container));
     screen = gdk_window_get_screen (cont_window);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+    monitor_num = gdk_display_get_monitor_at_window (gdk_screen_get_display (screen),
+                                                     cont_window);
+    gdk_monitor_get_geometry (monitor_num, &monitor);
+#else
     monitor_num = gdk_screen_get_monitor_at_window (screen, cont_window);
     gdk_screen_get_monitor_geometry (screen, monitor_num, &monitor);
+#endif
 
     gtk_widget_realize (search_dialog);
 

--- a/src/caja-zoom-control.c
+++ b/src/caja-zoom-control.c
@@ -144,8 +144,13 @@ menu_position_under_widget (GtkMenu   *menu,
     GtkRequisition req;
     GtkRequisition menu_req;
     GdkRectangle monitor;
+#if GTK_CHECK_VERSION (3, 22, 0)
+    GdkMonitor *monitor_num;
+    GdkDisplay *display;
+#else
     int monitor_num;
     GdkScreen *screen;
+#endif
     GtkAllocation allocation;
 
     widget = GTK_WIDGET (user_data);
@@ -158,6 +163,13 @@ menu_position_under_widget (GtkMenu   *menu,
     gtk_widget_get_preferred_size (widget, &req, NULL);
     gtk_widget_get_allocation (widget, &allocation);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+    display = gtk_widget_get_display (GTK_WIDGET (menu));
+    monitor_num = gdk_display_get_monitor_at_window (display, gtk_widget_get_window (widget));
+    if (monitor_num == NULL)
+        monitor_num = gdk_display_get_monitor (display, 0);
+    gdk_monitor_get_geometry (monitor_num, &monitor);
+#else
     screen = gtk_widget_get_screen (GTK_WIDGET (menu));
     monitor_num = gdk_screen_get_monitor_at_window (screen, gtk_widget_get_window (widget));
     if (monitor_num < 0)
@@ -165,6 +177,7 @@ menu_position_under_widget (GtkMenu   *menu,
         monitor_num = 0;
     }
     gdk_screen_get_monitor_geometry (screen, monitor_num, &monitor);
+#endif
 
     gdk_window_get_origin (gtk_widget_get_window (widget), x, y);
     if (!gtk_widget_get_has_window (widget))


### PR DESCRIPTION
avoid deprecated:

gdk_screen_get_monitor_geometry
gdk_screen_get_monitor_at_window