### PR TITLE
fm-icon-view: Show size on disk as sort criterion

### DIFF
--- a/src/file-manager/caja-icon-view-ui.xml
+++ b/src/file-manager/caja-icon-view-ui.xml
@@ -13,6 +13,7 @@
 				<placeholder name="Auto Layout">
 					<menuitem name="Sort by Name" action="Sort by Name"/>
 					<menuitem name="Sort by Size" action="Sort by Size"/>
+					<menuitem name="Sort by Size on Disk" action="Sort by Size on Disk"/>
 					<menuitem name="Sort by Type" action="Sort by Type"/>
 					<menuitem name="Sort by Modification Date" action="Sort by Modification Date"/>
 					<menuitem name="Sort by Emblems" action="Sort by Emblems"/>
@@ -37,6 +38,7 @@
 				<placeholder name="Auto Layout">
 					<menuitem name="Sort by Name" action="Sort by Name"/>
 					<menuitem name="Sort by Size" action="Sort by Size"/>
+					<menuitem name="Sort by Size on Disk" action="Sort by Size on Disk"/>
 					<menuitem name="Sort by Type" action="Sort by Type"/>
 					<menuitem name="Sort by Modification Date" action="Sort by Modification Date"/>
 					<menuitem name="Sort by Emblems" action="Sort by Emblems"/>

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -139,7 +139,7 @@ static const SortCriterion sort_criteria[] =
         CAJA_FILE_SORT_BY_SIZE_ON_DISK,
         "size_on_disk",
         "Sort by Size on Disk",
-        N_("by Size on Disk"),
+        N_("by S_ize on Disk"),
         N_("Keep icons sorted by disk usage in rows")
     },
     {
@@ -1752,6 +1752,12 @@ static const GtkRadioActionEntry arrange_radio_entries[] =
         N_("By _Size"), NULL,
         N_("Keep icons sorted by size in rows"),
         CAJA_FILE_SORT_BY_SIZE
+    },
+    {
+        "Sort by Size on Disk", NULL,
+        N_("By S_ize on Disk"), NULL,
+        N_("Keep icons sorted by disk usage in rows"),
+        CAJA_FILE_SORT_BY_SIZE_ON_DISK
     },
     {
         "Sort by Type", NULL,


### PR DESCRIPTION
This was introduced in commit b28445b3d2c42a7d2dbac97983d007e4ab58684d
but has never been added to some parts of the UI.

The GUI part was only implemented for the list view (but still selectable as default in the preferences for other views).