### PR TITLE
freedesktop-dbus: open location and force raise the window when using dbus show methods.

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -414,6 +414,37 @@ caja_application_open_location (CajaApplication *application,
 }
 
 void
+caja_application_open_location_and_force_raise (CajaApplication *application,
+                                GFile *location,
+                                GFile *selection,
+                                const char *startup_id,
+                                const gboolean open_in_tabs)
+{
+    CajaWindow *window;
+    GList *sel_list = NULL;
+
+    window = caja_application_create_navigation_window (application, gdk_screen_get_default ());
+
+    if (selection != NULL) {
+        sel_list = g_list_prepend (NULL, g_object_ref (selection));
+    }
+
+    caja_window_slot_open_location_full (caja_window_get_active_slot (window), location,
+                                         0, CAJA_WINDOW_OPEN_FLAG_NEW_WINDOW, sel_list, NULL, NULL);
+
+    //use x11 to force show caja window at toplevel.
+    gtk_window_set_position (GTK_WINDOW (window), GTK_WIN_POS_CENTER_ALWAYS);
+    GdkWindow *gdk_window = gtk_widget_get_window (GTK_WINDOW (window));
+    Window window_xid = gdk_x11_window_get_xid (gdk_window);
+    Display *display;
+    XRaiseWindow (display, window_xid);
+
+    if (sel_list != NULL) {
+        caja_file_list_free (sel_list);
+    }
+}
+
+void
 caja_application_quit (CajaApplication *self)
 {
     GApplication *app = G_APPLICATION (self);

--- a/src/caja-application.h
+++ b/src/caja-application.h
@@ -103,4 +103,10 @@ void caja_application_open_location (CajaApplication *application,
         const char *startup_id,
         const gboolean open_in_tabs);
 
+void caja_application_open_location_and_force_raise (CajaApplication *application,
+        GFile *location,
+        GFile *selection,
+        const char *startup_id,
+        const gboolean open_in_tabs);
+
 #endif /* CAJA_APPLICATION_H */

--- a/src/caja-freedesktop-dbus.c
+++ b/src/caja-freedesktop-dbus.c
@@ -75,10 +75,10 @@ skeleton_handle_show_items_cb (CajaFreedesktopFileManager1 *object,
         parent = g_file_get_parent (file);
 
         if (parent != NULL) {
-            caja_application_open_location (application, parent, file, startup_id, 0);
+            caja_application_open_location_and_force_raise (application, parent, file, startup_id, 0);
             g_object_unref (parent);
         } else {
-            caja_application_open_location (application, file, NULL, startup_id, 0);
+            caja_application_open_location_and_force_raise (application, file, NULL, startup_id, 0);
         }
 
         g_object_unref (file);
@@ -105,7 +105,7 @@ skeleton_handle_show_folders_cb (CajaFreedesktopFileManager1 *object,
 
         file = g_file_new_for_uri (uris[i]);
 
-        caja_application_open_location (application, file, NULL, startup_id, 0);
+        caja_application_open_location_and_force_raise (application, file, NULL, startup_id, 0);
 
         g_object_unref (file);
     }


### PR DESCRIPTION
Hi, all.

I have found that when i use firefox to open 'download' location, **the caja window was obscured by Filefox sometimes.**
This problem may occurs after you maximize and then restore the Filefox window. I'm not sure, but it happens a lot.
I don't think it's Caja's problem. it's some of GTK's problems. But the most straightforward way is to force the window to top. So I made a patch here.