### PR TITLE
icon-dnd: remove hardcoded highlight frame

### DIFF
--- a/libcaja-private/caja-icon-dnd.c
+++ b/libcaja-private/caja-icon-dnd.c
@@ -1573,7 +1573,7 @@ drag_highlight_draw (GtkWidget *widget,
     style = gtk_widget_get_style_context (widget);
 
     gtk_style_context_save (style);
-    gtk_style_context_add_class (style, "dnd");
+    gtk_style_context_add_class (style, GTK_STYLE_CLASS_DND);
     gtk_style_context_set_state (style, GTK_STATE_FLAG_FOCUSED);
 
     gtk_render_frame (style,
@@ -1582,11 +1582,6 @@ drag_highlight_draw (GtkWidget *widget,
 
     gtk_style_context_restore (style);
 
-    cairo_set_line_width (cr, 1.0);
-    cairo_set_source_rgb (cr, 0, 0, 0);
-    cairo_rectangle (cr, 0.5, 0.5, width - 1, height - 1);
-
-    cairo_stroke (cr);
     return FALSE;
 }
 


### PR DESCRIPTION
The call to gtk_render_frame() should be enough;
Now the .dnd style class setting from themes are used.
Fixes https://github.com/mate-desktop/mate-themes/issues/194

origin commit:
https://git.gnome.org/browse/nautilus/commit/?id=8d8979f