### PR TITLE
editable-label: avoid deprecated 'gtk_im_multicontext_append_menuitems'

### DIFF
--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -3051,7 +3051,7 @@ popup_targets_received (GtkClipboard     *clipboard,
                         GtkSelectionData *data,
                         gpointer          user_data)
 {
-    GtkWidget *menuitem, *submenu;
+    GtkWidget *menuitem;
     gboolean have_selection;
     gboolean clipboard_contains_text;
     PopupInfo *info;
@@ -3091,20 +3091,6 @@ popup_targets_received (GtkClipboard     *clipboard,
                                  G_CONNECT_SWAPPED);
         gtk_widget_show (menuitem);
         gtk_menu_shell_append (GTK_MENU_SHELL (label->popup_menu), menuitem);
-
-        menuitem = gtk_separator_menu_item_new ();
-        gtk_widget_show (menuitem);
-        gtk_menu_shell_append (GTK_MENU_SHELL (label->popup_menu), menuitem);
-
-        menuitem = eel_image_menu_item_new_from_icon (NULL, _("Input Methods"));
-        gtk_widget_show (menuitem);
-        submenu = gtk_menu_new ();
-        gtk_menu_item_set_submenu (GTK_MENU_ITEM (menuitem), submenu);
-
-        gtk_menu_shell_append (GTK_MENU_SHELL (label->popup_menu), menuitem);
-
-        gtk_im_multicontext_append_menuitems (GTK_IM_MULTICONTEXT (label->im_context),
-                                              GTK_MENU_SHELL (submenu));
 
         g_signal_emit (label,
                        signals[POPULATE_POPUP], 0,


### PR DESCRIPTION
drop "Input Methods"

I am not sure, we need it?

**EDIT**: with this PR:

![caja_pr_998](https://user-images.githubusercontent.com/7734191/40085012-5c250c00-5899-11e8-8542-85de5aef30ac.png)