### PR TITLE
caja-application: avoid NULL inside 'g_object_unref'

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -2217,9 +2217,10 @@ caja_application_local_command_line (GApplication *application,
         g_free (concatOptions);
     }
 
-    for (idx = 0; idx < len; idx++) {
-        g_object_unref (files[idx]);
-    }
+    if (files)
+        for (idx = 0; idx < len; idx++) {
+            g_object_unref (files[idx]);
+        }
     g_free (files);
 
  out:


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
caja-application.c:2221:25: warning: Array access (from variable 'files') results in a null pointer dereference
        g_object_unref (files[idx]);
                        ^~~~~~~~~~
```