### PR TITLE
Fix warnings from HiDPI commits

### DIFF
--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -280,7 +280,7 @@ caja_icon_canvas_item_finalize (GObject *object)
 
     if (details->rendered_surface != NULL)
     {
-        g_object_unref (details->rendered_surface);
+    cairo_surface_destroy (details->rendered_surface);
     }
 
     if (details->editable_text_layout != NULL)

--- a/libcaja-private/caja-icon-info.c
+++ b/libcaja-private/caja-icon-info.c
@@ -643,6 +643,9 @@ caja_icon_info_get_surface_nodefault_at_size (CajaIconInfo *icon,
     cairo_surface_t *surface;
 
     pixbuf = caja_icon_info_get_pixbuf_nodefault_at_size (icon, forced_size);
+    /*catch the case of caja_icon_info_get_pixbuf_nodefault_at_size returning NULL */
+    if (!pixbuf)
+        return NULL;
     surface = gdk_cairo_surface_create_from_pixbuf (pixbuf, icon->orig_scale, NULL);
     g_object_unref (pixbuf);
 

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -1538,9 +1538,13 @@ setup_file_path_mounted_mount (GFile *location, ButtonData *button_data)
     GFile *root, *default_location;
     gint scale;
 
+    /* Return false if button has not been set up yet or has been destroyed*/
+    if (!button_data->button)
+        return FALSE;
     result = FALSE;
     volume_monitor = g_volume_monitor_get ();
     mounts = g_volume_monitor_get_mounts (volume_monitor);
+
     scale = gtk_widget_get_scale_factor (GTK_WIDGET (button_data->button));
     for (l = mounts; l != NULL; l = l->next)
     {


### PR DESCRIPTION
*caja-pathbar: fix warning,and in the process maybe fix occassional segfaults on opening a mounted device from the desktop

*caja-icon-info: Stop  gdk_cairo_surface_create_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed warning by handling NULL return from function finding the pixbuf

caja-icon-canvas-item-c: do not use g_object_unref where it does not work Stop the g_object_unref: assertion 'G_IS_OBJECT (object)' failed warnings on closing icon views