### PR TITLE
caja-file: avoid shifting signed 32-bit value by 31 bits

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -98,7 +98,7 @@
 /* Name of Caja trash directories */
 #define TRASH_DIRECTORY_NAME ".Trash"
 
-#define METADATA_ID_IS_LIST_MASK (1<<31)
+#define METADATA_ID_IS_LIST_MASK (1U<<31)
 
 #define SORT_BY_EXTENSION_FOLLOWING_MAX_LENGTH 3
 #define SORT_BY_EXTENSION_MAX_SEGMENTS 3


### PR DESCRIPTION
Fixes `cppcheck` warnings:

```
[libcaja-private/caja-file.c:288]: (error) Shifting signed 32-bit value by 31 bits is undefined behaviour
[libcaja-private/caja-file.c:334]: (error) Shifting signed 32-bit value by 31 bits is undefined behaviour
[libcaja-private/caja-file.c:386]: (error) Shifting signed 32-bit value by 31 bits is undefined behaviour
[libcaja-private/caja-file.c:3789]: (error) Shifting signed 32-bit value by 31 bits is undefined behaviour
```