### PR TITLE
fm-tree-view.c: avoid deprecated GtkImageMenuItem

### DIFF
--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -30,6 +30,8 @@
 #include "eel-editable-label.h"
 #include "eel-marshal.h"
 #include "eel-accessibility.h"
+#include "eel-gtk-extensions.h"
+
 #include <libgail-util/gailmisc.h>
 
 #include <glib/gi18n-lib.h>
@@ -3003,30 +3005,6 @@ activate_cb (GtkWidget *menuitem,
     g_signal_emit_by_name (label, signal);
 }
 
-static GtkWidget
-*mate_image_menu_item_new_from_icon (const gchar *icon_name,
-                                     const gchar *label_name)
-{
-    GtkWidget *icon;
-    GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
-
-    if (icon_name)
-        icon = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
-    else
-        icon = gtk_image_new ();
-
-    GtkWidget *label_menu = gtk_label_new_with_mnemonic (g_strconcat (label_name, "     ", NULL));
-    GtkWidget *menuitem = gtk_menu_item_new ();
- 
-    gtk_container_add (GTK_CONTAINER (box), icon);
-    gtk_container_add (GTK_CONTAINER (box), label_menu);
- 
-    gtk_container_add (GTK_CONTAINER (menuitem), box);
-    gtk_widget_show_all (menuitem);
-
-    return menuitem;
-}
-
 static void
 append_action_signal (EelEditableLabel     *label,
                       GtkWidget    *menu,
@@ -3035,7 +3013,7 @@ append_action_signal (EelEditableLabel     *label,
                       const gchar  *signal,
                       gboolean      sensitive)
 {
-    GtkWidget *menuitem = mate_image_menu_item_new_from_icon (icon_name, label_name);
+    GtkWidget *menuitem = eel_image_menu_item_new_from_icon (icon_name, label_name);
 
     g_object_set_data (G_OBJECT (menuitem), "gtk-signal", (char *)signal);
     g_signal_connect (menuitem, "activate",
@@ -3139,7 +3117,7 @@ popup_targets_received (GtkClipboard     *clipboard,
         append_action_signal (label, label->popup_menu, "edit-paste", _("_Paste"), "paste_clipboard",
                               clipboard_contains_text);
 
-        menuitem = mate_image_menu_item_new_from_icon ("edit-select-all", _("Select All"));
+        menuitem = eel_image_menu_item_new_from_icon ("edit-select-all", _("Select All"));
         g_signal_connect_object (menuitem, "activate",
                                  G_CALLBACK (eel_editable_label_select_all), label,
                                  G_CONNECT_SWAPPED);
@@ -3150,7 +3128,7 @@ popup_targets_received (GtkClipboard     *clipboard,
         gtk_widget_show (menuitem);
         gtk_menu_shell_append (GTK_MENU_SHELL (label->popup_menu), menuitem);
 
-        menuitem = mate_image_menu_item_new_from_icon (NULL, _("Input Methods"));
+        menuitem = eel_image_menu_item_new_from_icon (NULL, _("Input Methods"));
         gtk_widget_show (menuitem);
         submenu = gtk_menu_new ();
         gtk_menu_item_set_submenu (GTK_MENU_ITEM (menuitem), submenu);

--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -456,3 +456,27 @@ eel_gtk_message_dialog_set_details_label (GtkMessageDialog *dialog,
 	gtk_widget_show (label);
 	gtk_widget_show (expander);
 }
+
+GtkWidget *
+eel_image_menu_item_new_from_icon (const gchar *icon_name,
+                                   const gchar *label_name)
+{
+    GtkWidget *icon;
+    GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+
+    if (icon_name)
+        icon = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+    else
+        icon = gtk_image_new ();
+
+    GtkWidget *label_menu = gtk_label_new_with_mnemonic (g_strconcat (label_name, "     ", NULL));
+    GtkWidget *menuitem = gtk_menu_item_new ();
+ 
+    gtk_container_add (GTK_CONTAINER (box), icon);
+    gtk_container_add (GTK_CONTAINER (box), label_menu);
+ 
+    gtk_container_add (GTK_CONTAINER (menuitem), box);
+    gtk_widget_show_all (menuitem);
+
+    return menuitem;
+}

--- a/eel/eel-gtk-extensions.h
+++ b/eel/eel-gtk-extensions.h
@@ -65,11 +65,14 @@ GtkWidget *           eel_gtk_menu_tool_button_get_button             (GtkMenuTo
 void                  eel_gtk_label_make_bold                         (GtkLabel             *label);
 
 /* GtkTreeView */
-void                  eel_gtk_tree_view_set_activate_on_single_click  (GtkTreeView               *tree_view,
-        gboolean                   should_activate);
+void                  eel_gtk_tree_view_set_activate_on_single_click  (GtkTreeView          *tree_view,
+                                                                       gboolean              should_activate);
 
 /* GtkMessageDialog */
-void                  eel_gtk_message_dialog_set_details_label        (GtkMessageDialog          *dialog,
-								       const gchar               *details_text);
+void                  eel_gtk_message_dialog_set_details_label        (GtkMessageDialog     *dialog,
+                                                                       const gchar          *details_text);
+
+GtkWidget *           eel_image_menu_item_new_from_icon               (const gchar          *icon_name,
+                                                                       const gchar          *label_name);
 
 #endif /* EEL_GTK_EXTENSIONS_H */

--- a/src/file-manager/fm-tree-view.c
+++ b/src/file-manager/fm-tree-view.c
@@ -1255,18 +1255,15 @@ create_popup_menu (FMTreeView *view)
 
     popup = gtk_menu_new ();
 
+    gtk_menu_set_reserve_toggle_size (GTK_MENU (popup), FALSE);
+
     g_signal_connect (popup, "deactivate",
                       G_CALLBACK (popup_menu_deactivated),
                       view);
 
 
     /* add the "open" menu item */
-    menu_image = gtk_image_new_from_icon_name ("document-open",
-                                               GTK_ICON_SIZE_MENU);
-    gtk_widget_show (menu_image);
-    menu_item = gtk_image_menu_item_new_with_mnemonic (_("_Open"));
-    gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (menu_item),
-                                   menu_image);
+    menu_item = eel_image_menu_item_new_from_icon ("document-open", _("_Open"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_open_cb),
                       view);
@@ -1275,7 +1272,7 @@ create_popup_menu (FMTreeView *view)
     view->details->popup_open = menu_item;
 
     /* add the "open in new tab" menu item */
-    menu_item = gtk_menu_item_new_with_mnemonic (_("Open in New _Tab"));
+    menu_item = eel_image_menu_item_new_from_icon (NULL, _("Open in New _Tab"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_open_in_new_tab_cb),
                       view);
@@ -1284,7 +1281,7 @@ create_popup_menu (FMTreeView *view)
     view->details->popup_open_in_new_window = menu_item;
 
     /* add the "open in new window" menu item */
-    menu_item = gtk_menu_item_new_with_mnemonic (_("Open in New _Window"));
+    menu_item = eel_image_menu_item_new_from_icon (NULL, _("Open in New _Window"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_open_in_new_window_cb),
                       view);
@@ -1295,7 +1292,7 @@ create_popup_menu (FMTreeView *view)
     eel_gtk_menu_append_separator (GTK_MENU (popup));
 
     /* add the "create folder" menu item */
-    menu_item = gtk_image_menu_item_new_with_mnemonic (_("Create _Folder"));
+    menu_item = eel_image_menu_item_new_from_icon (NULL, _("Create _Folder"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_create_folder_cb),
                       view);
@@ -1306,7 +1303,7 @@ create_popup_menu (FMTreeView *view)
     eel_gtk_menu_append_separator (GTK_MENU (popup));
 
     /* add the "cut folder" menu item */
-    menu_item = gtk_image_menu_item_new_from_stock ("gtk-cut", NULL);
+    menu_item = eel_image_menu_item_new_from_icon ("edit-cut", _("Cu_t"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_cut_cb),
                       view);
@@ -1315,7 +1312,7 @@ create_popup_menu (FMTreeView *view)
     view->details->popup_cut = menu_item;
 
     /* add the "copy folder" menu item */
-    menu_item = gtk_image_menu_item_new_from_stock ("gtk-copy", NULL);
+    menu_item = eel_image_menu_item_new_from_icon ("edit-copy", _("_Copy"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_copy_cb),
                       view);
@@ -1324,12 +1321,7 @@ create_popup_menu (FMTreeView *view)
     view->details->popup_copy = menu_item;
 
     /* add the "paste files into folder" menu item */
-    menu_image = gtk_image_new_from_icon_name ("edit-paste",
-                                               GTK_ICON_SIZE_MENU);
-    gtk_widget_show (menu_image);
-    menu_item = gtk_image_menu_item_new_with_mnemonic (_("_Paste Into Folder"));
-    gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (menu_item),
-                                   menu_image);
+    menu_item = eel_image_menu_item_new_from_icon ("edit-paste", _("_Paste Into Folder"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_paste_cb),
                       view);
@@ -1340,12 +1332,7 @@ create_popup_menu (FMTreeView *view)
     eel_gtk_menu_append_separator (GTK_MENU (popup));
 
     /* add the "move to trash" menu item */
-    menu_image = gtk_image_new_from_icon_name (CAJA_ICON_TRASH_FULL,
-                 GTK_ICON_SIZE_MENU);
-    gtk_widget_show (menu_image);
-    menu_item = gtk_image_menu_item_new_with_mnemonic (_("Mo_ve to Trash"));
-    gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (menu_item),
-                                   menu_image);
+    menu_item = eel_image_menu_item_new_from_icon (CAJA_ICON_TRASH_FULL, _("Mo_ve to Trash"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_trash_cb),
                       view);
@@ -1354,12 +1341,7 @@ create_popup_menu (FMTreeView *view)
     view->details->popup_trash = menu_item;
 
     /* add the "delete" menu item */
-    menu_image = gtk_image_new_from_icon_name (CAJA_ICON_DELETE,
-                 GTK_ICON_SIZE_MENU);
-    gtk_widget_show (menu_image);
-    menu_item = gtk_image_menu_item_new_with_mnemonic (_("_Delete"));
-    gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (menu_item),
-                                   menu_image);
+    menu_item = eel_image_menu_item_new_from_icon (CAJA_ICON_DELETE, _("_Delete"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_delete_cb),
                       view);
@@ -1370,7 +1352,7 @@ create_popup_menu (FMTreeView *view)
     eel_gtk_menu_append_separator (GTK_MENU (popup));
 
     /* add the "Unmount" menu item */
-    menu_item = gtk_image_menu_item_new_with_mnemonic (_("_Unmount"));
+    menu_item = eel_image_menu_item_new_from_icon (NULL, _("_Unmount"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_unmount_cb),
                       view);
@@ -1379,7 +1361,7 @@ create_popup_menu (FMTreeView *view)
     view->details->popup_unmount = menu_item;
 
     /* add the "Eject" menu item */
-    menu_item = gtk_image_menu_item_new_with_mnemonic (_("_Eject"));
+    menu_item = eel_image_menu_item_new_from_icon (NULL, _("_Eject"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_eject_cb),
                       view);
@@ -1392,7 +1374,7 @@ create_popup_menu (FMTreeView *view)
         GTK_WIDGET (eel_gtk_menu_append_separator (GTK_MENU (popup)));
 
     /* add the "properties" menu item */
-    menu_item = gtk_image_menu_item_new_from_stock ("gtk-properties", NULL);
+    menu_item = eel_image_menu_item_new_from_icon ("document-properties", _("_Properties"));
     g_signal_connect (menu_item, "activate",
                       G_CALLBACK (fm_tree_view_properties_cb),
                       view);


### PR DESCRIPTION
avoid deprecated:

gtk_image_menu_item_new_from_stock
gtk_image_menu_item_new_with_mnemonic
gtk_image_menu_item_set_image

![treeprcaja](https://user-images.githubusercontent.com/7734191/37939047-37b208fa-3161-11e8-9b8a-5a1e29af3e94.png)