### PR TITLE
caja-file: Fix: true and false branches are identical

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -4855,8 +4855,6 @@ caja_file_fit_date_as_string (CajaFile *file,
 		formats = TODAY_TIME_FORMATS;
 	} else if (file_date_age == 1) {
 		formats = YESTERDAY_TIME_FORMATS;
-	} else if (file_date_age < 7) {
-		formats = CURRENT_WEEK_TIME_FORMATS;
 	} else {
 		formats = CURRENT_WEEK_TIME_FORMATS;
 	}


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
caja-file.c:4858:9: warning: true and false branches are identical
        } else if (file_date_age < 7) {
               ^
```