### PR TITLE
Remove the distcheck return value override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,4 +118,3 @@ variables:
 
 after_scripts:
   - make distcheck
-  - 'if [ $? -ne 0 ];then RED="\033[0;31m"; ENDC="\033[0m"; printf "${RED}!!! ERROR: Run make distcheck failed.${ENDC}\n"; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build autotools
 
 env:
-  - DISTRO="base/archlinux"
+  - DISTRO="archlinux/base"
   - DISTRO="debian:sid"
   - DISTRO="fedora:29"
   - DISTRO="ubuntu:18.10"
@@ -40,6 +40,7 @@ requires:
     - libsm
     - mate-common
     - mate-desktop
+    - which
 
   debian:
     # Useful URL: https://github.com/mate-desktop/debian-packages


### PR DESCRIPTION
Because make distcheck has been fixed, the return value is directly detected.