### PR TITLE
open folder in new window: [ctrl] + [shift] + [w]

### DIFF
--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -7286,7 +7286,7 @@ static const GtkActionEntry directory_view_entries[] = {
   /* tooltip */                  NULL,
                                  G_CALLBACK (action_open_callback) },
   /* name, stock id */         { "OpenAlternate", NULL,
-  /* label, accelerator */       N_("Open in Navigation Window"), "<control><shift>o",
+  /* label, accelerator */       N_("Open in Navigation Window"), "<control><shift>w",
   /* tooltip */                  N_("Open each selected item in a navigation window"),
                                  G_CALLBACK (action_open_alternate_callback) },
   /* name, stock id */         { "OpenInNewTab", NULL,


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/caja/issues/859

In the issue is suggested [ctrl+shift+o] to open new window

Currently [ctrl+shift+o] works to open in new tab, and it happens since years ago, so, I suppose some users prefer to keep it with no changes

I suggest the change in "open new window" to [ctrl+shift+w], it can be done faster, with one hand