### PR TITLE
fix backgrounds and emblems dialog content rendering

### DIFF
--- a/eel/eel-wrap-table.c
+++ b/eel/eel-wrap-table.c
@@ -53,6 +53,7 @@ struct EelWrapTableDetails
 
     guint is_scrolled : 1;
     guint cols;
+    gboolean drawn;
 };
 
 /* Private EelWrapTable methods */
@@ -252,6 +253,11 @@ eel_wrap_table_draw (GtkWidget *widget,
                                       cr);
     }
 
+    /*Redraw the table once and only once to ensure it is displayed */
+    if (wrap_table->details->drawn == FALSE){
+        gtk_widget_queue_allocate (GTK_WIDGET(widget));
+        wrap_table->details->drawn = TRUE;
+        }
     return FALSE;
 }
 
@@ -797,6 +803,8 @@ eel_wrap_table_new (gboolean homogeneous)
     wrap_table = EEL_WRAP_TABLE (gtk_widget_new (eel_wrap_table_get_type (), NULL));
 
     eel_wrap_table_set_homogeneous (wrap_table, homogeneous);
+
+    wrap_table->details->drawn = FALSE;
 
     return GTK_WIDGET (wrap_table);
 }


### PR DESCRIPTION
Fix https://github.com/mate-desktop/caja/issues/506

Note that it still takes a few seconds for new content to show when switching between patterns, colors, and emblems but now they at least appear. Also it was necessary to use gtk_widget_queue_allocate and not gtk_widget_queue_resize to avoid massive amounts of  "Allocating size to<all widgets using eel_wrap_table> without calling gtk_widget_get_preferred_width/height(). How does the code know the size to allocate?" log spam. 