### PR TITLE
Add 'Configurable' extension interface, enabling Configure Extension

### DIFF
--- a/libcaja-extension/Makefile.am
+++ b/libcaja-extension/Makefile.am
@@ -34,6 +34,7 @@ libcaja_extension_include_HEADERS = \
 	caja-property-page-provider.h \
 	caja-property-page.h \
 	caja-menu.h \
+	caja-configurable.h \
 	$(NULL)
 
 libcaja_extension_la_SOURCES = \
@@ -50,6 +51,7 @@ libcaja_extension_la_SOURCES = \
 	caja-property-page-provider.c \
 	caja-property-page.c \
 	caja-menu.c \
+	caja-configurable.c \
 	$(NULL)
 
 pkgconfigdir=$(libdir)/pkgconfig

--- a/libcaja-extension/caja-configurable.c
+++ b/libcaja-extension/caja-configurable.c
@@ -1,0 +1,88 @@
+/*
+ *  caja-configurable.c - Interface for configuration
+ *
+ *  Copyright (C) 2003 Novell, Inc.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  Author: 20kdc <gamemanj@hotmail.co.uk>
+ *  Based on caja-menu-provider.c by Dave Camp <dave@ximian.com>
+ *
+ */
+
+#include <config.h>
+#include "caja-configurable.h"
+
+#include <glib-object.h>
+
+/**
+ * SECTION:caja-configurable
+ * @title: CajaConfigurable
+ * @short_description: Interface to allow an extension to be configured
+ * @include: libcaja-extension/caja-configurable.h
+ *
+ * #CajaConfigurable allows an extension to show a configuration page.
+ * The presence of CajaConfigurable enables the 'Configure' button.
+ */
+
+static void
+caja_configurable_base_init (gpointer g_class)
+{
+}
+
+GType
+caja_configurable_get_type (void)
+{
+    static GType type = 0;
+
+    if (!type) {
+        const GTypeInfo info = {
+            sizeof (CajaConfigurableIface),
+            caja_configurable_base_init,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            NULL
+        };
+
+        type = g_type_register_static (G_TYPE_INTERFACE,
+                                       "CajaConfigurable",
+                                       &info, 0);
+        g_type_interface_add_prerequisite (type, G_TYPE_OBJECT);
+    }
+
+    return type;
+}
+
+/**
+ * caja_configurable_run:
+ * @provider: a #CajaConfigurable
+ */
+void
+caja_configurable_run_config (CajaConfigurable *provider)
+{
+    if (!CAJA_IS_CONFIGURABLE(provider)) {
+        return;
+    }
+
+    if (CAJA_CONFIGURABLE_GET_IFACE (provider)->run_config) {
+        CAJA_CONFIGURABLE_GET_IFACE (provider)->run_config(provider);
+    }
+}
+
+

--- a/libcaja-extension/caja-configurable.h
+++ b/libcaja-extension/caja-configurable.h
@@ -1,0 +1,68 @@
+/*
+ *  caja-configurable.c - Interface for configuration
+ *
+ *  Copyright (C) 2003 Novell, Inc.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  Author: 20kdc <gamemanj@hotmail.co.uk>
+ *  Based on caja-menu-provider.h by Dave Camp <dave@ximian.com>
+ *
+ */
+
+/* This interface is implemented by Caja extensions that want to
+ * have configuration screens (this is particularly important for open-terminal)
+ */
+
+#ifndef CAJA_CONFIGURABLE_H
+#define CAJA_CONFIGURABLE_H
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+#include "caja-extension-types.h"
+#include "caja-file-info.h"
+#include "caja-menu.h"
+
+G_BEGIN_DECLS
+
+#define CAJA_TYPE_CONFIGURABLE           (caja_configurable_get_type ())
+#define CAJA_CONFIGURABLE(obj)           (G_TYPE_CHECK_INSTANCE_CAST ((obj), CAJA_TYPE_CONFIGURABLE, CajaConfigurable))
+#define CAJA_IS_CONFIGURABLE(obj)        (G_TYPE_CHECK_INSTANCE_TYPE ((obj), CAJA_TYPE_CONFIGURABLE))
+#define CAJA_CONFIGURABLE_GET_IFACE(obj) (G_TYPE_INSTANCE_GET_INTERFACE ((obj), CAJA_TYPE_CONFIGURABLE, CajaConfigurableIface))
+
+typedef struct _CajaConfigurable       CajaConfigurable;
+typedef struct _CajaConfigurableIface  CajaConfigurableIface;
+
+/**
+ * CajaConfigurableIface:
+ * @g_iface: The parent interface.
+ * @run: Starts the configuration panel (should use g_dialog_run)
+ *
+ * Interface for extensions to provide additional menu items.
+ */
+
+struct _CajaConfigurableIface {
+    GTypeInterface g_iface;
+
+    void (*run_config) (CajaConfigurable *provider);
+};
+
+/* Interface Functions */
+GType caja_configurable_get_type   (void);
+void  caja_configurable_run_config (CajaConfigurable *provider);
+
+G_END_DECLS
+
+#endif


### PR DESCRIPTION
This commit just creates a 'CajaConfigurable' interface for extensions to implement, so that things like open-terminal can have configuration UIs.

A particular use-case is open-terminal, which is rather configurable, but this configuration is all hidden, leading to the problem of hidden settings that can make the extension unusable in some cases.

This shouldn't affect any localizable strings, as it just makes existing UI call a function if available.

The reason I added a second signal handler to the extensions list for the separate button is because passing two buttons in various other ways seems simply more likely to cause memory leaks (that said, if there's a better solution, I'll modify the PR accordingly).

I tested this by adding the interface to an extension with a debug-print-stub (so not a full test. This said, it's meant to act somewhat like the About dialog in being an inner g\_dialog\_run, so this shouldn't be too much trouble), and having another extension installed to check the configuration-not-supported case.

IDK if I'll end up PRing an open-terminal configurator later, but this'll be an interface for whoever does.