### PR TITLE
Backport permission fixes

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -555,7 +555,7 @@ modify_link_hash_table (CajaFile *file,
 	GList **list_ptr;
 
 	/* Check if there is a symlink name. If none, we are OK. */
-	if (file->details->symlink_name == NULL) {
+	if (file->details->symlink_name == NULL || !caja_file_is_symbolic_link (file)) {
 		return;
 	}
 

--- a/src/caja-connect-server-dialog.c
+++ b/src/caja-connect-server-dialog.c
@@ -1227,6 +1227,12 @@ caja_connect_server_dialog_fill_details_async (CajaConnectServerDialog *self,
 			g_mount_operation_set_password (G_MOUNT_OPERATION (operation),
 							str);
 			set_flags ^= G_ASK_PASSWORD_NEED_PASSWORD;
+			
+			if (flags & G_ASK_PASSWORD_SAVING_SUPPORTED &&
+			    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (self->details->remember_checkbox))) {
+				g_mount_operation_set_password_save (G_MOUNT_OPERATION (operation),
+								     G_PASSWORD_SAVE_PERMANENTLY);
+			}
 
 			self->details->last_password_set = TRUE;
 		}

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -3611,7 +3611,7 @@ initial_permission_state_consistent (FMPropertiesWindow *window,
 			first_permissions = permissions;
 			first = FALSE;
 
-		} else if ((permissions & mask) != first_permissions) {
+		} else if ((permissions & mask) != (first_permissions & mask)) {
 			/* Not same permissions as first -> inconsistent */
 			return FALSE;
 		}


### PR DESCRIPTION
This cleans up commits from #1058 so that they preserve the log history

May fix the following issus (according to the original PR, yet to be tested)
* #1019 
* #954 
* #421 
