### PR TITLE
caja-tree-view-drag-dest: Fix memory leak

### DIFF
--- a/libcaja-private/caja-tree-view-drag-dest.c
+++ b/libcaja-private/caja-tree-view-drag-dest.c
@@ -1034,6 +1034,7 @@ set_direct_save_uri (CajaTreeViewDragDest *dest,
 
             g_object_unref (base);
             g_object_unref (child);
+            g_free (filename);
 
             /* Change the property */
             gdk_property_change (gdk_drag_context_get_source_window (context),


### PR DESCRIPTION
to avoid warning with Clang Analyzer

![2019-02-23_16-59](https://user-images.githubusercontent.com/7734191/53288738-1db79e00-378d-11e9-8349-738fdb631ee0.png)

```
caja-tree-view-drag-dest.c:1032:19: warning: Potential leak of memory pointed to by 'filename'
            child = g_file_get_child (base, filename);
            ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```