### PR TITLE
desktop window: Add is-desktop AtkObject attribute

### DIFF
--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -37,6 +37,41 @@
 #include <gio/gio.h>
 #include <glib/gi18n.h>    
 
+/* Tell screen readers that this is a desktop window */
+
+G_DEFINE_TYPE (CajaDesktopWindowAccessible, caja_desktop_window_accessible,
+               GTK_TYPE_WINDOW_ACCESSIBLE);
+
+static AtkAttributeSet *
+desktop_get_attributes (AtkObject *accessible)
+{
+    AtkAttributeSet *attributes;
+    AtkAttribute *is_desktop;
+
+    attributes = ATK_OBJECT_CLASS (caja_desktop_window_accessible_parent_class)->get_attributes (accessible);
+
+    is_desktop = g_malloc (sizeof (AtkAttribute));
+    is_desktop->name = g_strdup ("is-desktop");
+    is_desktop->value = g_strdup ("true");
+
+    attributes = g_slist_append (attributes, is_desktop);
+
+    return attributes;
+}
+
+static void
+caja_desktop_window_accessible_init (CajaDesktopWindowAccessible *window)
+{
+}
+
+static void
+caja_desktop_window_accessible_class_init (CajaDesktopWindowAccessibleClass *klass)
+{
+    AtkObjectClass *aclass = ATK_OBJECT_CLASS (klass);
+
+    aclass->get_attributes = desktop_get_attributes;
+}
+
 struct CajaDesktopWindowDetails
 {
     gulong size_changed_id;
@@ -285,6 +320,8 @@ caja_desktop_window_class_init (CajaDesktopWindowClass *klass)
     wclass->unrealize = unrealize;
     wclass->map = map;
     wclass->draw = draw;
+
+    gtk_widget_class_set_accessible_type (wclass, CAJA_TYPE_DESKTOP_WINDOW_ACCESSIBLE);
 
     nclass->window_type = CAJA_WINDOW_DESKTOP;
     nclass->get_title = real_get_title;

--- a/src/caja-desktop-window.h
+++ b/src/caja-desktop-window.h
@@ -32,6 +32,8 @@
 #include "caja-application.h"
 #include "caja-spatial-window.h"
 
+#include <gtk/gtk-a11y.h>
+
 #define CAJA_TYPE_DESKTOP_WINDOW caja_desktop_window_get_type()
 #define CAJA_DESKTOP_WINDOW(obj) \
   (G_TYPE_CHECK_INSTANCE_CAST ((obj), CAJA_TYPE_DESKTOP_WINDOW, CajaDesktopWindow))
@@ -63,5 +65,17 @@ CajaDesktopWindow *caja_desktop_window_new                 (CajaApplication *app
         GdkScreen           *screen);
 void                   caja_desktop_window_update_directory    (CajaDesktopWindow *window);
 gboolean               caja_desktop_window_loaded              (CajaDesktopWindow *window);
+
+#define CAJA_TYPE_DESKTOP_WINDOW_ACCESSIBLE caja_desktop_window_accessible_get_type()
+
+typedef struct
+{
+  GtkWindowAccessible parent_spot;
+} CajaDesktopWindowAccessible;
+
+typedef struct
+{
+  GtkWindowAccessibleClass parent_spot;
+} CajaDesktopWindowAccessibleClass;
 
 #endif /* CAJA_DESKTOP_WINDOW_H */


### PR DESCRIPTION
Screen readers need to distinguish between the desktop window and normal
windows, to be able to provide nicer speech synthesis.

This can be done by simply adding an "is-desktop" attribute to the
underlying AtkObject.

This is here done by introducing a thin caja_desktop_window_accessible_class
class which is based on GtkWindowAccessible and just appends the
attribute.

Closes: #999