### PR TITLE
Fix eject notifications

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -2135,7 +2135,10 @@ unmount_mount_callback (GObject *source_object,
 	if (data->eject) {
 		unmounted = g_mount_eject_with_operation_finish (G_MOUNT (source_object),
 								 res, &error);
-                caja_application_notify_unmount_show ("It is now safe to remove the drive");
+		if ((!error) || (unmounted == TRUE)){
+			caja_application_notify_unmount_show ("It is now safe to remove the drive");
+		}
+
 	} else {
 		unmounted = g_mount_unmount_with_operation_finish (G_MOUNT (source_object),
 								   res, &error);

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -2197,9 +2197,6 @@ drive_eject_cb (GObject *source_object,
         }
         g_error_free (error);
     }
-    else {
-        caja_application_notify_unmount_show ("It is now safe to remove the drive");
-    }
 }
 
 static void


### PR DESCRIPTION
Prevent "it is now safe to remove the drive" notification from being shown if unmounting fails or is cancelled by the user(e.g when the drive is busy). Also remove function in src/caja-places-sidebar.c for sending the notification as the same function in libcaja-private/caja-file-operations.c already sends it.