### PR TITLE
caja-autorun: avoid 'NULL' inside 'memcpy'

### DIFF
--- a/libcaja-private/caja-autorun.c
+++ b/libcaja-private/caja-autorun.c
@@ -136,7 +136,10 @@ add_elem_to_str_array (char **v, const char *s)
 
     len = v != NULL ? g_strv_length (v) : 0;
     r = g_new0 (char *, len + 2);
-    memcpy (r, v, len * sizeof (char *));
+
+    if (v)
+        memcpy (r, v, len * sizeof (char *));
+
     r[len] = g_strdup (s);
     r[len+1] = NULL;
     g_free (v);


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
caja-autorun.c:139:5: warning: Null pointer passed as an argument to a 'nonnull' parameter
    memcpy (r, v, len * sizeof (char *));
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```