### PR TITLE
eel-editable-label.c: avoid 'append_action_signal' with stock ids

### DIFF
--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -3132,11 +3132,11 @@ popup_targets_received (GtkClipboard     *clipboard,
 
         clipboard_contains_text = gtk_selection_data_targets_include_text (data);
 
-        append_action_signal (label, label->popup_menu, "gtk-cut", _("Cu_t"), "cut_clipboard",
+        append_action_signal (label, label->popup_menu, "edit-cut", _("Cu_t"), "cut_clipboard",
                               have_selection);
-        append_action_signal (label, label->popup_menu, "gtk-copy", _("_Copy"), "copy_clipboard",
+        append_action_signal (label, label->popup_menu, "edit-copy", _("_Copy"), "copy_clipboard",
                               have_selection);
-        append_action_signal (label, label->popup_menu, "gtk-paste", _("_Paste"), "paste_clipboard",
+        append_action_signal (label, label->popup_menu, "edit-paste", _("_Paste"), "paste_clipboard",
                               clipboard_contains_text);
 
         menuitem = mate_image_menu_item_new_from_icon ("edit-select-all", _("Select All"));


### PR DESCRIPTION
![gtk_image_stock_caja_pr](https://user-images.githubusercontent.com/7734191/36505036-9d420d1a-1752-11e8-9a97-bbd8271b9918.png)