### PR TITLE
Fix cast from non-struct type to struct type

### DIFF
--- a/libcaja-private/caja-file-utilities.c
+++ b/libcaja-private/caja-file-utilities.c
@@ -280,7 +280,7 @@ parse_xdg_dirs (const char *config_file)
 
     g_free (config_file_free);
 
-    return (XdgDirEntry *)g_array_free (array, FALSE);
+    return (XdgDirEntry *) (gpointer) g_array_free (array, FALSE);
 }
 
 static XdgDirEntry *cached_xdg_dirs = NULL;

--- a/libegg/eggsmclient-xsmp.c
+++ b/libegg/eggsmclient-xsmp.c
@@ -1153,7 +1153,7 @@ array_prop (const char *name, ...)
     va_end (ap);
 
     prop->num_vals = vals->len;
-    prop->vals = (SmPropValue *)vals->data;
+    prop->vals = (SmPropValue *) (gpointer) vals->data;
 
     g_array_free (vals, FALSE);
 
@@ -1186,7 +1186,7 @@ ptrarray_prop (const char *name, GPtrArray *values)
     }
 
     prop->num_vals = vals->len;
-    prop->vals = (SmPropValue *)vals->data;
+    prop->vals = (SmPropValue *) (gpointer) vals->data;
 
     g_array_free (vals, FALSE);
 

--- a/src/caja-property-browser.c
+++ b/src/caja-property-browser.c
@@ -1232,7 +1232,7 @@ caja_color_selection_dialog_new (CajaPropertyBrowser *property_browser)
 
 /* add the newly selected file to the browser images */
 static void
-add_pattern_to_browser (GtkDialog *dialog, gint response_id, gpointer *data)
+add_pattern_to_browser (GtkDialog *dialog, gint response_id, gpointer data)
 {
     char *directory_path, *destination_name;
     char *basename;
@@ -1405,7 +1405,7 @@ add_color_to_file (CajaPropertyBrowser *property_browser, const char *color_spec
 
 /* handle the OK button being pushed on the color selection dialog */
 static void
-add_color_to_browser (GtkWidget *widget, gint which_button, gpointer *data)
+add_color_to_browser (GtkWidget *widget, gint which_button, gpointer data)
 {
     char * color_spec;
     const char *color_name;
@@ -1444,10 +1444,10 @@ add_color_to_browser (GtkWidget *widget, gint which_button, gpointer *data)
 
 /* create the color selection dialog, pre-set with the color that was just selected */
 static void
-show_color_selection_window (GtkWidget *widget, gpointer *data)
+show_color_selection_window (GtkWidget *widget, gpointer data)
 {
     GdkColor color;
-    CajaPropertyBrowser *property_browser = CAJA_PROPERTY_BROWSER(data);
+    CajaPropertyBrowser *property_browser = CAJA_PROPERTY_BROWSER (data);
 
     gtk_color_selection_get_current_color (GTK_COLOR_SELECTION
                                            (gtk_color_selection_dialog_get_color_selection (GTK_COLOR_SELECTION_DIALOG (property_browser->details->colors_dialog))),


### PR DESCRIPTION
Fix cast from non-struct type to struct type

Fixes Clang static analyzer warnings:

```
eggsmclient-xsmp.c:1156:18: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
    prop->vals = (SmPropValue *)vals->data;
                 ^~~~~~~~~~~~~~~~~~~~~~~~~

eggsmclient-xsmp.c:1189:18: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
    prop->vals = (SmPropValue *)vals->data;
                 ^~~~~~~~~~~~~~~~~~~~~~~~~

caja-file-utilities.c:283:12: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
    return (XdgDirEntry *)g_array_free (array, FALSE);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

caja-property-browser.c:1242:45: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
    CajaPropertyBrowser *property_browser = CAJA_PROPERTY_BROWSER (data);
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

caja-property-browser.c:1414:45: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
    CajaPropertyBrowser *property_browser = CAJA_PROPERTY_BROWSER (data);
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

caja-property-browser.c:1450:45: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
    CajaPropertyBrowser *property_browser = CAJA_PROPERTY_BROWSER(data);
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```