### PR TITLE
caja-icon-container: Fix use of memory after it is freed

### DIFF
--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -7946,10 +7946,10 @@ caja_icon_container_remove (CajaIconContainer *container,
         return FALSE;
     }
 
+    g_signal_emit (container, signals[ICON_REMOVED], 0, icon);
+
     icon_destroy (container, icon);
     schedule_redo_layout (container);
-
-    g_signal_emit (container, signals[ICON_REMOVED], 0, icon);
 
     return TRUE;
 }


### PR DESCRIPTION
to avoid warning with Clang Analyzer

![2019-02-23_18-30](https://user-images.githubusercontent.com/7734191/53289667-2f9f3e00-3799-11e9-8a47-c13d36bd00f0.png)

```
caja-icon-container.c:7952:5: warning: Use of memory after it is freed
    g_signal_emit (container, signals[ICON_REMOVED], 0, icon);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```