### PR TITLE
avoid eel_create_question_dialog with stock ids

### DIFF
--- a/eel/eel-stock-dialogs.c
+++ b/eel/eel-stock-dialogs.c
@@ -586,6 +586,18 @@ eel_create_question_dialog (const char *primary_text,
                                     GTK_MESSAGE_QUESTION,
                                     GTK_BUTTONS_NONE,
                                     parent);
-    gtk_dialog_add_buttons (dialog, answer_1, response_1, answer_2, response_2, NULL);
+
+    if (g_strcmp0 (answer_1, "process-stop") == 0)
+        mate_dialog_add_button (dialog, _("_Cancel"), answer_1, response_1);
+    else
+        gtk_dialog_add_button (dialog, answer_1, response_1);
+
+    if (g_strcmp0 (answer_2, "gtk-ok") == 0)
+        mate_dialog_add_button (dialog, _("_OK"), answer_2, response_2);
+    else if (g_strcmp0 (answer_2, "edit-clear") == 0)
+        mate_dialog_add_button (dialog, _("_Clear"), answer_2, response_2);
+    else
+        gtk_dialog_add_button (dialog, answer_2, response_2);
+
     return dialog;
 }

--- a/libcaja-private/caja-mime-actions.c
+++ b/libcaja-private/caja-mime-actions.c
@@ -741,7 +741,7 @@ report_broken_symbolic_link (GtkWindow *parent_window, CajaFile *file)
         goto out;
     }
 
-    dialog = eel_show_yes_no_dialog (prompt, detail, _("Mo_ve to Trash"), "gtk-cancel",
+    dialog = eel_show_yes_no_dialog (prompt, detail, _("Mo_ve to Trash"), "process-stop",
                                      parent_window);
 
     gtk_dialog_set_default_response (dialog, GTK_RESPONSE_CANCEL);
@@ -1179,7 +1179,7 @@ confirm_multiple_windows (GtkWindow *parent_window,
                                            "This will open %d separate windows.", count), count);
     }
     dialog = eel_show_yes_no_dialog (prompt, detail,
-                                     "gtk-ok", "gtk-cancel",
+                                     "gtk-ok", "process-stop",
                                      parent_window);
     g_free (detail);
 

--- a/libcaja-private/caja-program-choosing.c
+++ b/libcaja-private/caja-program-choosing.c
@@ -91,10 +91,11 @@ application_cannot_open_location (GAppInfo *application,
         }
 
         message_dialog = eel_show_yes_no_dialog (prompt,
-                         message,
-                         GTK_STOCK_OK,
-                         GTK_STOCK_CANCEL,
-                         parent_window);
+                                                 message,
+                                                 "gtk-ok",
+                                                 "process-stop",
+                                                 parent_window);
+
         response = gtk_dialog_run (message_dialog);
         gtk_widget_destroy (GTK_WIDGET (message_dialog));
 

--- a/src/caja-navigation-window-menus.c
+++ b/src/caja-navigation-window-menus.c
@@ -131,8 +131,8 @@ forget_history_if_confirmed (CajaWindow *window)
     dialog = eel_create_question_dialog (_("Are you sure you want to clear the list "
                                            "of locations you have visited?"),
                                          NULL,
-                                         "gtk-cancel", GTK_RESPONSE_CANCEL,
-                                         "gtk-clear", RESPONSE_FORGET,
+                                         "process-stop", GTK_RESPONSE_CANCEL,
+                                         "edit-clear", RESPONSE_FORGET,
                                          GTK_WINDOW (window));
 
     gtk_widget_show (GTK_WIDGET (dialog));

--- a/src/caja-window-bookmarks.c
+++ b/src/caja-window-bookmarks.c
@@ -84,7 +84,7 @@ show_bogus_bookmark_window (CajaWindow *window,
 
     dialog = eel_show_yes_no_dialog (prompt, detail,
                                      _("Bookmark for Nonexistent Location"),
-                                     "gtk-cancel",
+                                     "process-stop",
                                      GTK_WINDOW (window));
 
     g_signal_connect (dialog, "response",

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -659,7 +659,7 @@ fm_directory_view_confirm_multiple (GtkWindow *parent_window,
 						   "This will open %'d separate windows.", count), count);
 	}
 	dialog = eel_show_yes_no_dialog (prompt, detail,
-					 "gtk-ok", "gtk-cancel",
+					 "gtk-ok", "process-stop",
 					 parent_window);
 	g_free (detail);
 


### PR DESCRIPTION
This PR affects some dialogs, I have tested with these dialogs:

![001caja](https://user-images.githubusercontent.com/7734191/36872678-525e2770-1da6-11e8-88e2-190304a7ddf2.png)

![002caja](https://user-images.githubusercontent.com/7734191/36872677-521d3210-1da6-11e8-98e7-bd1be252da57.png)