### PR TITLE
Update caja manpage with info about "--force-desktop" option

### DIFF
--- a/docs/caja.1
+++ b/docs/caja.1
@@ -35,6 +35,9 @@ Only create windows for explicitly specified URIs.
 \fB\-\-no\-desktop\fR
 Do not manage the desktop (ignore the preference set in the preferences dialog).
 .TP
+\fB\-\-force\-desktop\fR
+Manage the desktop regardless of set preferences or environment (on new startup only)
+.TP
 \fB\-q, \-\-quit\fR
 Quit Caja.
 .TP


### PR DESCRIPTION
The commit https://github.com/mate-desktop/caja/commit/9e5ea15d104720cfee752c193b77f8b03558c6b9 added a --force-desktop option, but not updated the manpage. Fix it.
