### PR TITLE
Fix invocation with --geometry from the command line

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -374,18 +374,25 @@ caja_application_open (GApplication *app,
         }
         sscanf (splitedOptions[2], "%d", &open_in_tabs);
 
+        open_windows (self, files,
+                      gdk_screen_get_default (),
+                      geometry,
+                      n_files,
+                      browser_window,
+                      open_in_tabs);
+
         /* Reset this or 3ed and later invocations will use same
          * geometry even if the user has resized open window */
         self->priv->geometry = NULL;
         g_strfreev (splitedOptions);
     }
-
-    open_windows (self, files,
-                  gdk_screen_get_default (),
-                  geometry,
-                  n_files,
-                  browser_window,
-                  open_in_tabs);
+    else
+        open_windows (self, files,
+                      gdk_screen_get_default (),
+                      geometry,
+                      n_files,
+                      browser_window,
+                      open_in_tabs);
 }
 
 void


### PR DESCRIPTION
Due to changes somewhere else windows called with --geometry must now be opened before splitedOptions is freed or the geometry passed to later functions gets corrrupted

Note that setting a width smaller than 654 px will generate GTK warnings (negative content width and similar) but will still mostly work.