### PR TITLE
eel: remove g_str_list_copy

### DIFF
--- a/eel/eel-glib-extensions.c
+++ b/eel/eel-glib-extensions.c
@@ -325,26 +325,6 @@ eel_g_str_list_equal (GList *list_a, GList *list_b)
 }
 
 /**
- * eel_g_str_list_copy
- *
- * @list: List of strings and/or NULLs to copy.
- * Return value: Deep copy of @list.
- **/
-GList *
-eel_g_str_list_copy (GList *list)
-{
-    GList *node, *result;
-
-    result = NULL;
-
-    for (node = g_list_last (list); node != NULL; node = node->prev)
-    {
-        result = g_list_prepend (result, g_strdup (node->data));
-    }
-    return result;
-}
-
-/**
  * eel_g_str_list_alphabetize
  *
  * Sort a list of strings using locale-sensitive rules.

--- a/eel/eel-glib-extensions.h
+++ b/eel/eel-glib-extensions.h
@@ -63,7 +63,6 @@ void        eel_g_list_free_deep_custom                 (GList                 *
 /* List functions for lists of C strings. */
 gboolean    eel_g_str_list_equal                        (GList                 *str_list_a,
         GList                 *str_list_b);
-GList *     eel_g_str_list_copy                         (GList                 *str_list);
 GList *     eel_g_str_list_alphabetize                  (GList                 *str_list);
 int         eel_g_str_list_index                        (GList                 *str_list,
         const char            *str);

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -7022,8 +7022,8 @@ caja_file_get_keywords (CajaFile *file)
 	keywords = caja_file_get_metadata_list
 		(file, CAJA_METADATA_KEY_EMBLEMS);
 
-	keywords = g_list_concat (keywords, eel_g_str_list_copy (file->details->extension_emblems));
-	keywords = g_list_concat (keywords, eel_g_str_list_copy (file->details->pending_extension_emblems));
+	keywords = g_list_concat (keywords, g_list_copy_deep (file->details->extension_emblems, (GCopyFunc) g_strdup, NULL));
+	keywords = g_list_concat (keywords, g_list_copy_deep (file->details->pending_extension_emblems, (GCopyFunc) g_strdup, NULL));
 
 	return sort_keyword_list_and_remove_duplicates (keywords);
 }

--- a/libcaja-private/caja-mime-actions.c
+++ b/libcaja-private/caja-mime-actions.c
@@ -221,7 +221,7 @@ application_launch_parameters_new (GAppInfo *application,
 
     result = g_new0 (ApplicationLaunchParameters, 1);
     result->application = g_object_ref (application);
-    result->uris = eel_g_str_list_copy (uris);
+    result->uris = g_list_copy_deep (uris, (GCopyFunc) g_strdup, NULL);
 
     return result;
 }

--- a/libcaja-private/caja-query.c
+++ b/libcaja-private/caja-query.c
@@ -117,14 +117,14 @@ caja_query_set_location (CajaQuery *query, const char *uri)
 GList *
 caja_query_get_mime_types (CajaQuery *query)
 {
-    return eel_g_str_list_copy (query->details->mime_types);
+    return g_list_copy_deep (query->details->mime_types, (GCopyFunc) g_strdup, NULL);
 }
 
 void
 caja_query_set_mime_types (CajaQuery *query, GList *mime_types)
 {
     g_list_free_full (query->details->mime_types, g_free);
-    query->details->mime_types = eel_g_str_list_copy (mime_types);
+    query->details->mime_types = g_list_copy_deep (mime_types, (GCopyFunc) g_strdup, NULL);
 }
 
 void
@@ -137,14 +137,14 @@ caja_query_add_mime_type (CajaQuery *query, const char *mime_type)
 GList *
 caja_query_get_tags (CajaQuery *query)
 {
-    return eel_g_str_list_copy (query->details->tags);
+    return g_list_copy_deep (query->details->tags, (GCopyFunc) g_strdup, NULL);
 }
 
 void
 caja_query_set_tags (CajaQuery *query, GList *tags)
 {
     g_list_free_full (query->details->tags, g_free);
-    query->details->tags = eel_g_str_list_copy (tags);
+    query->details->tags = g_list_copy_deep (tags, (GCopyFunc) g_strdup, NULL);
 }
 
 void


### PR DESCRIPTION
GNOME/nautilus@61e2aff

Replace eel_g_str_list_copy(Glist *list)
with g_list_copy_deep (list, (GCopyFunc) g_strdup, NULL)