### PR TITLE
list view: fix regression from #835

### DIFF
--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -2777,6 +2777,9 @@ fm_list_view_set_zoom_level (FMListView *view,
     gtk_cell_renderer_set_fixed_size (GTK_CELL_RENDERER (view->details->pixbuf_cell),
                                       -1, icon_size);
 
+    /* FIXME: https://bugzilla.gnome.org/show_bug.cgi?id=641518 */
+    gtk_tree_view_columns_autosize (view->details->tree_view);
+
     fm_directory_view_update_menus (FM_DIRECTORY_VIEW (view));
 
     gtk_tree_model_foreach (GTK_TREE_MODEL (view->details->model), list_view_changed_foreach, NULL);

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -1766,7 +1766,6 @@ create_and_set_up_tree_view (FMListView *view)
             gtk_tree_view_column_set_sort_column_id (view->details->file_name_column, column_num);
             gtk_tree_view_column_set_title (view->details->file_name_column, _("Name"));
             gtk_tree_view_column_set_resizable (view->details->file_name_column, TRUE);
-            gtk_tree_view_column_set_sizing(view->details->file_name_column, GTK_TREE_VIEW_COLUMN_AUTOSIZE);
 
             gtk_tree_view_column_pack_start (view->details->file_name_column, cell, FALSE);
             gtk_tree_view_column_set_attributes (view->details->file_name_column,
@@ -1806,7 +1805,6 @@ create_and_set_up_tree_view (FMListView *view)
                                  column);
 
             gtk_tree_view_column_set_resizable (column, TRUE);
-            gtk_tree_view_column_set_sizing(column, GTK_TREE_VIEW_COLUMN_AUTOSIZE);
         }
         g_free (name);
         g_free (label);


### PR DESCRIPTION
With this PR, the behavior is as follows:

- column resizing works again
- if you don't resize a column manually before zooming, it will adapt its size on zoom in/out
- if you resize it manually before zooming, it will keep the size you've set (i.e. size won't change on zoom in/out)
- changing from list view to some other one and back will reset that behavior

I also checked the behavior in GTK+2 build of 1.16:

- column resizing works, but the minimum size of Name column is way too big, more than a half of the window
- if you don't resize a column manually before zooming, it will get bigger on zoom in, but doesn't get smaller on zoom out
- if you resize it manually before zooming, it will keep the size you've set (i.e. size won't change on zoom in/out)
- changing from list view to some other one and back will reset that behavior

Not sure if the two differences in GTK+2 build are bugs or not.