### PR TITLE
Backport verify_destination from Nautilus - Symlink and freespace fixes

### DIFF
--- a/libcaja-private/caja-file-utilities.c
+++ b/libcaja-private/caja-file-utilities.c
@@ -1217,6 +1217,53 @@ caja_restore_files_from_trash (GList *files,
     caja_file_list_unref (unhandled_files);
 }
 
+GMount *
+caja_get_mounted_mount_for_root (GFile *location)
+{
+    g_autoptr (GVolumeMonitor) volume_monitor = NULL;
+    GList *mounts;
+    GList *l;
+    GMount *mount;
+    GMount *result = NULL;
+    GFile *root = NULL;
+    GFile *default_location = NULL;
+
+    volume_monitor = g_volume_monitor_get ();
+    mounts = g_volume_monitor_get_mounts (volume_monitor);
+
+    for (l = mounts; l != NULL; l = l->next)
+    {
+        mount = l->data;
+
+        if (g_mount_is_shadowed (mount))
+        {
+            continue;
+        }
+
+        root = g_mount_get_root (mount);
+        if (g_file_equal (location, root))
+        {
+            result = g_object_ref (mount);
+            break;
+        }
+
+        default_location = g_mount_get_default_location (mount);
+        if (!g_file_equal (default_location, root) &&
+            g_file_equal (location, default_location))
+        {
+            result = g_object_ref (mount);
+            break;
+        }
+    }
+
+    g_clear_object (&root);
+    g_clear_object (&default_location);
+    g_list_free_full (mounts, g_object_unref);
+
+    return result;
+}
+
+
 #if !defined (CAJA_OMIT_SELF_CHECK)
 
 void


### PR DESCRIPTION
Should help with the symlink issues like #315 , #947 , #748 . This version also verifies the amount of freespace available before copy.