### PR TITLE
icon-container: avoid deprecated 'gtk_style_context_get_border_color'

### DIFF
--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -2892,10 +2892,15 @@ start_rubberbanding (CajaIconContainer *container,
 	gtk_style_context_get (context, GTK_STATE_FLAG_NORMAL,
 			       GTK_STYLE_PROPERTY_BACKGROUND_COLOR,
 			       &c, NULL);
-	bg_color = *c;
-	gdk_rgba_free (c);
 
-	gtk_style_context_get_border_color (context, GTK_STATE_FLAG_NORMAL, &border_color);
+	bg_color = *c;
+
+	gtk_style_context_get (context, GTK_STATE_FLAG_NORMAL,
+			       GTK_STYLE_PROPERTY_BORDER_COLOR,
+			       &c, NULL);
+
+	border_color = *c;
+	gdk_rgba_free (c);
 
 	gtk_style_context_restore (context);
 


### PR DESCRIPTION
The expected: the same color in the border of this rectangle:

![border_color](https://user-images.githubusercontent.com/7734191/40175272-df39b872-59d7-11e8-9c66-60be0c11a2c5.png)