### PR TITLE
caja-window: Fix: mouse doesn't work with [ctrl] + [.] or [ctrl] + [;]

### DIFF
--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -1022,6 +1022,11 @@ static gboolean
 caja_window_key_press_event (GtkWidget *widget,
                              GdkEventKey *event)
 {
+    /* Fix for https://github.com/mate-desktop/caja/issues/1024 */
+    if ((event->state & GDK_CONTROL_MASK) &&
+        ((event->keyval == '.') || (event->keyval == ';')))
+        return TRUE;
+
     CajaWindow *window;
     int i;
 


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/caja/issues/1024