### PR TITLE
fm-directory-view: Fix use of memory after it is freed

### DIFF
--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -5386,7 +5386,6 @@ run_script_callback (GtkAction *action, gpointer callback_data)
 	g_free (file_uri);
 
 	quoted_path = g_shell_quote (local_file_path);
-	g_free (local_file_path);
 
 	old_working_dir = change_to_view_directory (launch_parameters->directory_view);
 
@@ -5406,6 +5405,7 @@ run_script_callback (GtkAction *action, gpointer callback_data)
 			    window, name, local_file_path);
 	caja_launch_application_from_command_array (screen, name, quoted_path, FALSE,
 							(const char * const *) parameters);
+	g_free (local_file_path);
 	g_free (name);
 	g_strfreev (parameters);
 


### PR DESCRIPTION
to avoid warning with Clang Analyzer

![2019-02-23_18-14](https://user-images.githubusercontent.com/7734191/53289496-f06fed80-3796-11e9-9a82-6a453ad339a3.png)

```
fm-directory-view.c:5404:2: warning: Use of memory after it is freed
        caja_debug_log (FALSE, CAJA_DEBUG_LOG_DOMAIN_USER,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```