### PR TITLE
caja-spatial-window.c: avoid deprecated GtkImageMenuItem

### DIFF
--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -494,3 +494,27 @@ eel_image_menu_item_new_from_icon (const gchar *icon_name,
 
     return menuitem;
 }
+
+GtkWidget *
+eel_image_menu_item_new_from_pixbuf (GdkPixbuf   *icon_pixbuf,
+                                     const gchar *label_name)
+{
+    GtkWidget *icon;
+    GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+
+    if (icon_pixbuf)
+        icon = gtk_image_new_from_pixbuf (icon_pixbuf);
+    else
+        icon = gtk_image_new ();
+
+    GtkWidget *label_menu = gtk_label_new (g_strconcat (label_name, "     ", NULL));
+    GtkWidget *menuitem = gtk_menu_item_new ();
+
+    gtk_container_add (GTK_CONTAINER (box), icon);
+    gtk_container_add (GTK_CONTAINER (box), label_menu);
+
+    gtk_container_add (GTK_CONTAINER (menuitem), box);
+    gtk_widget_show_all (menuitem);
+
+    return menuitem;
+}

--- a/eel/eel-gtk-extensions.h
+++ b/eel/eel-gtk-extensions.h
@@ -75,4 +75,7 @@ void                  eel_gtk_message_dialog_set_details_label        (GtkMessag
 GtkWidget *           eel_image_menu_item_new_from_icon               (const gchar          *icon_name,
                                                                        const gchar          *label_name);
 
+GtkWidget *           eel_image_menu_item_new_from_pixbuf               (GdkPixbuf          *icon_pixbuf,
+                                                                         const gchar        *label_name);
+
 #endif /* EEL_GTK_EXTENSIONS_H */


### PR DESCRIPTION
avoid deprecated:

gtk_image_menu_item_set_always_show_image
gtk_image_menu_item_new_with_label
gtk_image_menu_item_set_image

![press_spatial](https://user-images.githubusercontent.com/7734191/38341255-e12ef574-3877-11e8-94da-0c002b78b583.png)

![release_spatial](https://user-images.githubusercontent.com/7734191/38341258-e58ec23e-3877-11e8-8065-10d2ca4ffc48.png)