### PR TITLE
caja-information-panel: Fix use of memory after it is freed

### DIFF
--- a/src/caja-information-panel.c
+++ b/src/caja-information-panel.c
@@ -945,6 +945,9 @@ add_buttons_from_metadata (CajaInformationPanel *information_panel, const char *
             *temp_str = '\0';
             if (!g_ascii_strcasecmp (current_term, "button"))
             {
+                if (button_name)
+                    g_free (button_name);
+
                 button_name = g_strdup (temp_str + 1);
             }
             else if (!g_ascii_strcasecmp (current_term, "script"))
@@ -958,7 +961,6 @@ add_buttons_from_metadata (CajaInformationPanel *information_panel, const char *
                                         0);
                     information_panel->details->has_buttons = TRUE;
                     command_string = g_strdup (temp_str + 1);
-                    g_free (button_name);
 
                     g_signal_connect_data (temp_button,
                                            "clicked",
@@ -975,6 +977,7 @@ add_buttons_from_metadata (CajaInformationPanel *information_panel, const char *
         }
         g_free(current_term);
     }
+    g_free (button_name);
     g_strfreev (terms);
 }
 


### PR DESCRIPTION
to avoid warning with Clang Analyzer

![2019-02-23_19-11](https://user-images.githubusercontent.com/7734191/53290015-c9b5b500-379e-11e9-8874-9d47debe0219.png)

```
caja-information-panel.c:954:35: warning: Use of memory after it is freed
                    temp_button = gtk_button_new_with_label (button_name);
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```