### PR TITLE
[Security] eel-string: Use 'g_strlcat' instead of 'strcat'

### DIFF
--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -246,8 +246,8 @@ eel_str_middle_truncate (const char *string,
     truncated = g_new (char, strlen (string) + 1);
 
     g_utf8_strncpy (truncated, string, num_left_chars);
-    strcat (truncated, delimter);
-    strcat (truncated, g_utf8_offset_to_pointer  (string, length - num_right_chars));
+    g_strlcat (truncated, delimter, (truncate_length + 1));
+    g_strlcat (truncated, g_utf8_offset_to_pointer  (string, length - num_right_chars), (truncate_length + 1));
 
     return truncated;
 }


### PR DESCRIPTION
to avoid warnings with Clang Analyzer

![2019-02-23_15-51](https://user-images.githubusercontent.com/7734191/53287969-2a36f900-3783-11e9-8cf4-22883fc0e40c.png)

```
eel-string.c:249:5: warning: Call to function 'strcat' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcat'. CWE-119
    strcat (truncated, delimter);
    ^~~~~~
eel-string.c:250:5: warning: Call to function 'strcat' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcat'. CWE-119
    strcat (truncated, g_utf8_offset_to_pointer  (string, length - num_right_chars));
    ^~~~~~
```