### PR TITLE
eel-gdk-pixbuf-extensions: Fix division by zero

### DIFF
--- a/eel/eel-gdk-pixbuf-extensions.c
+++ b/eel/eel-gdk-pixbuf-extensions.c
@@ -400,9 +400,18 @@ eel_gdk_pixbuf_scale_down (GdkPixbuf *pixbuf,
             }
             else
             {
-                *dest++ = r / n_pixels;
-                *dest++ = g / n_pixels;
-                *dest++ = b / n_pixels;
+                if (n_pixels != 0)
+                {
+                    *dest++ = r / n_pixels;
+                    *dest++ = g / n_pixels;
+                    *dest++ = b / n_pixels;
+                }
+                else
+                {
+                    *dest++ = 0;
+                    *dest++ = 0;
+                    *dest++ = 0;
+                }
             }
 
             s_x1 = s_x2;


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
eel-gdk-pixbuf-extensions.c:403:29: warning: Division by zero
                *dest++ = r / n_pixels;
                          ~~^~~~~~~~~~
```