### PR TITLE
Alternative fix for crash on umounting remote network shares

### DIFF
--- a/libcaja-private/caja-bookmark.c
+++ b/libcaja-private/caja-bookmark.c
@@ -530,7 +530,14 @@ caja_bookmark_connect_file (CajaBookmark *bookmark)
     if (!caja_bookmark_uri_known_not_to_exist (bookmark))
     {
         bookmark->details->file = caja_file_get (bookmark->details->location);
-        g_assert (!caja_file_is_gone (bookmark->details->file));
+        /* Similar to what we do when a file has been trashed or deleted
+         * withouth noticing in bookmark_changed, just try to fall graciously.
+         */
+        if (caja_file_is_gone (bookmark->details->file))
+          {
+                caja_bookmark_disconnect_file (bookmark);
+                return;
+          }
 
         g_signal_connect_object (bookmark->details->file, "changed",
                                  G_CALLBACK (bookmark_file_changed_callback), bookmark, 0);

--- a/src/caja-window-menus.c
+++ b/src/caja-window-menus.c
@@ -1092,6 +1092,7 @@ add_extension_menu_items (CajaWindow *window,
             caja_menu_item_list_free (children);
             g_free (subdir);
         }
+        g_object_unref (action);
     }
 }
 


### PR DESCRIPTION
This is an alternative for https://github.com/mate-desktop/caja/pull/1074
First commit fixes the regression causes by 8fff655 .
Second commit fixes a similar crash in nautilus if mounting the unmounted drive again, with same error message.
```
ERROR:caja-bookmark.c:533:caja_bookmark_connect_file: assertion failed: (!caja_file_is_gone (bookmark->details->file))
````
See here for details.
https://bugs.launchpad.net/nautilus/+bug/1202159
https://bugzilla.gnome.org/show_bug.cgi?id=708282#c1
https://bugzilla.redhat.com/show_bug.cgi?id=1254161
Not sure if we really need the second one and we can remove them from PR for safety if you don't agree.

Please test.
