### PR TITLE
Backport two Nemo commits that substantially speed up opening and loading icon views

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -4517,13 +4517,15 @@ caja_file_get_icon (CajaFile *file,
 		return icon;
 	}
 
-	if (flags & CAJA_FILE_ICON_FLAGS_FORCE_THUMBNAIL_SIZE) {
-		modified_size = size * scale;
-	} else {
-		modified_size = size * scale * cached_thumbnail_size / CAJA_ICON_SIZE_STANDARD;
-	}
 	if (flags & CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS &&
 	    caja_file_should_show_thumbnail (file)) {
+
+		if (flags & CAJA_FILE_ICON_FLAGS_FORCE_THUMBNAIL_SIZE) {
+			modified_size = size * scale;
+			} else {
+			modified_size = size * scale * cached_thumbnail_size / CAJA_ICON_SIZE_STANDARD;
+		}
+
 		if (file->details->thumbnail) {
 			int w, h, s;
 			double thumb_scale;
@@ -4595,10 +4597,6 @@ caja_file_get_icon (CajaFile *file,
 
 	if (gicon) {
 		icon = caja_icon_info_lookup (gicon, size, scale);
-		if (caja_icon_info_is_fallback (icon)) {
-			g_object_unref (icon);
-			icon = caja_icon_info_lookup (get_default_file_icon (flags), size, scale);
-		}
 		g_object_unref (gicon);
 		return icon;
 	} else {

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -88,9 +88,9 @@
 #include <libmate-desktop/mate-desktop-utils.h>
 
 /* Minimum starting update inverval */
-#define UPDATE_INTERVAL_MIN 100
+#define UPDATE_INTERVAL_MIN 50
 /* Maximum update interval */
-#define UPDATE_INTERVAL_MAX 2000
+#define UPDATE_INTERVAL_MAX 2050
 /* Amount of miliseconds the update interval is increased */
 #define UPDATE_INTERVAL_INC 250
 /* Interval at which the update interval is increased */


### PR DESCRIPTION
Backport these two Nemo commits to Caja:

https://github.com/linuxmint/nemo/commit/61368e3fc33c0d662f45731d6bbb2a28fc5023ca
nemo-view.c: Decrease minimum update interval. 

https://github.com/linuxmint/nemo/commit/98843e26b48cd3526cacfe90cfa4ba201d1f3aee
nemo-icon-info: Optimize icon lookups by GIcon.

Each of these significantly sped up Nemo in test benchmarks (shown in the commit comments and copied into commit comments in this PR), and my own testing in Caja bears out the speed improvements.

Fixes https://github.com/mate-desktop/caja/issues/1060