### PR TITLE
eel-string: Use 'memmove' instead of 'memcpy'

### DIFF
--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -321,13 +321,13 @@ eel_str_replace_substring (const char *string,
         if (substring_position == NULL)
         {
             remaining_length = strlen (p);
-            memcpy (result_position, p, remaining_length);
+            memmove (result_position, p, remaining_length);
             result_position += remaining_length;
             break;
         }
-        memcpy (result_position, p, substring_position - p);
+        memmove (result_position, p, substring_position - p);
         result_position += substring_position - p;
-        memcpy (result_position, replacement, replacement_length);
+        memmove (result_position, replacement, replacement_length);
         result_position += replacement_length;
     }
 


### PR DESCRIPTION
Fixes `flawfinder` warnings:

`(buffer) memcpy: Does not check for buffer overflows when copying to destination (CWE-120). Make sure destination can always hold the source data.`

http://cwe.mitre.org/data/definitions/120.html