### PR TITLE
fm-desktop-icon-view: remove dead code

### DIFF
--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -319,23 +319,13 @@ fm_desktop_icon_view_handle_middle_click (CajaIconContainer *icon_container,
         FMDesktopIconView *desktop_icon_view)
 {
     XButtonEvent x_event;
-    GdkDevice *keyboard = NULL, *pointer = NULL, *cur;
+    GdkDevice *keyboard = NULL, *pointer = NULL;
     GdkSeat *seat;
     GdkDisplay *display;
 
     seat = gdk_display_get_default_seat (gtk_widget_get_display (GTK_WIDGET (icon_container)));
     pointer = gdk_seat_get_pointer (seat);
     keyboard = gdk_seat_get_keyboard (seat);
-
-    {
-        if (pointer == NULL && (gdk_device_get_source (cur) == GDK_SOURCE_MOUSE)) {
-                pointer = cur;
-        }
-
-        if (keyboard == NULL && (gdk_device_get_source (cur) == GDK_SOURCE_KEYBOARD)) {
-                keyboard = cur;
-        }
-    }
 
     /* During a mouse click we have the pointer and keyboard grab.
      * We will send a fake event to the root window which will cause it


### PR DESCRIPTION
Fixes Clang static analyzer warnings:

```
fm-desktop-icon-view.c:331:33: warning: 1st function call argument is an uninitialized value
        if (pointer == NULL && (gdk_device_get_source (cur) == GDK_SOURCE_MOUSE)) {
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~

fm-desktop-icon-view.c:335:34: warning: 1st function call argument is an uninitialized value
        if (keyboard == NULL && (gdk_device_get_source (cur) == GDK_SOURCE_KEYBOARD)) {
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```