### PR TITLE
caja-sidebar-title: avoid 'NULL' inside 'setup_gc_with_fg'

### DIFF
--- a/src/caja-sidebar-title.c
+++ b/src/caja-sidebar-title.c
@@ -260,7 +260,7 @@ caja_sidebar_title_select_text_color (CajaSidebarTitle *sidebar_title,
 
     if (!dark_info_color)
     {
-        light_info_color = g_malloc (sizeof (GdkRGBA));
+        dark_info_color = g_malloc (sizeof (GdkRGBA));
         gdk_rgba_parse (dark_info_color, DEFAULT_DARK_INFO_COLOR);
     }
 


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
caja-sidebar-title.c:233:49: warning: Dereference of null pointer (loaded from variable 'color')
    sidebar_title->details->label_colors[idx] = *color;
                                                ^~~~~~
```

with git master:

![2019-03-24_01-51](https://user-images.githubusercontent.com/7734191/54873487-63d93f00-4dd7-11e9-91f2-cd831c0f29cd.png)

that line seems to be wrong, and it was fixed by this PR