### PR TITLE
eel-editable-label: Use 'memmove' instead of 'memcpy'

### DIFF
--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -2320,7 +2320,7 @@ eel_editable_label_insert_text (EelEditableLabel *label,
     g_object_freeze_notify (G_OBJECT (label));
 
     memmove (label->text + *index + new_text_length, label->text + *index, label->n_bytes - *index);
-    memcpy (label->text + *index, new_text, new_text_length);
+    memmove (label->text + *index, new_text, new_text_length);
 
     label->n_bytes += new_text_length;
 


### PR DESCRIPTION
Fixes 'flawfinder' warning:

`(buffer) memcpy: Does not check for buffer overflows when copying to destination (CWE-120). Make sure destination can always hold the source data.`

http://cwe.mitre.org/data/definitions/120.html

The expected with this PR: the same behavior renaming folders and files.