### PR TITLE
Simpler fix for crash on umounting remote network shares, keeps any bookmarks from them valid

### DIFF
--- a/libcaja-private/caja-monitor.c
+++ b/libcaja-private/caja-monitor.c
@@ -154,13 +154,13 @@ caja_monitor_directory (GFile *location)
     if (dir_monitor != NULL) {
         ret->monitor = dir_monitor;
     }
-
+    /*This caused a crash on umounting remote shares
     else if (!g_file_is_native (location)) {
         ret->mount = caja_get_mounted_mount_for_root (location);
         ret->location = g_object_ref (location);
         ret->volume_monitor = g_volume_monitor_get ();
     }
-
+    */
     if (ret->monitor != NULL) {
         g_signal_connect (ret->monitor, "changed",
                   G_CALLBACK (dir_changed), ret);


### PR DESCRIPTION
Don't treat remote filesystems differently when unmounting, so that bookmarks can remount them if they are available and so caja does not crash.

An alternative to 
https://github.com/mate-desktop/caja/pull/1075
and to
https://github.com/mate-desktop/caja/pull/1074