### PR TITLE
Fix crash on umounting remote network shares

### DIFF
--- a/libcaja-private/caja-bookmark.c
+++ b/libcaja-private/caja-bookmark.c
@@ -530,8 +530,11 @@ caja_bookmark_connect_file (CajaBookmark *bookmark)
     if (!caja_bookmark_uri_known_not_to_exist (bookmark))
     {
         bookmark->details->file = caja_file_get (bookmark->details->location);
-        g_assert (!caja_file_is_gone (bookmark->details->file));
+        /*Catch the case of removing a remote mount triggering this code block*/
+        if(caja_file_is_gone (bookmark->details->file))
+            return;
 
+        /*g_assert (!caja_file_is_gone (bookmark->details->file));  assert is now redundant*/
         g_signal_connect_object (bookmark->details->file, "changed",
                                  G_CALLBACK (bookmark_file_changed_callback), bookmark, 0);
     }


### PR DESCRIPTION
fix regression from https://github.com/mate-desktop/caja/commit/8fff655552209fd181f9608d02d0f72660b10768 that caused unmounting network shares