### PR TITLE
Fix segfault on stopping USB hard drives

### DIFF
--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -2548,7 +2548,7 @@ drive_stop_cb (GObject *source_object,
     g_object_unref (window);
 
     error = NULL;
-    if (!g_drive_poll_for_media_finish (G_DRIVE (source_object), res, &error))
+    if (!g_drive_stop_finish(G_DRIVE (source_object), res, &error))
     {
         if (error->code != G_IO_ERROR_FAILED_HANDLED)
         {

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -1899,7 +1899,7 @@ drive_start_from_bookmark_cb (GObject      *source_object,
     char *name;
 
     error = NULL;
-    if (!g_drive_poll_for_media_finish (G_DRIVE (source_object), res, &error))
+    if (!g_drive_start_finish (G_DRIVE (source_object), res, &error))
     {
         if (error->code != G_IO_ERROR_FAILED_HANDLED)
         {
@@ -2488,7 +2488,7 @@ drive_start_cb (GObject      *source_object,
     char *name;
 
     error = NULL;
-    if (!g_drive_poll_for_media_finish (G_DRIVE (source_object), res, &error))
+    if (!g_drive_start_finish (G_DRIVE (source_object), res, &error))
     {
         if (error->code != G_IO_ERROR_FAILED_HANDLED)
         {


### PR DESCRIPTION
Fix https://github.com/mate-desktop/caja/issues/1046
drive_stop_cb should never have used g_drive_poll_for_media_finish which is for
ejectable media in a fixed drive (e.g CD drive) and not for stopping a removable drive

See
https://developer.gnome.org/gio/stable/GDrive.html
https://developer.gnome.org/gio/stable/GDrive.html#g-drive-stop-finish