### PR TITLE
remove the shadows

### DIFF
--- a/src/caja-history-sidebar.c
+++ b/src/caja-history-sidebar.c
@@ -274,7 +274,6 @@ caja_history_sidebar_init (CajaHistorySidebar *sidebar)
                                     GTK_POLICY_AUTOMATIC);
     gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
     gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
-    gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (sidebar), GTK_SHADOW_IN);
     gtk_container_add (GTK_CONTAINER (sidebar), GTK_WIDGET (tree_view));
     gtk_widget_show (GTK_WIDGET (sidebar));
 

--- a/src/caja-notes-viewer.c
+++ b/src/caja-notes-viewer.c
@@ -343,8 +343,6 @@ caja_notes_viewer_init (CajaNotesViewer *sidebar)
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (sidebar),
                                     GTK_POLICY_AUTOMATIC,
                                     GTK_POLICY_AUTOMATIC);
-    gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (sidebar),
-                                         GTK_SHADOW_IN);
     gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
     gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
     gtk_container_add (GTK_CONTAINER (sidebar), details->note_text_field);

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -3167,7 +3167,6 @@ caja_places_sidebar_init (CajaPlacesSidebar *sidebar)
                                     GTK_POLICY_AUTOMATIC);
     gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
     gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
-    gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (sidebar), GTK_SHADOW_IN);
 
     /* tree view */
     tree_view = GTK_TREE_VIEW (gtk_tree_view_new ());

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -2005,7 +2005,6 @@ fm_directory_view_init (FMDirectoryView *view)
 					GTK_POLICY_AUTOMATIC);
 	gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (view), NULL);
 	gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (view), NULL);
-	gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (view), GTK_SHADOW_ETCHED_IN);
 
 	set_up_scripts_directory_global ();
 	scripts_directory = caja_directory_get_by_uri (scripts_directory_uri);

--- a/src/file-manager/fm-tree-view.c
+++ b/src/file-manager/fm-tree-view.c
@@ -1590,7 +1590,6 @@ fm_tree_view_init (FMTreeView *view)
                                     GTK_POLICY_AUTOMATIC);
     gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (view), NULL);
     gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (view), NULL);
-    gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (view), GTK_SHADOW_IN);
 
     gtk_widget_show (GTK_WIDGET (view));
 


### PR DESCRIPTION
This is obviously a very controversial change but IMHO makes caja look much more modern. You might want to do a poll with the community or so before merging this. Please note that also before these commits some of the sidebar tabs did not have a shadow (e.g. the information tab).
Anyway here are some screenshots with the default Ubuntu Ambiance theme:
before:
![caja-before](https://user-images.githubusercontent.com/2668288/32989423-ba5eaa52-cd15-11e7-99e9-3837521091f0.png)
after:
![caja-after](https://user-images.githubusercontent.com/2668288/32989424-c1864b46-cd15-11e7-9c9c-65dd46a5cf20.png)
