### PR TITLE
ui: don't use overlay-scrollbars

### DIFF
--- a/eel/eel-wrap-table.c
+++ b/eel/eel-wrap-table.c
@@ -1101,6 +1101,9 @@ eel_scrolled_wrap_table_new (gboolean homogeneous,
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolled_window),
                                     GTK_POLICY_NEVER,
                                     GTK_POLICY_AUTOMATIC);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (scrolled_window), FALSE);
+#endif
 
     viewport = gtk_viewport_new (gtk_scrolled_window_get_hadjustment (GTK_SCROLLED_WINDOW (scrolled_window)),
                                  gtk_scrolled_window_get_vadjustment (GTK_SCROLLED_WINDOW (scrolled_window)));

--- a/libcaja-private/caja-column-chooser.c
+++ b/libcaja-private/caja-column-chooser.c
@@ -280,6 +280,9 @@ add_tree_view (CajaColumnChooser *chooser)
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolled),
                                     GTK_POLICY_AUTOMATIC,
                                     GTK_POLICY_AUTOMATIC);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (scrolled), FALSE);
+#endif
     gtk_widget_show (GTK_WIDGET (scrolled));
 
     gtk_container_add (GTK_CONTAINER (scrolled), view);

--- a/libcaja-private/caja-mime-application-chooser.c
+++ b/libcaja-private/caja-mime-application-chooser.c
@@ -404,6 +404,9 @@ caja_mime_application_chooser_init (CajaMimeApplicationChooser *chooser)
                                     GTK_POLICY_AUTOMATIC);
     gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (scrolled),
                                          GTK_SHADOW_IN);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (scrolled), FALSE);
+#endif
 
     gtk_widget_show (scrolled);
     gtk_box_pack_start (GTK_BOX (chooser), scrolled, TRUE, TRUE, 6);

--- a/libcaja-private/caja-open-with-dialog.c
+++ b/libcaja-private/caja-open-with-dialog.c
@@ -870,6 +870,9 @@ caja_open_with_dialog_init (CajaOpenWithDialog *dialog)
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolled_window),
                                     GTK_POLICY_AUTOMATIC,
                                     GTK_POLICY_AUTOMATIC);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (scrolled_window), FALSE);
+#endif
     dialog->details->program_list = gtk_tree_view_new ();
     gtk_tree_view_set_headers_visible (GTK_TREE_VIEW (dialog->details->program_list),
                                        FALSE);

--- a/src/caja-history-sidebar.c
+++ b/src/caja-history-sidebar.c
@@ -275,6 +275,9 @@ caja_history_sidebar_init (CajaHistorySidebar *sidebar)
     gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
     gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
     gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (sidebar), GTK_SHADOW_IN);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (sidebar), FALSE);
+#endif
     gtk_container_add (GTK_CONTAINER (sidebar), GTK_WIDGET (tree_view));
     gtk_widget_show (GTK_WIDGET (sidebar));
 

--- a/src/caja-notes-viewer.c
+++ b/src/caja-notes-viewer.c
@@ -347,6 +347,9 @@ caja_notes_viewer_init (CajaNotesViewer *sidebar)
                                          GTK_SHADOW_IN);
     gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
     gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (sidebar), NULL);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (sidebar), FALSE);
+#endif
     gtk_container_add (GTK_CONTAINER (sidebar), details->note_text_field);
 
     g_signal_connect (details->note_text_field, "focus_out_event",

--- a/src/caja-property-browser.c
+++ b/src/caja-property-browser.c
@@ -326,6 +326,10 @@ caja_property_browser_init (CajaPropertyBrowser *property_browser)
     gtk_widget_show (property_browser->details->category_container);
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (property_browser->details->category_container),
                                     GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (property_browser->details->category_container),
+                                               FALSE);
+#endif
 
     /* allocate a table to hold the category selector */
     property_browser->details->category_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
@@ -2204,6 +2208,10 @@ caja_property_browser_update_contents (CajaPropertyBrowser *property_browser)
     gtk_widget_show (property_browser->details->content_frame);
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (property_browser->details->content_frame),
                                     GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (property_browser->details->content_frame),
+                                               FALSE);
+#endif
 
     /* allocate a table to hold the content widgets */
     property_browser->details->content_table = eel_image_table_new (TRUE);

--- a/src/caja-query-editor.c
+++ b/src/caja-query-editor.c
@@ -723,6 +723,10 @@ type_combo_changed (GtkComboBox *combo_box, CajaQueryEditorRow *row)
                                         GTK_POLICY_AUTOMATIC);
         gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (scrolled),
                                              GTK_SHADOW_IN);
+#if GTK_CHECK_VERSION (3, 16, 0)
+        gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (scrolled),
+                                                   FALSE);
+#endif
 
         gtk_widget_show (scrolled);
         gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dialog))), scrolled, TRUE, TRUE, 6);

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -637,6 +637,9 @@ fm_desktop_icon_view_init (FMDesktopIconView *desktop_icon_view)
 
     gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (desktop_icon_view),
                                          GTK_SHADOW_NONE);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (desktop_icon_view), FALSE);
+#endif
 
     fm_directory_view_ignore_hidden_file_preferences
     (FM_DIRECTORY_VIEW (desktop_icon_view));

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -2006,6 +2006,9 @@ fm_directory_view_init (FMDirectoryView *view)
 	gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (view), NULL);
 	gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (view), NULL);
 	gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (view), GTK_SHADOW_ETCHED_IN);
+#if GTK_CHECK_VERSION (3, 16, 0)
+	gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (view), FALSE);
+#endif
 
 	set_up_scripts_directory_global ();
 	scripts_directory = caja_directory_get_by_uri (scripts_directory_uri);

--- a/src/file-manager/fm-tree-view.c
+++ b/src/file-manager/fm-tree-view.c
@@ -1591,6 +1591,9 @@ fm_tree_view_init (FMTreeView *view)
     gtk_scrolled_window_set_hadjustment (GTK_SCROLLED_WINDOW (view), NULL);
     gtk_scrolled_window_set_vadjustment (GTK_SCROLLED_WINDOW (view), NULL);
     gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (view), GTK_SHADOW_IN);
+#if GTK_CHECK_VERSION (3, 16, 0)
+    gtk_scrolled_window_set_overlay_scrolling (GTK_SCROLLED_WINDOW (view), FALSE);
+#endif
 
     gtk_widget_show (GTK_WIDGET (view));
 


### PR DESCRIPTION
Make it consistent with behaviour for caja-places-sidebar.

You need to run caja as super user to see the scrollbars again.