### PR TITLE
eel-editable-label: call argument with initialized value

### DIFF
--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -2595,10 +2595,10 @@ eel_editable_label_move_line (EelEditableLabel *label,
                               gint      start,
                               gint      count)
 {
-    int n_lines, i;
-    int x;
     PangoLayoutLine *line;
     int index;
+    int n_lines, i;
+    int x = 0;
 
     eel_editable_label_ensure_layout (label, FALSE);
 


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
eel-editable-label.c:2624:9: warning: 2nd function call argument is an uninitialized value
    if (pango_layout_line_x_to_index (line,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```