### PR TITLE
caja-file-operations: make sure 'error' isn't NULL

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -2162,7 +2162,7 @@ unmount_mount_callback (GObject *source_object,
 	}
 
 	if (! unmounted) {
-		if (error->code != G_IO_ERROR_FAILED_HANDLED) {
+		if (error && error->code != G_IO_ERROR_FAILED_HANDLED) {
 			if (data->eject) {
 				primary = f (_("Unable to eject %V"), source_object);
 			} else {
@@ -5445,7 +5445,7 @@ link_file (CopyMoveJob *job,
 			details = NULL;
 		} else {
 			secondary = f (_("There was an error creating the symlink in %F."), dest_dir);
-			details = error->message;
+			details = error ? error->message : NULL;
 		}
 
 		response = run_warning (common,


### PR DESCRIPTION
Fixes Clang static analyzer warnings:

```
caja-file-operations.c:2165:7: warning: Access to field 'code' results in a dereference of a null pointer (loaded from variable 'error')
                if (error->code != G_IO_ERROR_FAILED_HANDLED) {
                    ^~~~~~~~~~~

caja-file-operations.c:5448:14: warning: Access to field 'message' results in a dereference of a null pointer (loaded from variable 'error')
                        details = error->message;
                                  ^~~~~~~~~~~~~~
```