### PR TITLE
GTK 3.23: fix warnings and crash from pathbar

### DIFF
--- a/libcaja-private/caja-directory.c
+++ b/libcaja-private/caja-directory.c
@@ -212,20 +212,6 @@ caja_directory_finalize (GObject *object)
     EEL_CALL_PARENT (G_OBJECT_CLASS, finalize, (object));
 }
 
-static void
-invalidate_one_count (gpointer key, gpointer value, gpointer user_data)
-{
-    CajaDirectory *directory;
-
-    g_assert (key != NULL);
-    g_assert (CAJA_IS_DIRECTORY (value));
-    g_assert (user_data == NULL);
-
-    directory = CAJA_DIRECTORY (value);
-
-    caja_directory_invalidate_count_and_mime_list (directory);
-}
-
 void
 emit_change_signals_for_all_files (CajaDirectory *directory)
 {
@@ -275,23 +261,6 @@ emit_change_signals_for_all_files_in_all_directories (void)
 
     g_list_free (dirs);
 }
-
-static void
-async_state_changed_one (gpointer key, gpointer value, gpointer user_data)
-{
-    CajaDirectory *directory;
-
-    g_assert (key != NULL);
-    g_assert (CAJA_IS_DIRECTORY (value));
-    g_assert (user_data == NULL);
-
-    directory = CAJA_DIRECTORY (value);
-
-    caja_directory_async_state_changed (directory);
-    emit_change_signals_for_all_files (directory);
-}
-
-
 
 /**
  * caja_directory_get_by_uri:

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -817,7 +817,6 @@ caja_path_bar_size_allocate (GtkWidget     *widget,
         if (direction == GTK_TEXT_DIR_RTL)
         {
             child_allocation.x -= path_bar->spacing;
-            down_slider_offset = child_allocation.x - widget_allocation.x - path_bar->slider_width;
             down_slider_offset = child_allocation.x - allocation->x - path_bar->slider_width;
         }
         else
@@ -2058,7 +2057,6 @@ caja_path_bar_update_path (CajaPathBar *path_bar,
     fake_root = NULL;
     result = TRUE;
     first_directory = TRUE;
-    last_directory = FALSE;
     new_buttons = NULL;
     current_button_data = NULL;
 

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -1901,12 +1901,13 @@ make_directory_button (CajaPathBar  *path_bar,
     switch (button_data->type)
     {
     case ROOT_BUTTON:
-        child = button_data->image;
-        button_data->label = NULL;
-        break;
+    /* Fall through */
     case HOME_BUTTON:
+    /* Fall through */
     case DESKTOP_BUTTON:
+    /* Fall through */
     case MOUNT_BUTTON:
+    /* Fall through */
     case DEFAULT_LOCATION_BUTTON:
         button_data->label = gtk_label_new (NULL);
         child = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 2);

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -169,13 +169,17 @@ update_button_types (CajaPathBar *path_bar)
         button_data = BUTTON_DATA (list->data);
         if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (button_data->button)))
         {
-            path = button_data->path;
+            /*Increase the reference count on path so it does not get cleared
+             *by caja_path_bar_clear_buttons during caja_path_bar_update_path
+             */
+            path = g_object_ref (button_data->path);
             break;
         }
     }
     if (path != NULL)
     {
         caja_path_bar_update_path (path_bar, path, TRUE);
+        g_object_unref (path);
     }
 }
 
@@ -2103,6 +2107,7 @@ caja_path_bar_update_path (CajaPathBar *path_bar,
     }
 
     path_bar->current_path = g_object_ref (file_path);
+
     path_bar->current_button_data = current_button_data;
 
     return result;


### PR DESCRIPTION
Stop button_data_file_changed: assertion 'path_bar->current_path != NULL' warnings and crashes. Note that these warnings do not appear with GTK 3.22, and the crashes occur only if GTK is built with --enable-debug=no. If GTK 3.23 is built with --enable-debug=minimal(as with release versions), these warnings still appear from the pathbar on toggling desktop_is_home_dir or rapidly opening many windows, but Caja does not crash:
```

(caja:13075): GLib-GObject-CRITICAL **: 22:31:36.471: g_object_ref: assertion 'G_IS_OBJECT (object)' failed

** (caja:13075): CRITICAL **: 22:31:36.504: button_data_file_changed: assertion 'path_bar->current_path != NULL' failed

(caja:13075): GLib-GObject-CRITICAL **: 22:31:36.932: g_object_ref: assertion 'G_IS_OBJECT (object)' failed

(caja:13075): GLib-GObject-CRITICAL **: 22:31:37.309: g_object_ref: assertion 'G_IS_OBJECT (object)' failed

** (caja:13075): CRITICAL **: 22:31:37.340: button_data_file_changed: assertion 'path_bar->current_path != NULL' failed

(caja:13075): GLib-GObject-CRITICAL **: 22:31:37.624: g_object_ref: assertion 'G_IS_OBJECT (object)' failed

```