### PR TITLE
eel-string: Use 'va_copy' instead of 'G_VA_COPY'

### DIFF
--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -678,7 +678,7 @@ eel_strdup_vprintf_with_custom (EelPrintfHandler *custom,
         {
             char *val;
 
-            G_VA_COPY(va, va_orig);
+            va_copy (va, va_orig);
             skip_to_arg (&va, args, custom, conversions[i].precision_pos);
             val = g_strdup_vprintf ("%d", va);
             va_end (va);
@@ -694,7 +694,7 @@ eel_strdup_vprintf_with_custom (EelPrintfHandler *custom,
         {
             char *val;
 
-            G_VA_COPY(va, va_orig);
+            va_copy (va, va_orig);
             skip_to_arg (&va, args, custom, conversions[i].width_pos);
             val = g_strdup_vprintf ("%d", va);
             va_end (va);
@@ -706,7 +706,7 @@ eel_strdup_vprintf_with_custom (EelPrintfHandler *custom,
             g_free (val);
         }
 
-        G_VA_COPY(va, va_orig);
+        va_copy (va, va_orig);
         skip_to_arg (&va, args, custom, conversions[i].arg_pos);
         type = args[conversions[i].arg_pos];
         if (type < 0)


### PR DESCRIPTION
Fixes `cppcheck` warnings:

```
[eel-string.c:681]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:682]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:683]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:684]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:697]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:698]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:699]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:700]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:709]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:710]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:714]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:720]: (error) va_list 'va' used before va_start() was called.
[eel-string.c:722]: (error) va_list 'va' used before va_start() was called.
```