### PR TITLE
caja-application.c: Remove redundant empty lines

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -114,10 +114,7 @@ struct _CajaApplicationPriv {
     gchar *geometry;
 };
 
-
-
 GList *
-
 caja_application_get_spatial_window_list (void)
 {
     return caja_application_spatial_window_list;


### PR DESCRIPTION
There are some redundant empty lines in caja-application.c. Remove it.