### PR TITLE
Avoid deprecated g_type_class_add_private

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -38,8 +38,6 @@
 #include <stdio.h>
 #include <libcaja-private/caja-global-preferences.h>
 
-G_DEFINE_TYPE (EelBackground, eel_background, G_TYPE_OBJECT);
-
 enum
 {
     APPEARANCE_CHANGED,
@@ -50,7 +48,7 @@ enum
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-struct EelBackgroundDetails
+struct EelBackgroundPrivate
 {
     GtkWidget *widget;
     GtkWidget *front_widget;
@@ -81,6 +79,9 @@ struct EelBackgroundDetails
 };
 
 static GList *desktop_bg_objects = NULL;
+
+G_DEFINE_TYPE_WITH_CODE (EelBackground, eel_background, G_TYPE_OBJECT,
+                         G_ADD_PRIVATE (EelBackground))
 
 static void
 free_fade (EelBackground *self)
@@ -794,17 +795,12 @@ eel_background_class_init (EelBackgroundClass *klass)
                       NULL, NULL, g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
 
     object_class->finalize = eel_background_finalize;
-
-    g_type_class_add_private (klass, sizeof (EelBackgroundDetails));
 }
 
 static void
 eel_background_init (EelBackground *self)
 {
-    self->details =
-          G_TYPE_INSTANCE_GET_PRIVATE (self,
-        			       EEL_TYPE_BACKGROUND,
-        			       EelBackgroundDetails);
+    self->details = eel_background_get_instance_private(self);
 
     self->details->bg = mate_bg_new ();
     self->details->default_color.red = 1.0;

--- a/eel/eel-background.h
+++ b/eel/eel-background.h
@@ -126,12 +126,12 @@ void			    eel_bg_load_from_system_gsettings    (EelBackground   *self,
 void                        eel_background_set_active            (EelBackground   *self,
         							  gboolean         is_active);
 
-typedef struct EelBackgroundDetails EelBackgroundDetails;
+typedef struct EelBackgroundPrivate EelBackgroundPrivate;
 
 struct EelBackground
 {
     GObject object;
-    EelBackgroundDetails *details;
+    EelBackgroundPrivate *details;
 };
 
 struct EelBackgroundClass

--- a/eel/eel-image-table.c
+++ b/eel/eel-image-table.c
@@ -40,7 +40,7 @@ enum
 };
 
 /* Detail member struct */
-struct EelImageTableDetails
+struct EelImageTablePrivate
 {
     GtkWidget *child_under_pointer;
     GtkWidget *child_being_pressed;
@@ -85,16 +85,15 @@ static int     ancestor_button_release_event        (GtkWidget          *widget,
         GdkEventButton     *event,
         gpointer            event_data);
 
-G_DEFINE_TYPE (EelImageTable, eel_image_table, EEL_TYPE_WRAP_TABLE)
+G_DEFINE_TYPE_WITH_CODE (EelImageTable, eel_image_table, EEL_TYPE_WRAP_TABLE,
+                         G_ADD_PRIVATE (EelImageTable))
 
 static void
 eel_image_table_init (EelImageTable *image_table)
 {
     gtk_widget_set_has_window (GTK_WIDGET (image_table), FALSE);
 
-    image_table->details = G_TYPE_INSTANCE_GET_PRIVATE (image_table,
-    							EEL_TYPE_IMAGE_TABLE,
-    							EelImageTableDetails);
+    image_table->details = eel_image_table_get_instance_private (image_table);
 }
 
 /* GObjectClass methods */
@@ -292,7 +291,6 @@ eel_image_table_class_init (EelImageTableClass *image_table_class)
                                          GTK_TYPE_WIDGET,
                                          G_TYPE_POINTER);
 
-    g_type_class_add_private (image_table_class, sizeof (EelImageTableDetails));
 }
 
 static void

--- a/eel/eel-image-table.h
+++ b/eel/eel-image-table.h
@@ -45,7 +45,7 @@ extern "C" {
 
     typedef struct EelImageTable		EelImageTable;
     typedef struct EelImageTableClass	EelImageTableClass;
-    typedef struct EelImageTableDetails	EelImageTableDetails;
+    typedef struct EelImageTablePrivate	EelImageTablePrivate;
 
     typedef struct
     {
@@ -62,7 +62,7 @@ extern "C" {
         EelWrapTable wrap_table;
 
         /* Private things */
-        EelImageTableDetails *details;
+        EelImageTablePrivate *details;
     };
 
     struct EelImageTableClass

--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -66,7 +66,7 @@ enum
 };
 
 /* Detail member struct */
-struct EelLabeledImageDetails
+struct EelLabeledImagePrivate
 {
     GtkWidget *image;
     GtkWidget *label;
@@ -104,16 +104,15 @@ static gboolean      labeled_image_show_image             (const EelLabeledImage
 
 static guint labeled_image_signals[LAST_SIGNAL] = { 0 };
 
-G_DEFINE_TYPE (EelLabeledImage, eel_labeled_image, GTK_TYPE_CONTAINER)
+G_DEFINE_TYPE_WITH_CODE (EelLabeledImage, eel_labeled_image, GTK_TYPE_CONTAINER,
+                         G_ADD_PRIVATE (EelLabeledImage))
 
 static void
 eel_labeled_image_init (EelLabeledImage *labeled_image)
 {
     gtk_widget_set_has_window (GTK_WIDGET (labeled_image), FALSE);
 
-    labeled_image->details = G_TYPE_INSTANCE_GET_PRIVATE (labeled_image,
-    							  EEL_TYPE_LABELED_IMAGE,
-    							  EelLabeledImageDetails);
+    labeled_image->details = eel_labeled_image_get_instance_private (labeled_image);
     labeled_image->details->show_label = TRUE;
     labeled_image->details->show_image = TRUE;
     labeled_image->details->label_position = GTK_POS_BOTTOM;
@@ -668,7 +667,6 @@ eel_labeled_image_class_init (EelLabeledImageClass *labeled_image_class)
                               FALSE,
                               G_PARAM_READWRITE));
 
-    g_type_class_add_private (labeled_image_class, sizeof (EelLabeledImageDetails));
 }
 
 /* Private EelLabeledImage methods */

--- a/eel/eel-labeled-image.h
+++ b/eel/eel-labeled-image.h
@@ -68,7 +68,7 @@ extern "C" {
 
     typedef struct EelLabeledImage		  EelLabeledImage;
     typedef struct EelLabeledImageClass	  EelLabeledImageClass;
-    typedef struct EelLabeledImageDetails	  EelLabeledImageDetails;
+    typedef struct EelLabeledImagePrivate	  EelLabeledImagePrivate;
 
     struct EelLabeledImage
     {
@@ -76,7 +76,7 @@ extern "C" {
         GtkContainer container;
 
         /* Private things */
-        EelLabeledImageDetails *details;
+        EelLabeledImagePrivate *details;
     };
 
     struct EelLabeledImageClass

--- a/eel/eel-wrap-table.c
+++ b/eel/eel-wrap-table.c
@@ -42,7 +42,7 @@ enum
 };
 
 /* Detail member struct */
-struct EelWrapTableDetails
+struct EelWrapTablePrivate
 {
     guint x_spacing;
     guint y_spacing;
@@ -70,16 +70,15 @@ static gboolean      wrap_table_child_focus_in           (GtkWidget           *w
 static void          wrap_table_layout                   (EelWrapTable        *wrap_table);
 
 
-G_DEFINE_TYPE (EelWrapTable, eel_wrap_table, GTK_TYPE_CONTAINER)
+G_DEFINE_TYPE_WITH_CODE (EelWrapTable, eel_wrap_table, GTK_TYPE_CONTAINER,
+                         G_ADD_PRIVATE (EelWrapTable))
 
 static void
 eel_wrap_table_init (EelWrapTable *wrap_table)
 {
     gtk_widget_set_has_window (GTK_WIDGET (wrap_table), FALSE);
 
-    wrap_table->details = G_TYPE_INSTANCE_GET_PRIVATE (wrap_table,
-    						       EEL_TYPE_WRAP_TABLE,
-    						       EelWrapTableDetails);
+    wrap_table->details = eel_wrap_table_get_instance_private (wrap_table);
     wrap_table->details->x_justification = EEL_JUSTIFICATION_BEGINNING;
     wrap_table->details->y_justification = EEL_JUSTIFICATION_END;
     wrap_table->details->cols = 1;
@@ -485,7 +484,6 @@ eel_wrap_table_class_init (EelWrapTableClass *wrap_table_class)
      g_param_spec_boolean ("homogeneous", NULL, NULL,
                            FALSE, G_PARAM_READWRITE));
 
-    g_type_class_add_private (wrap_table_class, sizeof (EelWrapTableDetails));
 }
 
 /* Private EelWrapTable methods */

--- a/eel/eel-wrap-table.h
+++ b/eel/eel-wrap-table.h
@@ -46,7 +46,7 @@ extern "C" {
 
     typedef struct EelWrapTable	       EelWrapTable;
     typedef struct EelWrapTableClass       EelWrapTableClass;
-    typedef struct EelWrapTableDetails     EelWrapTableDetails;
+    typedef struct EelWrapTablePrivate     EelWrapTablePrivate;
 
     struct EelWrapTable
     {
@@ -54,7 +54,7 @@ extern "C" {
         GtkContainer container;
 
         /* Private things */
-        EelWrapTableDetails *details;
+        EelWrapTablePrivate *details;
     };
 
     struct EelWrapTableClass

--- a/libegg/eggsmclient.c
+++ b/libegg/eggsmclient.c
@@ -48,7 +48,8 @@ struct _EggSMClientPrivate
 
 #define EGG_SM_CLIENT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), EGG_TYPE_SM_CLIENT, EggSMClientPrivate))
 
-G_DEFINE_TYPE (EggSMClient, egg_sm_client, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_CODE (EggSMClient, egg_sm_client, G_TYPE_OBJECT,
+                         G_ADD_PRIVATE (EggSMClient))
 
 static EggSMClient *global_client;
 static EggSMClientMode global_client_mode = EGG_SM_CLIENT_MODE_NORMAL;
@@ -71,8 +72,6 @@ static void
 egg_sm_client_class_init (EggSMClientClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-    g_type_class_add_private (klass, sizeof (EggSMClientPrivate));
 
     /**
      * EggSMClient::save_state:
@@ -413,7 +412,7 @@ egg_sm_client_is_resumed (EggSMClient *client)
 GKeyFile *
 egg_sm_client_get_state_file (EggSMClient *client)
 {
-    EggSMClientPrivate *priv = EGG_SM_CLIENT_GET_PRIVATE (client);
+    EggSMClientPrivate *priv = egg_sm_client_get_instance_private (client);
     char *state_file_path;
     GError *err = NULL;
 


### PR DESCRIPTION
With minimal changes to avoid deprecated g_type_class_add_private.