### PR TITLE
caja-file-conflict-dialog: avoid gtk_dialog_add_buttons with stock id

### DIFF
--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -555,6 +555,24 @@ diff_button_clicked_cb (GtkButton *w,
 }
 
 static void
+mate_dialog_add_button (GtkDialog   *dialog,
+                        const gchar *button_text,
+                        const gchar *icon_name,
+                        gint         response_id)
+{
+    GtkWidget *button;
+
+    button = gtk_button_new_with_mnemonic (button_text);
+    gtk_button_set_image (GTK_BUTTON (button), gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_BUTTON));
+
+    gtk_button_set_use_underline (GTK_BUTTON (button), TRUE);
+    gtk_style_context_add_class (gtk_widget_get_style_context (button), "text-button");
+    gtk_widget_set_can_default (button, TRUE);
+    gtk_widget_show (button);
+    gtk_dialog_add_action_widget (GTK_DIALOG (dialog), button, response_id);
+}
+
+static void
 caja_file_conflict_dialog_init (CajaFileConflictDialog *fcd)
 {
     GtkWidget *hbox, *vbox, *vbox2;
@@ -650,12 +668,15 @@ caja_file_conflict_dialog_init (CajaFileConflictDialog *fcd)
                       G_CALLBACK (checkbox_toggled_cb), dialog);
 
     /* Add buttons */
-    gtk_dialog_add_buttons (dialog,
-                            "gtk-cancel",
-                            GTK_RESPONSE_CANCEL,
-                            _("_Skip"),
-                            CONFLICT_RESPONSE_SKIP,
-                            NULL);
+    mate_dialog_add_button (dialog,
+                            _("_Cancel"),
+                            "process-stop",
+                            GTK_RESPONSE_CANCEL);
+
+    gtk_dialog_add_button (dialog,
+                           _("_Skip"),
+                           CONFLICT_RESPONSE_SKIP);
+
     details->rename_button =
         gtk_dialog_add_button (dialog,
                                _("Re_name"),


### PR DESCRIPTION
This PR affects the cancel button here:

![caja_with_pr](https://user-images.githubusercontent.com/7734191/36597916-edaea8d6-18aa-11e8-9e4a-4ab4082ad705.png)