### PR TITLE
eel-canvas: Fix warning: Undefined or garbage value returned to caller

### DIFF
--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -3413,7 +3413,7 @@ eel_canvas_update_now (EelCanvas *canvas)
 EelCanvasItem *
 eel_canvas_get_item_at (EelCanvas *canvas, double x, double y)
 {
-    EelCanvasItem *item;
+    EelCanvasItem *item = NULL;
     double dist;
     int cx, cy;
 


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
eel-canvas.c:3426:9: warning: Undefined or garbage value returned to caller
        return item;
        ^~~~~~~~~~~
```