### PR TITLE
Fix  #1198 "Context menu with menu key broken"

### DIFF
--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -9187,9 +9187,13 @@ fm_directory_view_pop_up_selection_context_menu  (FMDirectoryView *view,
 
 	update_context_menu_position_from_event (view, event);
 
+	/* FIXME: passing event from here won't work
+	 * for gtk_menu_popup_at_pointer (in eel_pop_up_context_menu() )
+	 * if the menu is being triggered from here by the menu key
+	 */
 	eel_pop_up_context_menu (create_popup_menu
 	                         (view, FM_DIRECTORY_VIEW_POPUP_PATH_SELECTION),
-	                          event);
+	                          NULL);
 }
 
 /**

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -2552,8 +2552,12 @@ icon_container_context_click_background_callback (CajaIconContainer *container,
     g_assert (CAJA_IS_ICON_CONTAINER (container));
     g_assert (FM_IS_ICON_VIEW (icon_view));
 
+    /* FIXME: passing event from here won't work
+     * for gtk_menu_popup_at_pointer (in eel_pop_up_context_menu() )
+     * if the menu is being triggered from here by the menu key
+     */
     fm_directory_view_pop_up_background_context_menu
-    (FM_DIRECTORY_VIEW (icon_view), event);
+    (FM_DIRECTORY_VIEW (icon_view), NULL);
 }
 
 static gboolean


### PR DESCRIPTION
Pass "NULL" for event which is passed ultimately to gtk_menu_popup_at_pointer as an invalid event was being passed when the menu key was used to open the icon views context menu