### PR TITLE
caja-icon-canvas-item: initialize variable 'scale'

### DIFF
--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -505,7 +505,7 @@ get_scaled_icon_size (CajaIconCanvasItem *item,
 {
     EelCanvas *canvas;
     GdkPixbuf *pixbuf = NULL;
-    gint scale;
+    gint scale = 1;
 
     if (item != NULL) {
         canvas = EEL_CANVAS_ITEM (item)->canvas;


### PR DESCRIPTION
Fixes `cppcheck` warning:

`[libcaja-private/caja-icon-canvas-item.c:517]: (error) Uninitialized variable: scale`