### PR TITLE
configure.ac: Add check for PKG_CONFIG being set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,11 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AM_DISABLE_STATIC
 AM_PROG_LIBTOOL
-AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+PKG_PROG_PKG_CONFIG
+dnl Give error and exit if we dont have pkgconfig
+if test "x$PKG_CONFIG" = "x"; then
+  AC_MSG_ERROR([you need to have pkgconfig installed!])
+fi
 
 AC_CHECK_LIB(m, floor)
 


### PR DESCRIPTION
Add check for PKG_CONFIG being set.

Author: @sunweaver 

not sure how to test this PR, I just open this with the debian patch:

https://salsa.debian.org/debian-mate-team/caja/blob/debian/1.20.3-1/debian/patches/1001_use-correct-macros-to-cross-build.patch