### PR TITLE
caja-bookmarks-window.ui: avoid deprecated GtkButton:use-stock

### DIFF
--- a/src/caja-bookmarks-window.ui
+++ b/src/caja-bookmarks-window.ui
@@ -1,360 +1,376 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.2 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">help-browser</property>
+  </object>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-jump</property>
+  </object>
+  <object class="GtkImage" id="image3">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">list-remove</property>
+  </object>
+  <object class="GtkImage" id="image4">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkDialog" id="bookmarks_dialog">
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Edit Bookmarks</property>
-    <property name="type">GTK_WINDOW_TOPLEVEL</property>
-    <property name="window_position">GTK_WIN_POS_CENTER</property>
-    <property name="modal">False</property>
-    <property name="resizable">True</property>
-    <property name="destroy_with_parent">False</property>
+    <property name="window_position">center</property>
+    <property name="type_hint">normal</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
+      <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
-        <property name="homogeneous">False</property>
+        <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
+          <object class="GtkButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="helpbutton1">
+                <property name="label" translatable="yes">_Help</property>
                 <property name="visible">True</property>
-                <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-help</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="image">image1</property>
+                <property name="use_underline">True</property>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="bookmark_jump_button">
+                <property name="label" translatable="yes">_Jump to</property>
                 <property name="visible">True</property>
-                <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-jump-to</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="image">image2</property>
+                <property name="use_underline">True</property>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="bookmark_delete_button">
+                <property name="label" translatable="yes">_Remove</property>
                 <property name="visible">True</property>
-                <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-remove</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="image">image3</property>
+                <property name="use_underline">True</property>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="button2">
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
-                <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-close</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="image">image4</property>
+                <property name="use_underline">True</property>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">GTK_PACK_END</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkHBox" id="hbox1">
-            <property name="border_width">5</property>
             <property name="visible">True</property>
-            <property name="homogeneous">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">5</property>
             <property name="spacing">18</property>
+            <property name="homogeneous">True</property>
             <child>
               <object class="GtkAlignment" id="alignment1">
                 <property name="visible">True</property>
-                <property name="xalign">0.5</property>
-                <property name="yalign">0.5</property>
-                <property name="xscale">1</property>
-                <property name="yscale">1</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkVBox" id="vbox1">
                     <property name="visible">True</property>
-                    <property name="homogeneous">False</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
-                        <property name="label" translatable="yes">&lt;b&gt;_Bookmarks&lt;/b&gt;</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_markup">True</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
+                        <property name="label" translatable="yes">&lt;b&gt;_Bookmarks&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="use_underline">True</property>
                         <property name="mnemonic_widget">bookmark_tree_view</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkHBox" id="hbox4">
                         <property name="visible">True</property>
-                        <property name="homogeneous">False</property>
-                        <property name="spacing">0</property>
+                        <property name="can_focus">False</property>
                         <child>
                           <object class="GtkLabel" id="label4">
                             <property name="visible">True</property>
-                            <property name="label" translatable="no">    </property>
-                            <property name="use_underline">False</property>
-                            <property name="use_markup">False</property>
-                            <property name="justify">GTK_JUSTIFY_LEFT</property>
-                            <property name="wrap">False</property>
-                            <property name="selectable">False</property>
-                            <property name="xalign">0.5</property>
-                            <property name="yalign">0.5</property>
+                            <property name="can_focus">False</property>
                             <property name="xpad">0</property>
                             <property name="ypad">0</property>
+                            <property name="label">    </property>
+                            <property name="xalign">0.5</property>
+                            <property name="yalign">0.5</property>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkScrolledWindow" id="bookmark_list_window">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
-                            <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="shadow_type">GTK_SHADOW_IN</property>
-                            <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                            <property name="hscrollbar_policy">never</property>
+                            <property name="shadow_type">in</property>
                             <child>
                               <object class="GtkTreeView" id="bookmark_tree_view">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="headers_visible">False</property>
-                                <property name="rules_hint">False</property>
                                 <property name="reorderable">True</property>
-                                <property name="enable_search">True</property>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection"/>
+                                </child>
                               </object>
                             </child>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkAlignment" id="alignment2">
                 <property name="visible">True</property>
-                <property name="xalign">0.5</property>
-                <property name="yalign">0.5</property>
-                <property name="xscale">1</property>
-                <property name="yscale">1</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkVBox" id="vbox2">
                     <property name="visible">True</property>
-                    <property name="homogeneous">False</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">18</property>
                     <child>
                       <object class="GtkVBox" id="vbox4">
                         <property name="visible">True</property>
-                        <property name="homogeneous">False</property>
+                        <property name="can_focus">False</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel" id="bookmark_name_label">
                             <property name="visible">True</property>
-                            <property name="label" translatable="yes">&lt;b&gt;_Name&lt;/b&gt;</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_markup">True</property>
-                            <property name="justify">GTK_JUSTIFY_LEFT</property>
-                            <property name="wrap">False</property>
-                            <property name="selectable">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0.5</property>
+                            <property name="can_focus">False</property>
                             <property name="xpad">0</property>
                             <property name="ypad">0</property>
+                            <property name="label" translatable="yes">&lt;b&gt;_Name&lt;/b&gt;</property>
+                            <property name="use_markup">True</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0</property>
+                            <property name="yalign">0.5</property>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkHBox" id="hbox3">
                             <property name="visible">True</property>
-                            <property name="homogeneous">False</property>
-                            <property name="spacing">0</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkLabel" id="label3">
                                 <property name="visible">True</property>
-                                <property name="label" translatable="no">    </property>
-                                <property name="use_underline">False</property>
-                                <property name="use_markup">False</property>
-                                <property name="justify">GTK_JUSTIFY_LEFT</property>
-                                <property name="wrap">False</property>
-                                <property name="selectable">False</property>
-                                <property name="xalign">0.5</property>
-                                <property name="yalign">0.5</property>
+                                <property name="can_focus">False</property>
                                 <property name="xpad">0</property>
                                 <property name="ypad">0</property>
+                                <property name="label">    </property>
+                                <property name="xalign">0.5</property>
+                                <property name="yalign">0.5</property>
                               </object>
                               <packing>
-                                <property name="padding">0</property>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkHBox" id="bookmark_name_placeholder">
                                 <property name="visible">True</property>
-                                <property name="homogeneous">False</property>
-                                <property name="spacing">0</property>
+                                <property name="can_focus">False</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                               </object>
                               <packing>
-                                <property name="padding">0</property>
                                 <property name="expand">True</property>
                                 <property name="fill">True</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkVBox" id="vbox3">
                         <property name="visible">True</property>
-                        <property name="homogeneous">False</property>
+                        <property name="can_focus">False</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel" id="bookmark_location_label">
                             <property name="visible">True</property>
-                            <property name="label" translatable="yes">&lt;b&gt;_Location&lt;/b&gt;</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_markup">True</property>
-                            <property name="justify">GTK_JUSTIFY_LEFT</property>
-                            <property name="wrap">False</property>
-                            <property name="selectable">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0.5</property>
+                            <property name="can_focus">False</property>
                             <property name="xpad">2</property>
                             <property name="ypad">2</property>
+                            <property name="label" translatable="yes">&lt;b&gt;_Location&lt;/b&gt;</property>
+                            <property name="use_markup">True</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0</property>
+                            <property name="yalign">0.5</property>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkHBox" id="hbox2">
                             <property name="visible">True</property>
-                            <property name="homogeneous">False</property>
-                            <property name="spacing">0</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkLabel" id="label2">
                                 <property name="visible">True</property>
-                                <property name="label" translatable="no">    </property>
-                                <property name="use_underline">False</property>
-                                <property name="use_markup">False</property>
-                                <property name="justify">GTK_JUSTIFY_LEFT</property>
-                                <property name="wrap">False</property>
-                                <property name="selectable">False</property>
-                                <property name="xalign">0.5</property>
-                                <property name="yalign">0.5</property>
+                                <property name="can_focus">False</property>
                                 <property name="xpad">0</property>
                                 <property name="ypad">0</property>
+                                <property name="label">    </property>
+                                <property name="xalign">0.5</property>
+                                <property name="yalign">0.5</property>
                               </object>
                               <packing>
-                                <property name="padding">0</property>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkHBox" id="bookmark_location_placeholder">
                                 <property name="visible">True</property>
-                                <property name="homogeneous">False</property>
-                                <property name="spacing">0</property>
+                                <property name="can_focus">False</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                               </object>
                               <packing>
-                                <property name="padding">0</property>
                                 <property name="expand">True</property>
                                 <property name="fill">True</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -365,5 +381,8 @@
       <action-widget response="-2">bookmark_delete_button</action-widget>
       <action-widget response="-7">button2</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>


### PR DESCRIPTION
The expected: press [control + B] and see the same look like before

I edited the old file with Glade 3.20.2 to do the job, and I used **translatable="yes"** <- This is the correct way to work with _transifex_ later?