### PR TITLE
fm-tree-model: Fix use of memory after it is freed

### DIFF
--- a/src/file-manager/fm-tree-model.c
+++ b/src/file-manager/fm-tree-model.c
@@ -779,9 +779,13 @@ stop_monitoring_directory (FMTreeModel *model, TreeNode *node)
 static void
 destroy_children_without_reporting (FMTreeModel *model, TreeNode *parent)
 {
-    while (parent->first_child != NULL)
+    TreeNode *current_child = parent->first_child;
+    TreeNode *next_child;
+    while (current_child != NULL)
     {
-        destroy_node_without_reporting (model, parent->first_child);
+        next_child = current_child->next;
+        destroy_node_without_reporting (model, current_child);
+        current_child = next_child;
     }
 }
 


### PR DESCRIPTION
to avoid warning with Clang Analyzer

![2019-02-23_20-55](https://user-images.githubusercontent.com/7734191/53291046-6f702080-37ad-11e9-8339-69c8e8a0ecaf.png)

```
fm-tree-model.c:784:9: warning: Use of memory after it is freed
        destroy_node_without_reporting (model, parent->first_child);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```