### PR TITLE
replace deprecated gtk_menu_popup function part 2

### DIFF
--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -287,43 +287,12 @@ eel_gtk_window_set_initial_geometry_from_string (GtkWindow *window,
  * @event: The event that invoked this popup menu.
  **/
 void
-eel_pop_up_context_menu (GtkMenu	     *menu,
-                         gint16	      offset_x,
-                         gint16	      offset_y,
+eel_pop_up_context_menu (GtkMenu	*menu,
                          GdkEventButton *event)
 {
-    GdkPoint offset;
-    int button;
-
     g_return_if_fail (GTK_IS_MENU (menu));
 
-    offset.x = offset_x;
-    offset.y = offset_y;
-
-    /* The event button needs to be 0 if we're popping up this menu from
-     * a button release, else a 2nd click outside the menu with any button
-     * other than the one that invoked the menu will be ignored (instead
-     * of dismissing the menu). This is a subtle fragility of the GTK menu code.
-     */
-
-    if (event)
-    {
-        button = event->type == GDK_BUTTON_RELEASE
-                 ? 0
-                 : event->button;
-    }
-    else
-    {
-        button = 0;
-    }
-
-    gtk_menu_popup (menu,					/* menu */
-                    NULL,					/* parent_menu_shell */
-                    NULL,					/* parent_menu_item */
-                    NULL,
-                    &offset,			        /* data */
-                    button,					/* button */
-                    event ? event->time : GDK_CURRENT_TIME); /* activate_time */
+    gtk_menu_popup_at_pointer (menu, NULL);
 
     g_object_ref_sink (menu);
     g_object_unref (menu);

--- a/eel/eel-gtk-extensions.h
+++ b/eel/eel-gtk-extensions.h
@@ -32,8 +32,6 @@
 #include <gtk/gtk.h>
 #include <eel/eel-gdk-extensions.h>
 
-#define EEL_DEFAULT_POPUP_MENU_DISPLACEMENT 	2
-
 /* GtkWindow */
 void                  eel_gtk_window_set_initial_geometry             (GtkWindow            *window,
         EelGdkGeometryFlags   geometry_flags,
@@ -51,8 +49,6 @@ char *                eel_gtk_window_get_geometry_string              (GtkWindow
 
 /* GtkMenu and GtkMenuItem */
 void                  eel_pop_up_context_menu                         (GtkMenu              *menu,
-        gint16                offset_x,
-        gint16                offset_y,
         GdkEventButton       *event);
 GtkMenuItem *         eel_gtk_menu_append_separator                   (GtkMenu              *menu);
 GtkMenuItem *         eel_gtk_menu_insert_separator                   (GtkMenu              *menu,

--- a/src/caja-information-panel.c
+++ b/src/caja-information-panel.c
@@ -694,8 +694,6 @@ caja_information_panel_press_event (GtkWidget *widget, GdkEventButton *event)
     {
         menu = caja_information_panel_create_context_menu (information_panel);
         eel_pop_up_context_menu (GTK_MENU(menu),
-                                 EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-                                 EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
                                  event);
     }
     return TRUE;

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -2791,8 +2791,6 @@ bookmarks_popup_menu (CajaPlacesSidebar *sidebar,
 {
     bookmarks_update_popup_menu (sidebar);
     eel_pop_up_context_menu (GTK_MENU(sidebar->popup_menu),
-                             EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-                             EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
                              event);
 }
 

--- a/src/caja-zoom-control.c
+++ b/src/caja-zoom-control.c
@@ -124,12 +124,16 @@ zoom_button_clicked (GtkButton *button, CajaZoomControl *zoom_control)
 }
 
 static void
-zoom_popup_menu_show (GdkEventButton *event, CajaZoomControl *zoom_control)
+zoom_popup_menu_show (GtkWidget *widget, GdkEventButton *event, CajaZoomControl *zoom_control)
 {
-    eel_pop_up_context_menu (create_zoom_menu (zoom_control),
-                             EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-                             EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-                             event);
+    GtkMenu *menu;
+
+    menu = create_zoom_menu (zoom_control);
+    gtk_menu_popup_at_widget (menu,
+                              widget,
+                              GDK_GRAVITY_SOUTH_WEST,
+                              GDK_GRAVITY_NORTH_WEST,
+                              (const GdkEvent*) event);
 }
 
 static void
@@ -162,7 +166,7 @@ caja_zoom_control_button_press_event (GtkWidget *widget,
     /* check for the context menu button and show the menu */
     if (event->button == CONTEXTUAL_MENU_BUTTON)
     {
-        zoom_popup_menu_show (event, zoom_control);
+        zoom_popup_menu_show (widget, event, zoom_control);
         return TRUE;
     }
     /* We don't change our state (to reflect the new zoom) here.

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -9136,10 +9136,8 @@ fm_directory_view_pop_up_selection_context_menu  (FMDirectoryView *view,
 	update_context_menu_position_from_event (view, event);
 
 	eel_pop_up_context_menu (create_popup_menu
-				      	(view, FM_DIRECTORY_VIEW_POPUP_PATH_SELECTION),
-				      EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-				      EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-				      event);
+	                         (view, FM_DIRECTORY_VIEW_POPUP_PATH_SELECTION),
+	                          event);
 }
 
 /**
@@ -9164,12 +9162,9 @@ fm_directory_view_pop_up_background_context_menu (FMDirectoryView *view,
 
 	update_context_menu_position_from_event (view, event);
 
-
 	eel_pop_up_context_menu (create_popup_menu
-				      (view, FM_DIRECTORY_VIEW_POPUP_PATH_BACKGROUND),
-				      EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-				      EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-				      event);
+	                         (view, FM_DIRECTORY_VIEW_POPUP_PATH_BACKGROUND),
+	                         event);
 }
 
 static void
@@ -9181,10 +9176,8 @@ real_pop_up_location_context_menu (FMDirectoryView *view)
 	update_context_menu_position_from_event (view, view->details->location_popup_event);
 
 	eel_pop_up_context_menu (create_popup_menu
-				      (view, FM_DIRECTORY_VIEW_POPUP_PATH_LOCATION),
-				      EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-				      EEL_DEFAULT_POPUP_MENU_DISPLACEMENT,
-				      view->details->location_popup_event);
+	                         (view, FM_DIRECTORY_VIEW_POPUP_PATH_LOCATION),
+	                         view->details->location_popup_event);
 }
 
 static void


### PR DESCRIPTION
zoom-contol:
In favor of constant using of gtk_menu_popup_at_widget for mouse and keyboard events.
Now the popup is under the zoom-button if using mouse.

eel-gtk-extensions: 
open all context menus under pointer, same like before.