### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -31,7 +31,7 @@
 #include "eel-lib-self-check-functions.h"
 #include <gtk/gtk.h>
 #include <eel/eel-canvas.h>
-# include <cairo-xlib.h>
+#include <cairo-xlib.h>
 #include <gdk/gdkx.h>
 #include <gio/gio.h>
 #include <math.h>
@@ -311,33 +311,9 @@ drawable_get_adjusted_size (EelBackground *self,
 {
     if (self->details->is_desktop)
     {
-#if GTK_CHECK_VERSION (3, 22, 0)
-        GdkRectangle geometry;
-        GdkMonitor  *monitor;
-        GdkDisplay  *display;
-        int n = 0;
-        int i = 0;
-        int sc_width = 0;
-        int sc_height = 0;
-
-        display = gtk_widget_get_display (self->details->widget);
-        n = gdk_display_get_n_monitors (display);
-
-        for (i = 0; i < n; ++i)
-        {
-            monitor = gdk_display_get_monitor (display, i);
-            gdk_monitor_get_geometry (monitor, &geometry);
-            sc_width = sc_width + geometry.width;
-            sc_height = sc_height + geometry.height;
-        }
-
-        *width = sc_width;
-        *height = sc_height;
-#else
         GdkScreen *screen = gtk_widget_get_screen (self->details->widget);
-        *width = gdk_screen_get_width (screen);
-        *height = gdk_screen_get_height (screen);
-#endif
+        *width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+        *height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
     }
     else
     {

--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -36,6 +36,7 @@
 #include <pango/pango.h>
 #include <gtk/gtk.h>
 #include <gtk/gtk-a11y.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 
 
@@ -1051,7 +1052,6 @@ eel_editable_label_ensure_layout (EelEditableLabel *label,
             else
             {
                 gint wrap_width;
-                gint sc_width;
 
                 pango_layout_set_width (label->layout, -1);
                 pango_layout_get_extents (label->layout, NULL, &logical_rect);
@@ -1061,13 +1061,10 @@ eel_editable_label_ensure_layout (EelEditableLabel *label,
                 /* Try to guess a reasonable maximum width */
                 longest_paragraph = width;
 
-                gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                                         NULL, NULL, &sc_width, NULL);
-
                 wrap_width = get_label_wrap_width (label);
                 width = MIN (width, wrap_width);
                 width = MIN (width,
-                             PANGO_SCALE * (sc_width + 1) / 2);
+                             PANGO_SCALE * (WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) + 1) / 2);
 
                 pango_layout_set_width (label->layout, width);
                 pango_layout_get_extents (label->layout, NULL, &logical_rect);
@@ -3051,7 +3048,6 @@ popup_position_func (GtkMenu   *menu,
     GtkWidget *widget;
     GtkRequisition req;
     GtkAllocation allocation;
-    gint sc_width, sc_height;
 
     label = EEL_EDITABLE_LABEL (user_data);
     widget = GTK_WIDGET (label);
@@ -3066,11 +3062,8 @@ popup_position_func (GtkMenu   *menu,
     *x += allocation.width / 2;
     *y += allocation.height;
 
-    gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                             NULL, NULL, &sc_width, &sc_height);
-
-    *x = CLAMP (*x, 0, MAX (0, sc_width - req.width));
-    *y = CLAMP (*y, 0, MAX (0, sc_height - req.height));
+    *x = CLAMP (*x, 0, MAX (0, WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - req.width));
+    *y = CLAMP (*y, 0, MAX (0, HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - req.height));
 }
 
 static void

--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -86,11 +86,6 @@ eel_gtk_window_get_geometry_string (GtkWindow *window)
 static void
 sanity_check_window_position (int *left, int *top)
 {
-    gint sc_width, sc_height;
-
-    gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                             NULL, NULL, &sc_width, &sc_height);
-
     g_assert (left != NULL);
     g_assert (top != NULL);
 
@@ -100,7 +95,7 @@ sanity_check_window_position (int *left, int *top)
      * isn't off the bottom of the screen, or so close to the bottom
      * that it might be obscured by the panel.
      */
-    *top = CLAMP (*top, 0, sc_height - MINIMUM_ON_SCREEN_HEIGHT);
+    *top = CLAMP (*top, 0, HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - MINIMUM_ON_SCREEN_HEIGHT);
 
     /* FIXME bugzilla.eazel.com 669:
      * If window has negative left coordinate, set_uposition sends it
@@ -113,17 +108,12 @@ sanity_check_window_position (int *left, int *top)
      * the screen, or so close to the right edge that it might be
      * obscured by the panel.
      */
-    *left = CLAMP (*left, 0, sc_width - MINIMUM_ON_SCREEN_WIDTH);
+    *left = CLAMP (*left, 0, WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - MINIMUM_ON_SCREEN_WIDTH);
 }
 
 static void
 sanity_check_window_dimensions (guint *width, guint *height)
 {
-    gint sc_width, sc_height;
-
-    gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                             NULL, NULL, &sc_width, &sc_height);
-
     g_assert (width != NULL);
     g_assert (height != NULL);
 
@@ -132,8 +122,8 @@ sanity_check_window_dimensions (guint *width, guint *height)
      * be reached (might not be necessary with all window managers,
      * but seems reasonable anyway).
      */
-    *width = MIN (*width, sc_width);
-    *height = MIN (*height, sc_height);
+    *width = MIN (*width, WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())));
+    *height = MIN (*height, HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())));
 }
 
 /**
@@ -178,9 +168,8 @@ eel_gtk_window_set_initial_geometry (GtkWindow *window,
         real_top = top;
 
         screen = gtk_window_get_screen (window);
-
-        gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                                 &screen_width, &screen_height);
+        screen_width  = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+        screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
         /* This is sub-optimal. GDK doesn't allow us to set win_gravity
          * to South/East types, which should be done if using negative

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -326,7 +326,6 @@ icon_set_position (CajaIcon *icon,
     int item_width, item_height;
     int height_above, width_left;
     int min_x, max_x, min_y, max_y;
-    int sc_width, sc_height;
 
     if (icon->x == x && icon->y == y)
     {
@@ -355,16 +354,12 @@ icon_set_position (CajaIcon *icon,
 
         For now, we have a cheesy workaround:
         */
-
-        gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                                 NULL, NULL, &sc_width, &sc_height);
-
         container_x = 0;
         container_y = 0;
-        container_width = sc_width - container_x
+        container_width = WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - container_x
                           - container->details->left_margin
                           - container->details->right_margin;
-        container_height = sc_height - container_y
+        container_height = HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - container_y
                            - container->details->top_margin
                            - container->details->bottom_margin;
         pixels_per_unit = EEL_CANVAS (container)->pixels_per_unit;
@@ -5290,7 +5285,6 @@ caja_icon_container_search_position_func (CajaIconContainer *container,
     gint x, y;
     gint cont_x, cont_y;
     gint cont_width, cont_height;
-    gint sc_width, sc_height;
     GdkWindow *cont_window;
     GdkScreen *screen;
     GtkRequisition requisition;
@@ -5321,14 +5315,11 @@ caja_icon_container_search_position_func (CajaIconContainer *container,
     cont_width = gdk_window_get_width (cont_window);
     cont_height = gdk_window_get_height (cont_window);
 
-    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                             &sc_width, &sc_height);
-
     gtk_widget_get_preferred_size (search_dialog, &requisition, NULL);
 
-    if (cont_x + cont_width - requisition.width > sc_width)
+    if (cont_x + cont_width - requisition.width > WidthOfScreen (gdk_x11_screen_get_xscreen (screen)))
     {
-        x = sc_width - requisition.width;
+        x = WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) - requisition.width;
     }
     else if (cont_x + cont_width - requisition.width < 0)
     {
@@ -5339,9 +5330,9 @@ caja_icon_container_search_position_func (CajaIconContainer *container,
         x = cont_x + cont_width - requisition.width;
     }
 
-    if (cont_y + cont_height > sc_height)
+    if (cont_y + cont_height > HeightOfScreen (gdk_x11_screen_get_xscreen (screen)))
     {
-        y = sc_height - requisition.height;
+        y = HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) - requisition.height;
     }
     else if (cont_y + cont_height < 0)     /* isn't really possible ... */
     {
@@ -6087,7 +6078,6 @@ key_press_event (GtkWidget *widget,
         const char *new_text;
         gboolean retval;
         GdkScreen *screen;
-        gint sc_width, sc_height;
         gboolean text_modified;
         gulong popup_menu_id;
 
@@ -6105,13 +6095,9 @@ key_press_event (GtkWidget *widget,
 
         /* Move the entry off screen */
         screen = gtk_widget_get_screen (GTK_WIDGET (container));
-
-        gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                                 &sc_width, &sc_height);
-
         gtk_window_move (GTK_WINDOW (container->details->search_window),
-                         sc_width + 1,
-                         sc_height + 1);
+                         WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) + 1,
+                         HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) + 1);
         gtk_widget_show (container->details->search_window);
 
         /* Send the event to the window.  If the preedit_changed signal is emitted

--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -115,8 +115,8 @@ caja_desktop_window_screen_size_changed (GdkScreen             *screen,
 {
     int width_request, height_request;
 
-    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                             &width_request, &height_request);
+    width_request = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+    height_request = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
     g_object_set (window,
                   "width_request", width_request,
@@ -131,8 +131,8 @@ caja_desktop_window_new (CajaApplication *application,
     CajaDesktopWindow *window;
     int width_request, height_request;
 
-    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                             &width_request, &height_request);
+    width_request = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+    height_request = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
     window = CAJA_DESKTOP_WINDOW
              (gtk_widget_new (caja_desktop_window_get_type(),

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -516,12 +516,7 @@ caja_window_zoom_to_default (CajaWindow *window)
 static guint
 get_max_forced_height (GdkScreen *screen)
 {
-    gint height;
-
-    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                             NULL, &height);
-
-    return (height * 90) / 100;
+    return (HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) * 90) / 100;
 }
 
 /* Code should never force the window wider than this size.
@@ -530,12 +525,7 @@ get_max_forced_height (GdkScreen *screen)
 static guint
 get_max_forced_width (GdkScreen *screen)
 {
-    gint width;
-
-    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                             &width, NULL);
-
-    return (width * 90) / 100;
+    return (WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) * 90) / 100;
 }
 
 /* This must be called when construction of CajaWindow is finished,

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -119,8 +119,8 @@ icon_container_set_workarea (CajaIconContainer *icon_container,
 
     left = right = top = bottom = 0;
 
-    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                             &screen_width, &screen_height);
+    screen_width  = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+    screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
     for (i = 0; i < n_items; i += 4)
     {
@@ -442,10 +442,8 @@ realized_callback (GtkWidget *widget, FMDesktopIconView *desktop_icon_view)
      */
     allocation.x = 0;
     allocation.y = 0;
-
-    gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                             &allocation.width, &allocation.height);
-
+    allocation.width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+    allocation.height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
     gtk_widget_size_allocate (GTK_WIDGET(get_icon_container(desktop_icon_view)),
                               &allocation);
 


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/caja/commit/4c130e22b98bbc1a85747adac3b582e45d34514e
https://github.com/mate-desktop/caja/commit/ac12e6d16f4a51b3327d013781e72cfec17f3624
https://github.com/mate-desktop/caja/commit/17b3c0ca924ffcd4bd06fded98227eba626d4f0b
https://github.com/mate-desktop/caja/commit/42c8d2c3373c25d6e321be6950997c0d7ce44279

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height

gdk_screen_width
gdk_screen_height

In the tests, make sure you can't reproduce the issues: https://github.com/mate-desktop/caja/pull/824#issuecomment-323568583 and https://github.com/mate-desktop/caja/issues/836