### PR TITLE
pathbar: fix random segfaults on opening mounts from Desktop

### DIFF
--- a/src/caja-navigation-window-pane.c
+++ b/src/caja-navigation-window-pane.c
@@ -261,63 +261,21 @@ location_button_create (CajaNavigationWindowPane *pane)
 }
 
 static gboolean
-path_bar_button_pressed_callback (GtkWidget *widget,
-                                  GdkEventButton *event,
-                                  CajaNavigationWindowPane *pane)
-{
-    CajaWindowSlot *slot;
-    CajaView *view;
-    GFile *location;
-    char *uri;
+path_bar_path_event_callback (CajaPathBar *path_bar,
+                   GFile *location,
+                   GdkEventButton *event,
+                   CajaWindowPane *pane)
 
-    caja_window_set_active_pane (CAJA_WINDOW_PANE (pane)->window, CAJA_WINDOW_PANE (pane));
-
-    g_object_set_data (G_OBJECT (widget), "handle-button-release",
-                       GINT_TO_POINTER (TRUE));
-
-    if (event->button == 3)
-    {
-        slot = caja_window_get_active_slot (CAJA_WINDOW_PANE (pane)->window);
-        view = slot->content_view;
-        if (view != NULL)
-        {
-            location = caja_path_bar_get_path_for_button (
-                           CAJA_PATH_BAR (pane->path_bar), widget);
-            if (location != NULL)
-            {
-                uri = g_file_get_uri (location);
-                caja_view_pop_up_location_context_menu (
-                    view, event, uri);
-                g_object_unref (G_OBJECT (location));
-                g_free (uri);
-                return TRUE;
-            }
-        }
-    }
-
-    return FALSE;
-}
-
-static gboolean
-path_bar_button_released_callback (GtkWidget *widget,
-                                   GdkEventButton *event,
-                                   CajaNavigationWindowPane *pane)
 {
     CajaWindowSlot *slot;
     CajaWindowOpenFlags flags;
-    GFile *location;
     int mask;
-    gboolean handle_button_release;
+    CajaView *view;
+    char *uri;
 
-    mask = event->state & gtk_accelerator_get_default_mod_mask ();
-    flags = 0;
-
-    handle_button_release = GPOINTER_TO_UINT (g_object_get_data (G_OBJECT (widget),
-                            "handle-button-release"));
-
-    if (event->type == GDK_BUTTON_RELEASE && handle_button_release)
-    {
-        location = caja_path_bar_get_path_for_button (CAJA_PATH_BAR (pane->path_bar), widget);
+    if (event->type == GDK_BUTTON_RELEASE) {
+        mask = event->state & gtk_accelerator_get_default_mod_mask ();
+        flags = 0;
 
         if (event->button == 2 && mask == 0)
         {
@@ -334,23 +292,22 @@ path_bar_button_released_callback (GtkWidget *widget,
             caja_window_slot_info_open_location (slot, location,
                                                  CAJA_WINDOW_OPEN_ACCORDING_TO_MODE,
                                                  flags, NULL);
-            g_object_unref (location);
-            return TRUE;
         }
 
-        g_object_unref (location);
+         return FALSE;
     }
 
+    if (event->button == 3) {
+        slot = caja_window_get_active_slot (pane->window);
+        view = slot->content_view;
+        if (view != NULL) {
+            uri = g_file_get_uri (location);
+            caja_view_pop_up_location_context_menu (view, event, uri);
+            g_free (uri);
+        }
+        return TRUE;
+    }
     return FALSE;
-}
-
-static void
-path_bar_button_drag_begin_callback (GtkWidget *widget,
-                                     GdkEventButton *event,
-                                     gpointer user_data)
-{
-    g_object_set_data (G_OBJECT (widget), "handle-button-release",
-                       GINT_TO_POINTER (FALSE));
 }
 
 static void
@@ -361,46 +318,6 @@ notebook_popup_menu_new_tab_cb (GtkMenuItem *menuitem,
 
     pane = CAJA_WINDOW_PANE (user_data);
     caja_window_new_tab (pane->window);
-}
-
-static void
-path_bar_path_set_callback (GtkWidget *widget,
-                            GFile *location,
-                            CajaNavigationWindowPane *pane)
-{
-    GList *children, *l;
-    GtkWidget *child;
-
-    children = gtk_container_get_children (GTK_CONTAINER (widget));
-
-    for (l = children; l != NULL; l = l->next)
-    {
-        child = GTK_WIDGET (l->data);
-
-        if (!GTK_IS_TOGGLE_BUTTON (child))
-        {
-            continue;
-        }
-
-        if (!g_signal_handler_find (child,
-                                    G_SIGNAL_MATCH_FUNC | G_SIGNAL_MATCH_DATA,
-                                    0, 0, NULL,
-                                    path_bar_button_pressed_callback,
-                                    pane))
-        {
-            g_signal_connect (child, "button-press-event",
-                              G_CALLBACK (path_bar_button_pressed_callback),
-                              pane);
-            g_signal_connect (child, "button-release-event",
-                              G_CALLBACK (path_bar_button_released_callback),
-                              pane);
-            g_signal_connect (child, "drag-begin",
-                              G_CALLBACK (path_bar_button_drag_begin_callback),
-                              pane);
-        }
-    }
-
-    g_list_free (children);
 }
 
 static void
@@ -766,8 +683,9 @@ caja_navigation_window_pane_setup (CajaNavigationWindowPane *pane)
 
     g_signal_connect_object (pane->path_bar, "path_clicked",
                              G_CALLBACK (path_bar_location_changed_callback), pane, 0);
-    g_signal_connect_object (pane->path_bar, "path_set",
-                             G_CALLBACK (path_bar_path_set_callback), pane, 0);
+
+    g_signal_connect_object (pane->path_bar, "path-event",
+                             G_CALLBACK (path_bar_path_event_callback), pane, 0);
 
     gtk_box_pack_start (GTK_BOX (hbox),
                         pane->path_bar,

--- a/src/caja-pathbar.h
+++ b/src/caja-pathbar.h
@@ -71,15 +71,19 @@ struct _CajaPathBarClass
 
     void (* path_clicked)   (CajaPathBar  *path_bar,
                              GFile             *location);
-    void (* path_set)       (CajaPathBar  *path_bar,
-                             GFile             *location);
+
+    void (* path_event)     (CajaPathBar  *path_bar,
+                             GdkEventButton   *event,
+                             GFile            *location);
 };
 
 GType    caja_path_bar_get_type (void) G_GNUC_CONST;
 
 gboolean caja_path_bar_set_path    (CajaPathBar *path_bar, GFile *file);
+
 GFile *  caja_path_bar_get_path_for_button (CajaPathBar *path_bar,
         GtkWidget       *button);
+
 void     caja_path_bar_clear_buttons (CajaPathBar *path_bar);
 
 GtkWidget * caja_path_bar_get_button_from_button_list_entry (gpointer entry);


### PR DESCRIPTION
Apply Nautilus commit
https://github.com/GNOME/nautilus/commit/e1ad3c05a6cd08c8cbf18ae53701dd742249d5fd#diff-f896071d07d34e87af94a18de95e4ea2
"pathbar: add a path-event signal"

and then apply most of

https://github.com/GNOME/nautilus/commit/875efc324f8e91f2d157c7532fe5570c1de421c7#diff-f896071d07d34e87af94a18de95e4ea2
pathbar: remove unused code

Which removes the function that was randomly segfaulting on creating certain navigation windows, usually on clicking a mounted volume from the desktop, probably by being called before the window was created. Replacement in button-event should never be called before the buttons exist