### PR TITLE
eel-editable-label.c: avoid gtk_image_menu_item_new_from_stock

### DIFF
--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -3003,14 +3003,39 @@ activate_cb (GtkWidget *menuitem,
     g_signal_emit_by_name (label, signal);
 }
 
+static GtkWidget
+*mate_image_menu_item_new_from_icon (const gchar *icon_name,
+                                     const gchar *label_name)
+{
+    GtkWidget *icon;
+    GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+
+    if (icon_name)
+        icon = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+    else
+        icon = gtk_image_new ();
+
+    GtkWidget *label_menu = gtk_label_new_with_mnemonic (g_strconcat (label_name, "     ", NULL));
+    GtkWidget *menuitem = gtk_menu_item_new ();
+ 
+    gtk_container_add (GTK_CONTAINER (box), icon);
+    gtk_container_add (GTK_CONTAINER (box), label_menu);
+ 
+    gtk_container_add (GTK_CONTAINER (menuitem), box);
+    gtk_widget_show_all (menuitem);
+
+    return menuitem;
+}
+
 static void
 append_action_signal (EelEditableLabel     *label,
                       GtkWidget    *menu,
-                      const gchar  *stock_id,
+                      const gchar  *icon_name,
+                      const gchar  *label_name,
                       const gchar  *signal,
                       gboolean      sensitive)
 {
-    GtkWidget *menuitem = gtk_image_menu_item_new_from_stock (stock_id, NULL);
+    GtkWidget *menuitem = mate_image_menu_item_new_from_icon (icon_name, label_name);
 
     g_object_set_data (G_OBJECT (menuitem), "gtk-signal", (char *)signal);
     g_signal_connect (menuitem, "activate",
@@ -3096,6 +3121,8 @@ popup_targets_received (GtkClipboard     *clipboard,
 
         label->popup_menu = gtk_menu_new ();
 
+        gtk_menu_set_reserve_toggle_size (GTK_MENU (label->popup_menu), FALSE);
+
         gtk_menu_attach_to_widget (GTK_MENU (label->popup_menu),
                                    GTK_WIDGET (label),
                                    popup_menu_detach);
@@ -3105,14 +3132,14 @@ popup_targets_received (GtkClipboard     *clipboard,
 
         clipboard_contains_text = gtk_selection_data_targets_include_text (data);
 
-        append_action_signal (label, label->popup_menu, "gtk-cut", "cut_clipboard",
+        append_action_signal (label, label->popup_menu, "gtk-cut", _("Cu_t"), "cut_clipboard",
                               have_selection);
-        append_action_signal (label, label->popup_menu, "gtk-copy", "copy_clipboard",
+        append_action_signal (label, label->popup_menu, "gtk-copy", _("_Copy"), "copy_clipboard",
                               have_selection);
-        append_action_signal (label, label->popup_menu, "gtk-paste", "paste_clipboard",
+        append_action_signal (label, label->popup_menu, "gtk-paste", _("_Paste"), "paste_clipboard",
                               clipboard_contains_text);
 
-        menuitem = gtk_menu_item_new_with_label (_("Select All"));
+        menuitem = mate_image_menu_item_new_from_icon ("edit-select-all", _("Select All"));
         g_signal_connect_object (menuitem, "activate",
                                  G_CALLBACK (eel_editable_label_select_all), label,
                                  G_CONNECT_SWAPPED);
@@ -3123,7 +3150,7 @@ popup_targets_received (GtkClipboard     *clipboard,
         gtk_widget_show (menuitem);
         gtk_menu_shell_append (GTK_MENU_SHELL (label->popup_menu), menuitem);
 
-        menuitem = gtk_menu_item_new_with_label (_("Input Methods"));
+        menuitem = mate_image_menu_item_new_from_icon (NULL, _("Input Methods"));
         gtk_widget_show (menuitem);
         submenu = gtk_menu_new ();
         gtk_menu_item_set_submenu (GTK_MENU_ITEM (menuitem), submenu);


### PR DESCRIPTION
avoid `gtk_image_menu_item_new_from_stock` and add icon to "Select All"

without the PR:

![image_stock_caja_without](https://user-images.githubusercontent.com/7734191/36505016-9296590c-1752-11e8-9c2d-cd2a85ed82a4.png)

with the PR:

![gtk_image_stock_caja_pr](https://user-images.githubusercontent.com/7734191/36505036-9d420d1a-1752-11e8-9a97-bbd8271b9918.png)