### PR TITLE
caja-desktop-directory: stop segfaults in directory_ready_callback

### DIFF
--- a/libcaja-private/caja-desktop-directory.c
+++ b/libcaja-private/caja-desktop-directory.c
@@ -162,6 +162,10 @@ directory_ready_callback (CajaDirectory *directory,
     g_assert (callback_data != NULL);
 
     merged_callback = callback_data;
+    /*Prevent segfaults on the assert with GTK 3.23*/
+    if (merged_callback->non_ready_directories == NULL)
+        return;
+
     g_assert (g_list_find (merged_callback->non_ready_directories, directory) != NULL);
 
     /* Update based on this call. */


### PR DESCRIPTION
Prevent segfault on g_list_find in directory_ready_callback by catching the NULL case. This segfault can happen on rare occasions with GTK 3.23.0, I've had it several times in a week.