### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: c
+sudo: required
+services:
+  - docker
+script:
+  - docker run -v$PWD:/w -it fedora:27 /bin/sh -c "cd w && dnf install -y mate-common gobject-introspection-devel mate-desktop-devel libxml2-devel libnotify-devel redhat-rpm-config libSM-devel -yq && ./autogen.sh && make"


### PR DESCRIPTION
This will build Caja on Fedora 27.

Output would look like this: https://travis-ci.org/jhasse/caja/builds/330877194

The repository would need to be activated here: https://travis-ci.org/mate-desktop