### PR TITLE
Avoid deprecated g_type_class_add_private

### DIFF
--- a/src/caja-connect-server-dialog.c
+++ b/src/caja-connect-server-dialog.c
@@ -45,7 +45,7 @@
  * - NetworkManager integration
  */
 
-struct _CajaConnectServerDialogDetails
+struct _CajaConnectServerDialogPrivate
 {
     CajaApplication *application;
 
@@ -79,7 +79,7 @@ struct _CajaConnectServerDialogDetails
     gboolean should_destroy;
 };
 
-G_DEFINE_TYPE (CajaConnectServerDialog, caja_connect_server_dialog,
+G_DEFINE_TYPE_WITH_PRIVATE (CajaConnectServerDialog, caja_connect_server_dialog,
 	       GTK_TYPE_DIALOG)
 
 static void sensitive_entry_changed_callback (GtkEditable *editable,
@@ -851,8 +851,7 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
     gchar *str;
     int i;
 
-    dialog->details = G_TYPE_INSTANCE_GET_PRIVATE (dialog, CAJA_TYPE_CONNECT_SERVER_DIALOG,
-						   CajaConnectServerDialogDetails);
+    dialog->details = caja_connect_server_dialog_get_instance_private (dialog);
 
     content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
 
@@ -1167,8 +1166,6 @@ caja_connect_server_dialog_class_init (CajaConnectServerDialogClass *class)
 
 	oclass = G_OBJECT_CLASS (class);
 	oclass->finalize = caja_connect_server_dialog_finalize;
-
-	g_type_class_add_private (class, sizeof (CajaConnectServerDialogDetails));
 }
 
 GtkWidget *

--- a/src/caja-connect-server-dialog.h
+++ b/src/caja-connect-server-dialog.h
@@ -42,12 +42,12 @@
 
 typedef struct _CajaConnectServerDialog CajaConnectServerDialog;
 typedef struct _CajaConnectServerDialogClass CajaConnectServerDialogClass;
-typedef struct _CajaConnectServerDialogDetails CajaConnectServerDialogDetails;
+typedef struct _CajaConnectServerDialogPrivate CajaConnectServerDialogPrivate;
 
 struct _CajaConnectServerDialog
 {
     GtkDialog parent;
-    CajaConnectServerDialogDetails *details;
+    CajaConnectServerDialogPrivate *details;
 };
 
 struct _CajaConnectServerDialogClass

--- a/src/caja-navigation-window.c
+++ b/src/caja-navigation-window.c
@@ -88,7 +88,7 @@ static void use_extra_mouse_buttons_changed          (gpointer                  
 static CajaWindowSlot *create_extra_pane         (CajaNavigationWindow *window);
 
 
-G_DEFINE_TYPE (CajaNavigationWindow, caja_navigation_window, CAJA_TYPE_WINDOW)
+G_DEFINE_TYPE_WITH_PRIVATE (CajaNavigationWindow, caja_navigation_window, CAJA_TYPE_WINDOW)
 #define parent_class caja_navigation_window_parent_class
 
 static const struct
@@ -115,7 +115,7 @@ caja_navigation_window_init (CajaNavigationWindow *window)
 
     win = CAJA_WINDOW (window);
 
-    window->details = G_TYPE_INSTANCE_GET_PRIVATE (window, CAJA_TYPE_NAVIGATION_WINDOW, CajaNavigationWindowDetails);
+    window->details = caja_navigation_window_get_instance_private (window);
 
     GtkStyleContext *context;
 
@@ -1285,8 +1285,6 @@ caja_navigation_window_class_init (CajaNavigationWindowClass *class)
 
     CAJA_WINDOW_CLASS (class)->open_slot = real_open_slot;
     CAJA_WINDOW_CLASS (class)->close_slot = real_close_slot;
-
-    g_type_class_add_private (G_OBJECT_CLASS (class), sizeof (CajaNavigationWindowDetails));
 
     g_signal_connect_swapped (caja_preferences,
                               "changed::" CAJA_PREFERENCES_MOUSE_BACK_BUTTON,

--- a/src/caja-navigation-window.h
+++ b/src/caja-navigation-window.h
@@ -53,14 +53,14 @@
 
 typedef struct _CajaNavigationWindow        CajaNavigationWindow;
 typedef struct _CajaNavigationWindowClass   CajaNavigationWindowClass;
-typedef struct _CajaNavigationWindowDetails CajaNavigationWindowDetails;
+typedef struct _CajaNavigationWindowPrivate CajaNavigationWindowPrivate;
 
 
 struct _CajaNavigationWindow
 {
     CajaWindow parent_object;
 
-    CajaNavigationWindowDetails *details;
+    CajaNavigationWindowPrivate *details;
 
     /** UI stuff **/
     CajaSidePane *sidebar;

--- a/src/caja-property-browser.c
+++ b/src/caja-property-browser.c
@@ -66,7 +66,7 @@ typedef enum
     CAJA_PROPERTY_EMBLEM
 } CajaPropertyType;
 
-struct CajaPropertyBrowserDetails
+struct _CajaPropertyBrowserPrivate
 {
     GtkWidget *container;
 
@@ -194,7 +194,7 @@ static GtkTargetEntry drag_types[] =
 };
 
 
-G_DEFINE_TYPE (CajaPropertyBrowser, caja_property_browser, GTK_TYPE_WINDOW)
+G_DEFINE_TYPE_WITH_PRIVATE (CajaPropertyBrowser, caja_property_browser, GTK_TYPE_WINDOW)
 
 
 /* Destroy the three dialogs for adding patterns/colors/emblems if any of them
@@ -253,8 +253,6 @@ caja_property_browser_class_init (CajaPropertyBrowserClass *klass)
     widget_class->drag_begin = caja_property_browser_drag_begin;
     widget_class->drag_data_get  = caja_property_browser_drag_data_get;
     widget_class->drag_end  = caja_property_browser_drag_end;
-
-    g_type_class_add_private (klass, sizeof (CajaPropertyBrowserDetails));
 }
 
 /* initialize the instance's fields, create the necessary subviews, etc. */
@@ -270,9 +268,7 @@ caja_property_browser_init (CajaPropertyBrowser *property_browser)
 
     widget = GTK_WIDGET (property_browser);
 
-    property_browser->details = G_TYPE_INSTANCE_GET_PRIVATE (property_browser,
-    							     CAJA_TYPE_PROPERTY_BROWSER,
-    							     CajaPropertyBrowserDetails);
+    property_browser->details = caja_property_browser_get_instance_private (property_browser);
 
     property_browser->details->category = g_strdup ("patterns");
     property_browser->details->category_type = CAJA_PROPERTY_PATTERN;

--- a/src/caja-property-browser.h
+++ b/src/caja-property-browser.h
@@ -49,12 +49,12 @@ typedef struct CajaPropertyBrowserClass  CajaPropertyBrowserClass;
 #define CAJA_PROPERTY_BROWSER_GET_CLASS(obj) \
   (G_TYPE_INSTANCE_GET_CLASS ((obj), CAJA_TYPE_PROPERTY_BROWSER, CajaPropertyBrowserClass))
 
-typedef struct CajaPropertyBrowserDetails CajaPropertyBrowserDetails;
+typedef struct _CajaPropertyBrowserPrivate CajaPropertyBrowserPrivate;
 
 struct CajaPropertyBrowser
 {
     GtkWindow window;
-    CajaPropertyBrowserDetails *details;
+    CajaPropertyBrowserPrivate *details;
 };
 
 struct CajaPropertyBrowserClass

--- a/src/caja-sidebar-title.c
+++ b/src/caja-sidebar-title.c
@@ -80,7 +80,7 @@ enum
     LAST_LABEL_COLOR
 };
 
-struct CajaSidebarTitleDetails
+struct _CajaSidebarTitlePrivate
 {
     CajaFile		*file;
     guint		 file_changed_connection;
@@ -97,7 +97,7 @@ struct CajaSidebarTitleDetails
     gboolean		 determined_icon;
 };
 
-G_DEFINE_TYPE (CajaSidebarTitle, caja_sidebar_title, GTK_TYPE_BOX)
+G_DEFINE_TYPE_WITH_PRIVATE (CajaSidebarTitle, caja_sidebar_title, GTK_TYPE_BOX)
 
 static void
 style_updated (GtkWidget *widget)
@@ -116,9 +116,7 @@ style_updated (GtkWidget *widget)
 static void
 caja_sidebar_title_init (CajaSidebarTitle *sidebar_title)
 {
-    sidebar_title->details = G_TYPE_INSTANCE_GET_PRIVATE (sidebar_title,
-    							  CAJA_TYPE_SIDEBAR_TITLE,
-    							  CajaSidebarTitleDetails);
+    sidebar_title->details = caja_sidebar_title_get_instance_private (sidebar_title);
 
     gtk_orientable_set_orientation (GTK_ORIENTABLE (sidebar_title), GTK_ORIENTATION_VERTICAL);
 
@@ -220,8 +218,6 @@ caja_sidebar_title_class_init (CajaSidebarTitleClass *klass)
                                 "Color used for information text against a light background",
                                 GDK_TYPE_RGBA,
                                 G_PARAM_READABLE));
-
-    g_type_class_add_private (klass, sizeof (CajaSidebarTitleDetails));
 }
 
 /* return a new index title object */

--- a/src/caja-sidebar-title.h
+++ b/src/caja-sidebar-title.h
@@ -45,12 +45,12 @@
 #define CAJA_SIDEBAR_TITLE_GET_CLASS(obj) \
   (G_TYPE_INSTANCE_GET_CLASS ((obj), CAJA_TYPE_SIDEBAR_TITLE, CajaSidebarTitleClass))
 
-typedef struct CajaSidebarTitleDetails CajaSidebarTitleDetails;
+typedef struct _CajaSidebarTitlePrivate CajaSidebarTitlePrivate;
 
 typedef struct
 {
     GtkBox box;
-    CajaSidebarTitleDetails *details;
+    CajaSidebarTitlePrivate *details;
 } CajaSidebarTitle;
 
 typedef struct

--- a/src/caja-trash-bar.c
+++ b/src/caja-trash-bar.c
@@ -42,7 +42,7 @@ enum
     NUM_PROPERTIES
 };
 
-struct CajaTrashBarPrivate
+struct _CajaTrashBarPrivate
 {
     GtkWidget *empty_button;
     GtkWidget *restore_button;
@@ -51,7 +51,7 @@ struct CajaTrashBarPrivate
     gulong selection_handler_id;
 };
 
-G_DEFINE_TYPE (CajaTrashBar, caja_trash_bar, GTK_TYPE_BOX);
+G_DEFINE_TYPE_WITH_PRIVATE (CajaTrashBar, caja_trash_bar, GTK_TYPE_BOX);
 
 static void
 restore_button_clicked_cb (GtkWidget *button,
@@ -163,8 +163,6 @@ caja_trash_bar_class_init (CajaTrashBarClass *klass)
                                              G_PARAM_WRITABLE |
                                              G_PARAM_CONSTRUCT_ONLY |
                                              G_PARAM_STATIC_STRINGS));
-
-    g_type_class_add_private (klass, sizeof (CajaTrashBarPrivate));
 }
 
 static void
@@ -183,7 +181,7 @@ caja_trash_bar_init (CajaTrashBar *bar)
     GtkWidget *label;
     GtkWidget *hbox;
 
-    bar->priv = CAJA_TRASH_BAR_GET_PRIVATE (bar);
+    bar->priv = caja_trash_bar_get_instance_private (bar);
 
     hbox = GTK_WIDGET (bar);
 

--- a/src/caja-trash-bar.h
+++ b/src/caja-trash-bar.h
@@ -27,9 +27,7 @@
 
 #include <gtk/gtk.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 #define CAJA_TYPE_TRASH_BAR         (caja_trash_bar_get_type ())
 #define CAJA_TRASH_BAR(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), CAJA_TYPE_TRASH_BAR, CajaTrashBar))
@@ -38,27 +36,24 @@ extern "C" {
 #define CAJA_IS_TRASH_BAR_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), CAJA_TYPE_TRASH_BAR))
 #define CAJA_TRASH_BAR_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), CAJA_TYPE_TRASH_BAR, CajaTrashBarClass))
 
-    typedef struct CajaTrashBarPrivate CajaTrashBarPrivate;
+typedef struct _CajaTrashBarPrivate CajaTrashBarPrivate;
 
-    typedef struct
-    {
+typedef struct
+{
         GtkBox	box;
         CajaTrashBarPrivate *priv;
-    } CajaTrashBar;
+} CajaTrashBar;
 
-    typedef struct
-    {
-        GtkBoxClass	    parent_class;
+typedef struct
+{
+GtkBoxClass	    parent_class;
 
-    } CajaTrashBarClass;
+} CajaTrashBarClass;
 
-    GType		 caja_trash_bar_get_type	(void) G_GNUC_CONST;
+GType		 caja_trash_bar_get_type	(void) G_GNUC_CONST;
 
-    GtkWidget       *caja_trash_bar_new         (CajaWindow *window);
+GtkWidget       *caja_trash_bar_new         (CajaWindow *window);
 
-
-#ifdef __cplusplus
-}
-#endif
+G_END_DECLS
 
 #endif /* __GS_TRASH_BAR_H */

--- a/src/caja-window-private.h
+++ b/src/caja-window-private.h
@@ -40,7 +40,7 @@
 struct _CajaNavigationWindowPane;
 
 /* FIXME bugzilla.gnome.org 42575: Migrate more fields into here. */
-struct CajaWindowDetails
+struct _CajaWindowPrivate
 {
     GtkWidget *grid;
 
@@ -91,7 +91,7 @@ struct CajaWindowDetails
     gboolean initiated_unmount;
 };
 
-struct _CajaNavigationWindowDetails
+struct _CajaNavigationWindowPrivate
 {
     GtkWidget *content_paned;
     GtkWidget *content_box;

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -100,6 +100,7 @@ static void action_view_as_callback         (GtkAction               *action,
 static GList *history_list;
 
 G_DEFINE_TYPE_WITH_CODE (CajaWindow, caja_window, GTK_TYPE_WINDOW,
+                         G_ADD_PRIVATE (CajaWindow)
                          G_IMPLEMENT_INTERFACE (CAJA_TYPE_WINDOW_INFO,
                                  caja_window_info_iface_init));
 
@@ -152,7 +153,7 @@ caja_window_init (CajaWindow *window)
     }
 
     g_object_unref (provider);
-    window->details = G_TYPE_INSTANCE_GET_PRIVATE (window, CAJA_TYPE_WINDOW, CajaWindowDetails);
+    window->details = caja_window_get_instance_private (window);
 
     window->details->panes = NULL;
     window->details->active_pane = NULL;
@@ -2186,8 +2187,4 @@ caja_window_class_init (CajaWindowClass *class)
 
     class->reload = caja_window_reload;
     class->go_up = caja_window_go_up_signal;
-
-
-
-    g_type_class_add_private (G_OBJECT_CLASS (class), sizeof (CajaWindowDetails));
 }

--- a/src/caja-window.h
+++ b/src/caja-window.h
@@ -79,7 +79,7 @@ enum CajaWindowOpenSlotFlags
     CAJA_WINDOW_OPEN_SLOT_APPEND = 1
 };
 
-typedef struct CajaWindowDetails CajaWindowDetails;
+typedef struct _CajaWindowPrivate CajaWindowPrivate;
 
 typedef struct
 {
@@ -120,7 +120,7 @@ struct CajaWindow
 {
     GtkWindow parent_object;
 
-    CajaWindowDetails *details;
+    CajaWindowPrivate *details;
 
     CajaApplication *application;
 };

--- a/src/caja-zoom-action.c
+++ b/src/caja-zoom-action.c
@@ -33,16 +33,12 @@
 #include <gtk/gtk.h>
 #include <eel/eel-gtk-extensions.h>
 
-G_DEFINE_TYPE (CajaZoomAction, caja_zoom_action, GTK_TYPE_ACTION)
-
 static void caja_zoom_action_init       (CajaZoomAction *action);
 static void caja_zoom_action_class_init (CajaZoomActionClass *class);
 
 static GObjectClass *parent_class = NULL;
 
-#define CAJA_ZOOM_ACTION_GET_PRIVATE(object)(G_TYPE_INSTANCE_GET_PRIVATE ((object), CAJA_TYPE_ZOOM_ACTION, CajaZoomActionPrivate))
-
-struct CajaZoomActionPrivate
+struct _CajaZoomActionPrivate
 {
     CajaNavigationWindow *window;
 };
@@ -52,6 +48,8 @@ enum
     PROP_0,
     PROP_WINDOW
 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (CajaZoomAction, caja_zoom_action, GTK_TYPE_ACTION)
 
 static void
 zoom_changed_callback (CajaWindow *window,
@@ -199,12 +197,10 @@ caja_zoom_action_class_init (CajaZoomActionClass *class)
                                              "The navigation window",
                                              G_TYPE_OBJECT,
                                              G_PARAM_READWRITE));
-
-    g_type_class_add_private (object_class, sizeof(CajaZoomActionPrivate));
 }
 
 static void
 caja_zoom_action_init (CajaZoomAction *action)
 {
-    action->priv = CAJA_ZOOM_ACTION_GET_PRIVATE (action);
+    action->priv = caja_zoom_action_get_instance_private (action);
 }

--- a/src/caja-zoom-action.h
+++ b/src/caja-zoom-action.h
@@ -37,7 +37,7 @@
 
 typedef struct _CajaZoomAction       CajaZoomAction;
 typedef struct _CajaZoomActionClass  CajaZoomActionClass;
-typedef struct CajaZoomActionPrivate CajaZoomActionPrivate;
+typedef struct _CajaZoomActionPrivate CajaZoomActionPrivate;
 
 struct _CajaZoomAction
 {

--- a/src/caja-zoom-control.c
+++ b/src/caja-zoom-control.c
@@ -55,7 +55,7 @@ enum
     LAST_SIGNAL
 };
 
-struct CajaZoomControlDetails
+struct _CajaZoomControlPrivate
 {
     GtkWidget *zoom_in;
     GtkWidget *zoom_out;
@@ -107,7 +107,7 @@ static GType caja_zoom_control_accessible_get_type (void);
 
 #define NUM_ACTIONS ((int)G_N_ELEMENTS (caja_zoom_control_accessible_action_names))
 
-G_DEFINE_TYPE (CajaZoomControl, caja_zoom_control, GTK_TYPE_BOX);
+G_DEFINE_TYPE_WITH_PRIVATE (CajaZoomControl, caja_zoom_control, GTK_TYPE_BOX);
 
 static void
 caja_zoom_control_finalize (GObject *object)
@@ -230,7 +230,7 @@ caja_zoom_control_init (CajaZoomControl *zoom_control)
     GtkWidget *image;
     int i;
 
-    zoom_control->details = G_TYPE_INSTANCE_GET_PRIVATE (zoom_control, CAJA_TYPE_ZOOM_CONTROL, CajaZoomControlDetails);
+    zoom_control->details = caja_zoom_control_get_instance_private (zoom_control);
 
     zoom_control->details->zoom_level = CAJA_ZOOM_LEVEL_STANDARD;
     zoom_control->details->min_zoom_level = CAJA_ZOOM_LEVEL_SMALLEST;
@@ -677,8 +677,6 @@ caja_zoom_control_class_init (CajaZoomControlClass *class)
                                   "change_value",
                                   1, GTK_TYPE_SCROLL_TYPE,
                                   GTK_SCROLL_STEP_UP);
-
-    g_type_class_add_private (G_OBJECT_CLASS (class), sizeof (CajaZoomControlDetails));
 }
 
 static gboolean

--- a/src/caja-zoom-control.h
+++ b/src/caja-zoom-control.h
@@ -45,12 +45,12 @@
 
 typedef struct CajaZoomControl CajaZoomControl;
 typedef struct CajaZoomControlClass CajaZoomControlClass;
-typedef struct CajaZoomControlDetails CajaZoomControlDetails;
+typedef struct _CajaZoomControlPrivate CajaZoomControlPrivate;
 
 struct CajaZoomControl
 {
     GtkBox parent;
-    CajaZoomControlDetails *details;
+    CajaZoomControlPrivate *details;
 };
 
 struct CajaZoomControlClass

--- a/src/file-manager/fm-desktop-icon-view.h
+++ b/src/file-manager/fm-desktop-icon-view.h
@@ -41,11 +41,11 @@
 
 #define FM_DESKTOP_ICON_VIEW_ID "OAFIID:Caja_File_Manager_Desktop_Icon_View"
 
-typedef struct FMDesktopIconViewDetails FMDesktopIconViewDetails;
+typedef struct _FMDesktopIconViewPrivate FMDesktopIconViewPrivate;
 typedef struct
 {
     FMIconView parent;
-    FMDesktopIconViewDetails *details;
+    FMDesktopIconViewPrivate *priv;
 } FMDesktopIconView;
 
 typedef struct

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -83,7 +83,7 @@
 static GHashTable *windows;
 static GHashTable *pending_lists;
 
-struct FMPropertiesWindowDetails {
+struct _FMPropertiesWindowPrivate {
 	GList *original_files;
 	GList *target_files;
 
@@ -231,7 +231,7 @@ static GtkLabel *attach_ellipsizing_value_label   (GtkGrid *grid,
 
 static GtkWidget* create_pie_widget 		  (FMPropertiesWindow *window);
 
-G_DEFINE_TYPE (FMPropertiesWindow, fm_properties_window, GTK_TYPE_DIALOG);
+G_DEFINE_TYPE_WITH_PRIVATE (FMPropertiesWindow, fm_properties_window, GTK_TYPE_DIALOG);
 
 static gboolean
 is_multi_file_window (FMPropertiesWindow *window)
@@ -5762,14 +5762,10 @@ fm_properties_window_class_init (FMPropertiesWindowClass *class)
 	binding_set = gtk_binding_set_by_class (class);
 	gtk_binding_entry_add_signal (binding_set, GDK_KEY_Escape, 0,
 				      "close", 0);
-
-	g_type_class_add_private (class, sizeof (FMPropertiesWindowDetails));
 }
 
 static void
 fm_properties_window_init (FMPropertiesWindow *window)
 {
-	window->details = G_TYPE_INSTANCE_GET_PRIVATE (window, FM_TYPE_PROPERTIES_WINDOW,
-						       FMPropertiesWindowDetails);
-
+	window->details = fm_properties_window_get_instance_private (window);
 }

--- a/src/file-manager/fm-properties-window.h
+++ b/src/file-manager/fm-properties-window.h
@@ -43,12 +43,12 @@ typedef struct FMPropertiesWindow FMPropertiesWindow;
 #define FM_PROPERTIES_WINDOW_GET_CLASS(obj) \
   (G_TYPE_INSTANCE_GET_CLASS ((obj), FM_TYPE_PROPERTIES_WINDOW, FMPropertiesWindowClass))
 
-typedef struct FMPropertiesWindowDetails FMPropertiesWindowDetails;
+typedef struct _FMPropertiesWindowPrivate FMPropertiesWindowPrivate;
 
 struct FMPropertiesWindow
 {
     GtkDialog window;
-    FMPropertiesWindowDetails *details;
+    FMPropertiesWindowPrivate *details;
 };
 
 struct FMPropertiesWindowClass


### PR DESCRIPTION
Changed these files:
- caja-connect-server-dialog
- caja-navigation-window
- caja-property-browser
- caja-sidebar-title
- caja-trash-bar
- caja-window
- caja-zoom-action
- caja-zoom-control
- fm-desktop-icon-view
- fm-properties-window