### PR TITLE
Fix case-insensitive in running_in_mate

### DIFF
--- a/libegg/eggsmclient.c
+++ b/libegg/eggsmclient.c
@@ -57,8 +57,8 @@ static gboolean
 running_in_mate (void)
 {
     return (g_strcmp0 (g_getenv ("XDG_CURRENT_DESKTOP"), "MATE") == 0)
-        || (g_strcmp0 (g_getenv ("XDG_SESSION_DESKTOP"), "MATE") == 0)
-        || (g_strcmp0 (g_getenv ("DESKTOP_SESSION"), "MATE") == 0);
+        || (g_strcmp0 (g_getenv ("XDG_SESSION_DESKTOP"), "mate") == 0)
+        || (g_strcmp0 (g_getenv ("DESKTOP_SESSION"), "mate") == 0);
 }
 
 static void

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -2041,8 +2041,8 @@ static gboolean
 running_in_mate (void)
 {
     return (g_strcmp0 (g_getenv ("XDG_CURRENT_DESKTOP"), "MATE") == 0)
-        || (g_strcmp0 (g_getenv ("XDG_SESSION_DESKTOP"), "MATE") == 0)
-        || (g_strcmp0 (g_getenv ("DESKTOP_SESSION"), "MATE") == 0);
+        || (g_strcmp0 (g_getenv ("XDG_SESSION_DESKTOP"), "mate") == 0)
+        || (g_strcmp0 (g_getenv ("DESKTOP_SESSION"), "mate") == 0);
 }
 
 static gboolean

--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -220,8 +220,8 @@ static gboolean
 running_in_mate (void)
 {
     return (g_strcmp0 (g_getenv ("XDG_CURRENT_DESKTOP"), "MATE") == 0)
-        || (g_strcmp0 (g_getenv ("XDG_SESSION_DESKTOP"), "MATE") == 0)
-        || (g_strcmp0 (g_getenv ("DESKTOP_SESSION"), "MATE") == 0);
+        || (g_strcmp0 (g_getenv ("XDG_SESSION_DESKTOP"), "mate") == 0)
+        || (g_strcmp0 (g_getenv ("DESKTOP_SESSION"), "mate") == 0);
 }
 
 static gboolean


### PR DESCRIPTION
The environment variable XDG_SESSION_DESKTOP and DESKTOP_SESSION in
running_in_mate are compared using g_strcmp0. Actually the environment
variable in MATE DE is "mate"(lower case). Using g_ascii_strcasecmp
instead of g_strcmp0 to fix it.

The XDG_SESSION_DESKTOP and DESKTOP_SESSION are set here:
https://github.com/CanonicalLtd/lightdm/blob/7241fd81c0dfcbe354f2c9bc4ace04088de5d860/src/seat.c#L979

export:
[root@localhost]# export |grep XDG_SESSION_DESKTOP
declare -x XDG_SESSION_DESKTOP="mate"

[root@localhost]# export |grep DESKTOP_SESSION
declare -x DESKTOP_SESSION="mate"
