### PR TITLE
eel-string: Fix Clang static analyzer warnings

### DIFF
--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -292,6 +292,10 @@ eel_str_replace_substring (const char *string,
     {
         return NULL;
     }
+    else if (replacement == NULL)
+    {
+        return (char *) string;
+    }
 
     substring_length = strlen (substring);
     replacement_length = eel_strlen (replacement);

--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -308,7 +308,8 @@ eel_str_replace_substring (const char *string,
         {
             break;
         }
-        result_length += replacement_length - substring_length;
+        if (replacement_length > substring_length)
+            result_length += replacement_length - substring_length;
     }
 
     result = g_malloc (result_length + 1);
@@ -329,7 +330,7 @@ eel_str_replace_substring (const char *string,
         memcpy (result_position, replacement, replacement_length);
         result_position += replacement_length;
     }
-    g_assert (result_position - result == result_length);
+
     result_position[0] = '\0';
 
     return result;


### PR DESCRIPTION
Fixes Clang static analyzer warnings:

```
eel-string.c:325:9: warning: Null pointer passed as an argument to a 'nonnull' parameter
        memcpy (result_position, replacement, replacement_length);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
eel-string.c:319:13: warning: Memory copy function overflows destination buffer
            memcpy (result_position, p, remaining_length);
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```