### PR TITLE
[libcaja-private] Re-check file MIME type before picking an application.

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -2555,6 +2555,24 @@ caja_file_update_info (CajaFile *file,
 	return update_info_internal (file, info, FALSE);
 }
 
+void
+caja_file_refresh_info (CajaFile *file)
+{
+	GFile *gfile;
+	GFileInfo *new_info;
+
+	gfile = caja_file_get_location (file);
+	new_info = g_file_query_info (gfile, CAJA_FILE_DEFAULT_ATTRIBUTES,
+	                              G_FILE_QUERY_INFO_NONE, NULL, NULL);
+	if (new_info != NULL) {
+		if (caja_file_update_info (file, new_info)) {
+			caja_file_changed (file);
+		}
+		g_object_unref (new_info);
+	}
+	g_object_unref (gfile);
+}
+
 static gboolean
 update_name_internal (CajaFile *file,
 		      const char *name,

--- a/libcaja-private/caja-file.h
+++ b/libcaja-private/caja-file.h
@@ -144,6 +144,12 @@ void                    caja_file_monitor_add                       (CajaFile   
 void                    caja_file_monitor_remove                    (CajaFile                   *file,
         gconstpointer                   client);
 
+/* Synchronously refreshes file info from disk.
+ * This can call caja_file_changed, so don't call this function from any
+ * of the callbacks for that event.
+ */
+void                     caja_file_refresh_info                     (CajaFile                   *file);
+
 /* Waiting for data that's read asynchronously.
  * This interface currently works only for metadata, but could be expanded
  * to other attributes as well.

--- a/libcaja-private/caja-mime-actions.c
+++ b/libcaja-private/caja-mime-actions.c
@@ -997,6 +997,12 @@ make_activation_parameters (GList *uris,
         uri = l->data;
         file = caja_file_get_by_uri (uri);
 
+        /* Double-check if a file's MIME type has changed before we commit to a
+           choice of application for it. This can happen if, for instance, file
+           was originally created with 0 bytes and then content was added to it
+           later-- it will change from plaintext to something else. */
+        caja_file_refresh_info (file);
+
         app = caja_mime_get_default_application_for_file (file);
         if (app != NULL)
         {

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -8813,6 +8813,13 @@ real_update_menus (FMDirectoryView *view)
 
 		file = CAJA_FILE (l->data);
 
+		/* Double-check if the files' MIME types have changed before we
+		   commit to a choice of applications for them. This can happen
+		   if, for instance, a file was originally created with 0 bytes
+		   and then content was added to it later-- it will change from
+		   plaintext to something else. */
+		caja_file_refresh_info (file);
+
 		if (!caja_mime_file_opens_in_external_app (file)) {
 			show_app = FALSE;
 		}


### PR DESCRIPTION
An example of when the MIME type might change: a file is initially created
with 0 bytes of content, but more data is added later. Empty files are always
detected as plain text, but the file might not be empty anymore when the user
opens it.

I encounter this daily when I start downloading a youtube video using youtube-dl, and I want to double-click on the .part file to start watching it before it's done downloading.

I developed this against MATE 1.20 since that's what I'm running on my computer. Didn't feel comfortable submitting a PR against a version of MATE that I didn't personally test.