### PR TITLE
can selected all the search keywords with Ctrl+a. #918

### DIFF
--- a/src/caja-navigation-window-pane.c
+++ b/src/caja-navigation-window-pane.c
@@ -784,7 +784,7 @@ caja_navigation_window_pane_setup (CajaNavigationWindowPane *pane)
                         pane->navigation_bar,
                         TRUE, TRUE, 0);
 
-    pane->search_bar = caja_search_bar_new ();
+    pane->search_bar = caja_search_bar_new (CAJA_WINDOW_PANE (pane)->window);
     g_signal_connect_object (pane->search_bar, "activate",
                              G_CALLBACK (search_bar_activate_callback), pane, 0);
     g_signal_connect_object (pane->search_bar, "cancel",

--- a/src/caja-search-bar.c
+++ b/src/caja-search-bar.c
@@ -28,6 +28,7 @@
 #include <eel/eel-gtk-macros.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
+#include <libcaja-private/caja-clipboard.h>
 
 struct CajaSearchBarDetails
 {
@@ -212,11 +213,19 @@ caja_search_bar_return_entry (CajaSearchBar *bar)
 }
 
 GtkWidget *
-caja_search_bar_new (void)
+caja_search_bar_new (CajaWindow *window)
 {
     GtkWidget *bar;
+    CajaSearchBar *search_bar;
 
     bar = g_object_new (CAJA_TYPE_SEARCH_BAR, NULL);
+    search_bar = CAJA_SEARCH_BAR(bar);
+
+    /* Clipboard */
+    caja_clipboard_set_up_editable
+    (GTK_EDITABLE (search_bar->details->entry),
+     caja_window_get_ui_manager (window),
+     TRUE);
 
     return bar;
 }

--- a/src/caja-search-bar.h
+++ b/src/caja-search-bar.h
@@ -26,6 +26,7 @@
 
 #include <gtk/gtk.h>
 #include <libcaja-private/caja-query.h>
+#include "caja-window.h"
 
 #define CAJA_TYPE_SEARCH_BAR caja_search_bar_get_type()
 #define CAJA_SEARCH_BAR(obj) \
@@ -57,7 +58,7 @@ typedef struct
 } CajaSearchBarClass;
 
 GType      caja_search_bar_get_type     	(void);
-GtkWidget* caja_search_bar_new          	(void);
+GtkWidget* caja_search_bar_new          	(CajaWindow *window);
 
 GtkWidget *    caja_search_bar_borrow_entry  (CajaSearchBar *bar);
 void           caja_search_bar_return_entry  (CajaSearchBar *bar);


### PR DESCRIPTION
this commit fixes #918 
When the search entry gets focus, the keywords in the search entry can be selected with Ctrl+a.