### PR TITLE
libcaja-private/caja-recent.c: gvfs-open is a deprecated tool, switch…

### DIFF
--- a/libcaja-private/caja-recent.c
+++ b/libcaja-private/caja-recent.c
@@ -22,7 +22,7 @@
 
 #include <eel/eel-vfs-extensions.h>
 
-#define DEFAULT_APP_EXEC "gvfs-open %u"
+#define DEFAULT_APP_EXEC "gio open %u"
 
 static GtkRecentManager *
 caja_recent_get_manager (void)


### PR DESCRIPTION
… to "gio open" from libglib2.0-bin.