### PR TITLE
caja-open-with-dialog: make sure there is error before showing it

### DIFF
--- a/libcaja-private/caja-open-with-dialog.c
+++ b/libcaja-private/caja-open-with-dialog.c
@@ -249,12 +249,15 @@ add_or_find_application (CajaOpenWithDialog *dialog)
 
     if (app == NULL)
     {
-        message = g_strdup_printf (_("Could not add application to the application database: %s"), error->message);
+        message = g_strdup_printf (_("Could not add application to the application database: %s"), error ? error->message : _("Unknown error"));
         eel_show_error_dialog (_("Could not add application"),
                                message,
                                GTK_WINDOW (dialog));
         g_free (message);
-        g_error_free (error);
+
+        if (error)
+            g_error_free (error);
+
         return NULL;
     }
 


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
caja-open-with-dialog.c:252:100: warning: Access to field 'message' results in a dereference of a null pointer (loaded from variable 'error')
        message = g_strdup_printf (_("Could not add application to the application database: %s"), error->message);
                                                                                                   ^~~~~~~~~~~~~~
```