### PR TITLE
[Security] Use 'g_strlcpy' instead of 'strcpy'

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -6545,10 +6545,10 @@ mark_desktop_file_trusted (CommonJob *common,
 	}
 
 	if (!g_str_has_prefix (contents, "#!")) {
-		new_length = length + strlen (TRUSTED_SHEBANG);
-		new_contents = g_malloc (new_length);
+		new_length = length + strlen (TRUSTED_SHEBANG) + 1;
+		new_contents = g_malloc0 (new_length);
 
-		strcpy (new_contents, TRUSTED_SHEBANG);
+		g_strlcpy (new_contents, TRUSTED_SHEBANG, new_length);
 		memcpy (new_contents + strlen (TRUSTED_SHEBANG),
 			contents, length);
 

--- a/src/caja-sidebar-title.c
+++ b/src/caja-sidebar-title.c
@@ -433,7 +433,7 @@ override_title_font (GtkWidget   *widget,
     g_strreverse (tempsize);
 
     gchar tempfont [strlen (font)];
-    strcpy (tempfont, font);
+    g_strlcpy (tempfont, font, sizeof (tempfont));
     tempfont [strlen (font) - strlen (tempsize)] = 0;
 
     css = g_strdup_printf ("label { font-family: %s; font-size: %spt; }", tempfont, tempsize);


### PR DESCRIPTION
to avoid warnings with Clang Analyzer

```
caja-file-operations.c:6551:3: warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119
                strcpy (new_contents, TRUSTED_SHEBANG);
                ^~~~~~
```

```
caja-sidebar-title.c:436:5: warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119
    strcpy (tempfont, font);
    ^~~~~~
```