### PR TITLE
caja-autorun: avoid gtk_dialog_add_buttons with stock ids

### DIFF
--- a/libcaja-private/caja-autorun.c
+++ b/libcaja-private/caja-autorun.c
@@ -915,6 +915,24 @@ combo_box_enter_ok (GtkWidget *togglebutton, GdkEventKey *event, GtkDialog *dial
     return FALSE;
 }
 
+static void
+mate_dialog_add_button (GtkDialog   *dialog,
+                        const gchar *button_text,
+                        const gchar *icon_name,
+                        gint         response_id)
+{
+    GtkWidget *button;
+
+    button = gtk_button_new_with_mnemonic (button_text);
+    gtk_button_set_image (GTK_BUTTON (button), gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_BUTTON));
+
+    gtk_button_set_use_underline (GTK_BUTTON (button), TRUE);
+    gtk_style_context_add_class (gtk_widget_get_style_context (button), "text-button");
+    gtk_widget_set_can_default (button, TRUE);
+    gtk_widget_show (button);
+    gtk_dialog_add_action_widget (GTK_DIALOG (dialog), button, response_id);
+}
+
 /* returns TRUE if a folder window should be opened */
 static gboolean
 do_autorun_for_content_type (GMount *mount, const char *x_content_type, CajaAutorunOpenWindow open_window_func, gpointer user_data)
@@ -1126,10 +1144,16 @@ show_dialog:
                       data);
     gtk_box_pack_start (GTK_BOX (vbox), always_check_button, TRUE, TRUE, 0);
 
-    gtk_dialog_add_buttons (GTK_DIALOG (dialog),
-                            "gtk-cancel", GTK_RESPONSE_CANCEL,
-                            "gtk-ok", GTK_RESPONSE_OK,
-                            NULL);
+    mate_dialog_add_button (GTK_DIALOG (dialog),
+                            _("_Cancel"),
+                            "process-stop",
+                            GTK_RESPONSE_CANCEL);
+
+    mate_dialog_add_button (GTK_DIALOG (dialog),
+                            _("_OK"),
+                            "gtk-ok",
+                            GTK_RESPONSE_OK);
+
     gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);
 
     if (g_mount_can_eject (mount))


### PR DESCRIPTION
This PR affects the buttons "cancel" and "ok" in the dialog:

![autorun_with_pr](https://user-images.githubusercontent.com/7734191/36567887-44879d08-1828-11e8-8fb5-de4fb056f5a4.png)