### PR TITLE
caja-window: Fix garbage value

### DIFF
--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -540,7 +540,8 @@ caja_window_set_initial_window_geometry (CajaWindow *window)
     GdkScreen *screen;
     guint max_width_for_screen, max_height_for_screen;
 
-    guint default_width, default_height;
+    guint default_width = 0;
+    guint default_height = 0;
 
     screen = gtk_window_get_screen (GTK_WINDOW (window));
 


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
caja-window.c:554:34: warning: The left operand of '<' is a garbage value
                                 MIN (default_width,
                                 ^    ~~~~~~~~~~~~~
```