### PR TITLE
Fix refusal to unmount when sidebar is wide

### DIFF
--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -265,6 +265,7 @@ get_eject_icon (CajaPlacesSidebar *sidebar,
         icon_set = gtk_style_context_lookup_icon_set (style, GTK_STOCK_MISSING_IMAGE);
         eject = gtk_icon_set_render_icon_pixbuf (icon_set, style, GTK_ICON_SIZE_MENU);
     }
+        g_object_unref (icon);
         gtk_icon_info_free (icon_info);
 
     return eject;

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -232,16 +232,26 @@ G_DEFINE_TYPE_WITH_CODE (CajaPlacesSidebarProvider, caja_places_sidebar_provider
                                  sidebar_provider_iface_init));
 
 static GdkPixbuf *
-get_eject_icon (gboolean highlighted)
+get_eject_icon (CajaPlacesSidebar *sidebar,
+                gboolean highlighted)
 {
     GdkPixbuf *eject;
-    CajaIconInfo *eject_icon_info;
+    GtkIconInfo *icon_info;
+    GIcon *icon;
     int icon_size;
+    GtkIconTheme *icon_theme;
+    GtkStyleContext *style;
 
-    icon_size = caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU);
+    icon_theme = gtk_icon_theme_get_default ();
+    icon_size = caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_SMALL_TOOLBAR);
+    icon = g_themed_icon_new_with_default_fallbacks ("media-eject-symbolic");
+    icon_info = gtk_icon_theme_lookup_by_gicon (icon_theme, icon, icon_size, 0);
 
-    eject_icon_info = caja_icon_info_lookup_from_name ("media-eject", icon_size);
-    eject = caja_icon_info_get_pixbuf_at_size (eject_icon_info, icon_size);
+    style = gtk_widget_get_style_context (GTK_WIDGET (sidebar));
+    eject = gtk_icon_info_load_symbolic_for_context (icon_info,
+                                                     style,
+                                                     NULL,
+                                                     NULL);
 
     if (highlighted) {
         GdkPixbuf *high;
@@ -250,7 +260,8 @@ get_eject_icon (gboolean highlighted)
         eject = high;
     }
 
-    g_object_unref (eject_icon_info);
+    g_object_unref (icon);
+    gtk_icon_info_free (icon_info);
 
     return eject;
 }
@@ -375,7 +386,7 @@ add_place (CajaPlacesSidebar *sidebar,
     }
 
     if (show_eject_button) {
-        eject = get_eject_icon (FALSE);
+        eject = get_eject_icon (sidebar, FALSE);
     } else {
         eject = NULL;
     }
@@ -1022,6 +1033,9 @@ over_eject_button (CajaPlacesSidebar *sidebar,
         eject_button_size = caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU);
 
         if (x - total_width >= 0 &&
+            /* fix unwanted unmount requests if clicking on the label */
+            x >= total_width - eject_button_size &&
+            x >= 80 &&
             x - total_width <= eject_button_size) {
             return TRUE;
         }
@@ -2897,7 +2911,7 @@ update_eject_buttons (CajaPlacesSidebar *sidebar,
 
             gtk_list_store_set (sidebar->store,
                         &iter,
-                        PLACES_SIDEBAR_COLUMN_EJECT_ICON, get_eject_icon (FALSE),
+                        PLACES_SIDEBAR_COLUMN_EJECT_ICON, get_eject_icon (sidebar, FALSE),
                         -1);
             gtk_tree_model_filter_refilter (GTK_TREE_MODEL_FILTER (sidebar->filter_model));
 
@@ -2919,7 +2933,7 @@ update_eject_buttons (CajaPlacesSidebar *sidebar,
                      path);
         gtk_list_store_set (sidebar->store,
                     &iter,
-                    PLACES_SIDEBAR_COLUMN_EJECT_ICON, get_eject_icon (TRUE),
+                    PLACES_SIDEBAR_COLUMN_EJECT_ICON, get_eject_icon (sidebar, TRUE),
                     -1);
         gtk_tree_model_filter_refilter (GTK_TREE_MODEL_FILTER (sidebar->filter_model));
 

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -1022,15 +1022,9 @@ over_eject_button (CajaPlacesSidebar *sidebar,
         eject_button_size = caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU);
 
         if (x - total_width >= 0 &&
-            /* fix unwanted unmount requests if clicking on the label */
-            x >= total_width - eject_button_size &&
-            x >= 80 &&
             x - total_width <= eject_button_size) {
             return TRUE;
         }
-        /* Fix refusal to unmount when sidebar is wide enough to expand the eject column */
-        if (x >= 180)
-        return TRUE;
     }
 
 out:
@@ -3240,9 +3234,6 @@ caja_places_sidebar_init (CajaPlacesSidebar *sidebar)
                   "mode", GTK_CELL_RENDERER_MODE_ACTIVATABLE,
                   "stock-size", GTK_ICON_SIZE_MENU,
                   "xpad", EJECT_BUTTON_XPAD,
-                  /* align right, because for some reason gtk+ expands
-                  this even though we tell it not to. */
-                  "xalign", 1.0,
                   NULL);
     gtk_tree_view_column_pack_start (col, cell, FALSE);
     gtk_tree_view_column_set_attributes (col, cell,

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -53,7 +53,7 @@
 #include "caja-bookmark-list.h"
 #include "caja-places-sidebar.h"
 #include "caja-window.h"
-#define EJECT_BUTTON_XPAD 6
+#define EJECT_BUTTON_XPAD 10
 #define ICON_CELL_XPAD 6
 
 typedef struct
@@ -3163,7 +3163,9 @@ caja_places_sidebar_init (CajaPlacesSidebar *sidebar)
     gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
     gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
     gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (sidebar), GTK_SHADOW_IN);
-
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling(GTK_SCROLLED_WINDOW (sidebar), FALSE);
+#endif
     /* tree view */
     tree_view = GTK_TREE_VIEW (gtk_tree_view_new ());
     gtk_tree_view_set_headers_visible (tree_view, FALSE);

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -241,7 +241,7 @@ get_eject_icon (CajaPlacesSidebar *sidebar,
 
     icon_theme = gtk_icon_theme_get_default ();
     icon_size = caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_SMALL_TOOLBAR);
-    icon = g_themed_icon_new_with_default_fallbacks ("media-eject-symbolic");
+    icon = g_themed_icon_new_with_default_fallbacks ("media-eject");
     icon_info = gtk_icon_theme_lookup_by_gicon (icon_theme, icon, icon_size, 0);
 
     style = gtk_widget_get_style_context (GTK_WIDGET (sidebar));

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -245,20 +245,27 @@ get_eject_icon (CajaPlacesSidebar *sidebar,
     icon_info = gtk_icon_theme_lookup_by_gicon (icon_theme, icon, icon_size, 0);
 
     style = gtk_widget_get_style_context (GTK_WIDGET (sidebar));
-    eject = gtk_icon_info_load_symbolic_for_context (icon_info,
-                                                     style,
-                                                     NULL,
-                                                     NULL);
 
-    if (highlighted) {
-        GdkPixbuf *high;
-        high = eel_create_spotlight_pixbuf (eject);
-        g_object_unref (eject);
-        eject = high;
+    if (icon_info != NULL) {
+        eject = gtk_icon_info_load_symbolic_for_context (icon_info,
+                                                         style,
+                                                         NULL,
+                                                         NULL);
+
+        if (highlighted) {
+            GdkPixbuf *high;
+            high = eel_create_spotlight_pixbuf (eject);
+            g_object_unref (eject);
+            eject = high;
+        }
+
+    } else {
+        GtkIconSet *icon_set;
+        gtk_style_context_set_state (style, GTK_STATE_FLAG_NORMAL);
+        icon_set = gtk_style_context_lookup_icon_set (style, GTK_STOCK_MISSING_IMAGE);
+        eject = gtk_icon_set_render_icon_pixbuf (icon_set, style, GTK_ICON_SIZE_MENU);
     }
-
-    g_object_unref (icon);
-    gtk_icon_info_free (icon_info);
+        gtk_icon_info_free (icon_info);
 
     return eject;
 }

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -60,10 +60,7 @@ typedef struct
 {
     GtkScrolledWindow  parent;
     GtkTreeView        *tree_view;
-    GtkCellRenderer    *eject_text_cell_renderer;
-    GtkCellRenderer    *icon_cell_renderer;
-    GtkCellRenderer    *icon_padding_cell_renderer;
-    GtkCellRenderer    *padding_cell_renderer;
+    GtkCellRenderer    *eject_icon_cell_renderer;
     char               *uri;
     GtkListStore       *store;
     GtkTreeModel       *filter_model;
@@ -975,8 +972,7 @@ over_eject_button (CajaPlacesSidebar *sidebar,
                    GtkTreePath **path)
 {
     GtkTreeViewColumn *column;
-    GtkTextDirection direction;
-    int width, total_width;
+    int width, x_offset, hseparator;
     int eject_button_size;
     gboolean show_eject;
     GtkTreeIter iter;
@@ -998,45 +994,26 @@ over_eject_button (CajaPlacesSidebar *sidebar,
             goto out;
         }
 
-        total_width = 0;
-
         gtk_widget_style_get (GTK_WIDGET (sidebar->tree_view),
-                              "horizontal-separator", &width,
+                              "horizontal-separator",&hseparator,
                               NULL);
-        total_width += width;
+        /* Reload cell attributes for this particular row */
+        gtk_tree_view_column_cell_set_cell_data (column,
+                                                 model, &iter, FALSE, FALSE);
 
-        direction = gtk_widget_get_direction (GTK_WIDGET (sidebar->tree_view));
-        if (direction != GTK_TEXT_DIR_RTL) {
-            gtk_tree_view_column_cell_get_position (column,
-                                                    sidebar->padding_cell_renderer,
-                                                    NULL, &width);
-            total_width += width;
-
-            gtk_tree_view_column_cell_get_position (column,
-                                                    sidebar->icon_padding_cell_renderer,
-                                                    NULL, &width);
-            total_width += width;
-            
-            gtk_tree_view_column_cell_get_position (column,
-                                                    sidebar->icon_cell_renderer,
-                                                    NULL, &width);
-            total_width += width;
-
-            gtk_tree_view_column_cell_get_position (column,
-                                                    sidebar->eject_text_cell_renderer,
-                                                    NULL, &width);
-            total_width += width;
-        }
-
-        total_width += EJECT_BUTTON_XPAD;
+        gtk_tree_view_column_cell_get_position (column,
+                                                sidebar->eject_icon_cell_renderer,
+                                                &x_offset, &width);
 
         eject_button_size = caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU);
 
-        if (x - total_width >= 0 &&
-            /* fix unwanted unmount requests if clicking on the label */
-            x >= total_width - eject_button_size &&
-            x >= 80 &&
-            x - total_width <= eject_button_size) {
+       /* This is kinda weird, but we have to do it to workaround gtk+ expanding
+       * the eject cell renderer (even thought we told it not to) and we then
+       * had to set it right-aligned */
+        x_offset += width - hseparator - EJECT_BUTTON_XPAD - eject_button_size;
+
+        if (x - x_offset >= 0 &&
+        x - x_offset <= eject_button_size) {
             return TRUE;
         }
     }
@@ -3188,7 +3165,6 @@ caja_places_sidebar_init (CajaPlacesSidebar *sidebar)
 
     /* initial padding */
     cell = gtk_cell_renderer_text_new ();
-    sidebar->padding_cell_renderer = cell;
     gtk_tree_view_column_pack_start (col, cell, FALSE);
     g_object_set (cell,
                   "xpad", 6,
@@ -3212,7 +3188,6 @@ caja_places_sidebar_init (CajaPlacesSidebar *sidebar)
 
     /* icon padding */
     cell = gtk_cell_renderer_text_new ();
-    sidebar->icon_padding_cell_renderer = cell;
     gtk_tree_view_column_pack_start (col, cell, FALSE);
     gtk_tree_view_column_set_cell_data_func (col, cell,
                                              padding_cell_renderer_func,
@@ -3220,7 +3195,6 @@ caja_places_sidebar_init (CajaPlacesSidebar *sidebar)
 
     /* icon renderer */
     cell = gtk_cell_renderer_pixbuf_new ();
-    sidebar->icon_cell_renderer = cell;
     gtk_tree_view_column_pack_start (col, cell, FALSE);
     gtk_tree_view_column_set_attributes (col, cell,
                                          "pixbuf", PLACES_SIDEBAR_COLUMN_ICON,
@@ -3231,7 +3205,6 @@ caja_places_sidebar_init (CajaPlacesSidebar *sidebar)
 
     /* eject text renderer */
     cell = gtk_cell_renderer_text_new ();
-    sidebar->eject_text_cell_renderer = cell;
     gtk_tree_view_column_pack_start (col, cell, TRUE);
     gtk_tree_view_column_set_attributes (col, cell,
                                          "text", PLACES_SIDEBAR_COLUMN_NAME,
@@ -3244,10 +3217,14 @@ caja_places_sidebar_init (CajaPlacesSidebar *sidebar)
 
     /* eject icon renderer */
     cell = gtk_cell_renderer_pixbuf_new ();
+    sidebar->eject_icon_cell_renderer = cell;
     g_object_set (cell,
                   "mode", GTK_CELL_RENDERER_MODE_ACTIVATABLE,
                   "stock-size", GTK_ICON_SIZE_MENU,
                   "xpad", EJECT_BUTTON_XPAD,
+                  /* align right, because for some reason gtk+ expands
+                  this even though we tell it not to. */
+                  "xalign", 1.0,
                   NULL);
     gtk_tree_view_column_pack_start (col, cell, FALSE);
     gtk_tree_view_column_set_attributes (col, cell,

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -1028,6 +1028,9 @@ over_eject_button (CajaPlacesSidebar *sidebar,
             x - total_width <= eject_button_size) {
             return TRUE;
         }
+        /* Fix refusal to unmount when sidebar is wide enough to expand the eject column */
+        if (x >= 180)
+        return TRUE;
     }
 
 out:

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -240,7 +240,7 @@ get_eject_icon (CajaPlacesSidebar *sidebar,
     GtkStyleContext *style;
 
     icon_theme = gtk_icon_theme_get_default ();
-    icon_size = caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_SMALL_TOOLBAR);
+    icon_size = caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU);
     icon = g_themed_icon_new_with_default_fallbacks ("media-eject");
     icon_info = gtk_icon_theme_lookup_by_gicon (icon_theme, icon, icon_size, 0);
 

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -233,40 +233,27 @@ get_eject_icon (CajaPlacesSidebar *sidebar,
                 gboolean highlighted)
 {
     GdkPixbuf *eject;
-    GtkIconInfo *icon_info;
-    GIcon *icon;
+    CajaIconInfo *icon_info;
     int icon_size;
     GtkIconTheme *icon_theme;
     GtkStyleContext *style;
 
     icon_theme = gtk_icon_theme_get_default ();
     icon_size = caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU);
-    icon = g_themed_icon_new_with_default_fallbacks ("media-eject");
-    icon_info = gtk_icon_theme_lookup_by_gicon (icon_theme, icon, icon_size, 0);
+    icon_info = caja_icon_info_lookup_from_name ("media-eject", icon_size);
 
     style = gtk_widget_get_style_context (GTK_WIDGET (sidebar));
 
-    if (icon_info != NULL) {
-        eject = gtk_icon_info_load_symbolic_for_context (icon_info,
-                                                         style,
-                                                         NULL,
-                                                         NULL);
+    eject = caja_icon_info_get_pixbuf_at_size (icon_info, icon_size);
 
-        if (highlighted) {
-            GdkPixbuf *high;
-            high = eel_create_spotlight_pixbuf (eject);
-            g_object_unref (eject);
-            eject = high;
+    if (highlighted) {
+        GdkPixbuf *high;
+        high = eel_create_spotlight_pixbuf (eject);
+        g_object_unref (eject);
+        eject = high;
         }
 
-    } else {
-        GtkIconSet *icon_set;
-        gtk_style_context_set_state (style, GTK_STATE_FLAG_NORMAL);
-        icon_set = gtk_style_context_lookup_icon_set (style, GTK_STOCK_MISSING_IMAGE);
-        eject = gtk_icon_set_render_icon_pixbuf (icon_set, style, GTK_ICON_SIZE_MENU);
-    }
-        g_object_unref (icon);
-        gtk_icon_info_free (icon_info);
+    g_object_unref (icon_info);
 
     return eject;
 }

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -3240,6 +3240,9 @@ caja_places_sidebar_init (CajaPlacesSidebar *sidebar)
                   "mode", GTK_CELL_RENDERER_MODE_ACTIVATABLE,
                   "stock-size", GTK_ICON_SIZE_MENU,
                   "xpad", EJECT_BUTTON_XPAD,
+                  /* align right, because for some reason gtk+ expands
+                  this even though we tell it not to. */
+                  "xalign", 1.0,
                   NULL);
     gtk_tree_view_column_pack_start (col, cell, FALSE);
     gtk_tree_view_column_set_attributes (col, cell,


### PR DESCRIPTION
Fix refusal to unmount volumes from the sidebar when the sidebar is wide enough to expand the eject column.
Fixes https://github.com/mate-desktop/caja/issues/880