### PR TITLE
fix bug: the search_dispose and search_finilize can't be run after search finished. Closes #895

### DIFF
--- a/libcaja-private/caja-bookmark.c
+++ b/libcaja-private/caja-bookmark.c
@@ -572,7 +572,6 @@ caja_bookmark_new (GFile *location, const char *name, gboolean has_custom_name,
     CajaBookmark *new_bookmark;
 
     new_bookmark = CAJA_BOOKMARK (g_object_new (CAJA_TYPE_BOOKMARK, NULL));
-    g_object_ref_sink (new_bookmark);
 
     new_bookmark->details->name = g_strdup (name);
     new_bookmark->details->location = g_object_ref (location);


### PR DESCRIPTION
there is g_object_ref_sink in caja_bookmark_new of caja-bookmark.c , so The caja_bookmark_finilize will not be run to free object resources. because there is CajaSearchDirectory  reference in CajaFile of CajaBookmark, so the search_dispose , search_finalize will be not called to run.  