### PR TITLE
Eliminate accessible children-changed event flood on container repopulation

### DIFF
--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -7703,6 +7703,8 @@ finish_adding_new_icons (CajaIconContainer *container)
 
     new_icons = container->details->new_icons;
     container->details->new_icons = NULL;
+    container->details->is_populating_container =
+      g_list_length(new_icons) == g_hash_table_size(container->details->icon_set);
 
     /* Position most icons (not unpositioned manual-layout icons). */
     new_icons = g_list_reverse (new_icons);
@@ -9582,8 +9584,8 @@ caja_icon_container_accessible_icon_added_cb (CajaIconContainer *container,
     AtkObject *atk_child;
     int index;
 
-    // We don't want to emit children_changed signals during the initial load.
-    if (container->details->is_loading)
+    // We don't want to emit children_changed signals during any type of load.
+    if (container->details->is_loading || container->details->is_populating_container)
         return;
 
     icon = g_hash_table_lookup (container->details->icon_set, icon_data);

--- a/libcaja-private/caja-icon-private.h
+++ b/libcaja-private/caja-icon-private.h
@@ -271,6 +271,7 @@ struct CajaIconContainerDetails
     GQueue* a11y_item_action_queue;
 
     eel_boolean_bit is_loading : 1;
+    eel_boolean_bit is_populating_container : 1;
 
     eel_boolean_bit store_layout_timestamps : 1;
     eel_boolean_bit store_layout_timestamps_when_finishing_new_icons : 1;


### PR DESCRIPTION
When the icon container is repopulated (e.g. when using back/forward)
finish_adding_new_icons is called leading to an accessible children-
changed event flood. We can distinguish these unwanted notifications from
desired notifications by comparing the number of new icons to add with
the size of the container's icon set.