### PR TITLE
pathbar: enable mousewheel scrolling like it was with GTK+2

### DIFF
--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -155,6 +155,7 @@ get_slider_button (CajaPathBar  *path_bar,
 #else
     gtk_button_set_focus_on_click (GTK_BUTTON (button), FALSE);
 #endif
+    gtk_widget_add_events (button, GDK_SCROLL_MASK);
     gtk_container_add (GTK_CONTAINER (button),
                        gtk_image_new_from_icon_name (arrow_type, GTK_ICON_SIZE_MENU));
     gtk_container_add (GTK_CONTAINER (path_bar), button);
@@ -918,6 +919,9 @@ caja_path_bar_scroll (GtkWidget      *widget,
     case GDK_SCROLL_UP:
         caja_path_bar_scroll_up (path_bar);
         return TRUE;
+
+    case GDK_SCROLL_SMOOTH:
+        break;
     }
 
     return FALSE;
@@ -1842,6 +1846,7 @@ make_directory_button (CajaPathBar  *path_bar,
 #else
     gtk_button_set_focus_on_click (GTK_BUTTON (button_data->button), FALSE);
 #endif
+    gtk_widget_add_events (button_data->button, GDK_SCROLL_MASK);
     /* TODO update button type when xdg directories change */
 
     button_data->drag_info.target_location = g_object_ref (path);


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/caja/issues/779

How to test:
- change into some directory 4-5 levels deep, so that pathbar would show enough buttons
- make the window narrow, so that not all pathbar buttons will be visible
- use mousewheel scroll on some buttons

This should do the same as the left/right arrow buttons on pathbar sides do.