### PR TITLE
Revert "local #include files inside "" instead <>"

### DIFF
--- a/eel/check-program.c
+++ b/eel/check-program.c
@@ -23,15 +23,15 @@
 */
 
 #include <config.h>
+
+#include <eel/eel-debug.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-lib-self-check-functions.h>
+#include <eel/eel-self-checks.h>
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
 #include <libxml/parser.h>
 #include <stdlib.h>
-
-#include "eel-debug.h"
-#include "eel-glib-extensions.h"
-#include "eel-lib-self-check-functions.h"
-#include "eel-self-checks.h"
 
 int
 main (int argc, char *argv[])

--- a/eel/eel-accessibility.c
+++ b/eel/eel-accessibility.c
@@ -25,8 +25,7 @@
 #include <config.h>
 #include <gtk/gtk.h>
 #include <atk/atkrelationset.h>
-
-#include "eel-accessibility.h"
+#include <eel/eel-accessibility.h>
 
 void
 eel_accessibility_set_up_label_widget_relation (GtkWidget *label, GtkWidget *widget)

--- a/eel/eel-art-gtk-extensions.h
+++ b/eel/eel-art-gtk-extensions.h
@@ -35,8 +35,8 @@
 #ifndef EEL_ART_GTK_EXTENSIONS_H
 #define EEL_ART_GTK_EXTENSIONS_H
 
-#include "eel-gtk-extensions.h"
-#include "eel-art-extensions.h"
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-art-extensions.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -25,20 +25,18 @@
 */
 
 #include <config.h>
+#include "eel-background.h"
+#include "eel-gdk-extensions.h"
+#include "eel-glib-extensions.h"
+#include "eel-lib-self-check-functions.h"
 #include <gtk/gtk.h>
+#include <eel/eel-canvas.h>
 #include <cairo-xlib.h>
 #include <gdk/gdkx.h>
 #include <gio/gio.h>
 #include <math.h>
 #include <stdio.h>
-
-#include "eel-background.h"
-#include "eel-gdk-extensions.h"
-#include "eel-glib-extensions.h"
-#include "eel-lib-self-check-functions.h"
-#include "eel-canvas.h"
-
-#include "../libcaja-private/caja-global-preferences.h"
+#include <libcaja-private/caja-global-preferences.h>
 
 enum
 {

--- a/eel/eel-canvas-rect-ellipse.h
+++ b/eel/eel-canvas-rect-ellipse.h
@@ -35,7 +35,7 @@
 #define EEL_CANVAS_RECT_ELLIPSE_H
 
 
-#include "eel-canvas.h"
+#include <eel/eel-canvas.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/eel/eel-gtk-container.h
+++ b/eel/eel-gtk-container.h
@@ -27,7 +27,7 @@
 #define EEL_GTK_CONTAINER_H
 
 #include <gtk/gtk.h>
-#include "eel-art-extensions.h"
+#include <eel/eel-art-extensions.h>
 
 void eel_gtk_container_child_expose_event (GtkContainer   *container,
         GtkWidget      *child,

--- a/eel/eel-gtk-extensions.h
+++ b/eel/eel-gtk-extensions.h
@@ -30,7 +30,7 @@
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gtk/gtk.h>
-#include "eel-gdk-extensions.h"
+#include <eel/eel-gdk-extensions.h>
 
 /* GtkWindow */
 void                  eel_gtk_window_set_initial_geometry             (GtkWindow            *window,

--- a/eel/eel-image-table.h
+++ b/eel/eel-image-table.h
@@ -25,7 +25,7 @@
 #ifndef EEL_IMAGE_TABLE_H
 #define EEL_IMAGE_TABLE_H
 
-#include "eel-wrap-table.h"
+#include <eel/eel-wrap-table.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/eel/eel-labeled-image.h
+++ b/eel/eel-labeled-image.h
@@ -48,7 +48,7 @@
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gtk/gtk.h>
-#include "eel-art-extensions.h"
+#include <eel/eel-art-extensions.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/eel/eel-self-checks.h
+++ b/eel/eel-self-checks.h
@@ -27,7 +27,7 @@
 
 #include <glib.h>
 
-#include "eel-art-extensions.h"
+#include <eel/eel-art-extensions.h>
 
 #define EEL_CHECK_RESULT(type, expression, expected_value) \
 G_STMT_START { \

--- a/eel/eel.h
+++ b/eel/eel.h
@@ -25,24 +25,24 @@
 #ifndef EEL_H
 #define EEL_H
 
-#include "eel-art-extensions.h"
-#include "eel-art-gtk-extensions.h"
-#include "eel-background.h"
-#include "eel-gdk-extensions.h"
-#include "eel-gdk-pixbuf-extensions.h"
-#include "eel-glib-extensions.h"
-#include "eel-mate-extensions.h"
-#include "eel-graphic-effects.h"
-#include "eel-gtk-container.h"
-#include "eel-gtk-extensions.h"
-#include "eel-gtk-macros.h"
-#include "eel-image-table.h"
-#include "eel-labeled-image.h"
-#include "eel-self-checks.h"
-#include "eel-stock-dialogs.h"
-#include "eel-string.h"
-#include "eel-vfs-extensions.h"
-#include "eel-wrap-table.h"
-#include "eel-xml-extensions.h"
+#include <eel/eel-art-extensions.h>
+#include <eel/eel-art-gtk-extensions.h>
+#include <eel/eel-background.h>
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-mate-extensions.h>
+#include <eel/eel-graphic-effects.h>
+#include <eel/eel-gtk-container.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-image-table.h>
+#include <eel/eel-labeled-image.h>
+#include <eel/eel-self-checks.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-wrap-table.h>
+#include <eel/eel-xml-extensions.h>
 
 #endif /* EEL_H */

--- a/libcaja-extension/caja-extension-private.h
+++ b/libcaja-extension/caja-extension-private.h
@@ -24,7 +24,7 @@
 #ifndef CAJA_EXTENSION_PRIVATE_H
 #define CAJA_EXTENSION_PRIVATE_H
 
-#include "caja-file-info.h"
+#include <libcaja-extension/caja-file-info.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/libcaja-private/caja-autorun.c
+++ b/libcaja-private/caja-autorun.c
@@ -33,8 +33,8 @@
 #include <gdk/gdkkeysyms.h>
 #include <cairo-gobject.h>
 
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-stock-dialogs.h>
 
 #include "caja-icon-info.h"
 #include "caja-global-preferences.h"

--- a/libcaja-private/caja-autorun.h
+++ b/libcaja-private/caja-autorun.h
@@ -41,10 +41,8 @@
 #define CAJA_AUTORUN_H
 
 #include <gtk/gtk.h>
-
-#include "../eel/eel-background.h"
-
-#include "caja-file.h"
+#include <eel/eel-background.h>
+#include <libcaja-private/caja-file.h>
 
 typedef void (*CajaAutorunComboBoxChanged) (gboolean selected_ask,
         gboolean selected_ignore,

--- a/libcaja-private/caja-bookmark.c
+++ b/libcaja-private/caja-bookmark.c
@@ -23,17 +23,17 @@
 */
 
 #include <config.h>
+#include "caja-bookmark.h"
+
+#include "caja-file.h"
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-vfs-extensions.h>
 #include <gtk/gtk.h>
 #include <gio/gio.h>
-
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-vfs-extensions.h"
-
-#include "caja-bookmark.h"
-#include "caja-file.h"
-#include "caja-icon-names.h"
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-icon-names.h>
 
 enum
 {

--- a/libcaja-private/caja-clipboard-monitor.c
+++ b/libcaja-private/caja-clipboard-monitor.c
@@ -23,14 +23,13 @@
 */
 
 #include <config.h>
-#include <gtk/gtk.h>
-
-#include "../eel/eel-debug.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-glib-extensions.h"
-
 #include "caja-clipboard-monitor.h"
 #include "caja-file.h"
+
+#include <eel/eel-debug.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-glib-extensions.h>
+#include <gtk/gtk.h>
 
 /* X11 has a weakness when it comes to clipboard handling,
  * there is no way to get told when the owner of the clipboard

--- a/libcaja-private/caja-column-chooser.h
+++ b/libcaja-private/caja-column-chooser.h
@@ -26,8 +26,7 @@
 #define CAJA_COLUMN_CHOOSER_H
 
 #include <gtk/gtk.h>
-
-#include "caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 #define CAJA_TYPE_COLUMN_CHOOSER caja_column_chooser_get_type()
 #define CAJA_COLUMN_CHOOSER(obj) \

--- a/libcaja-private/caja-column-utilities.c
+++ b/libcaja-private/caja-column-utilities.c
@@ -23,15 +23,14 @@
 */
 
 #include <config.h>
-#include <string.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../libcaja-extension/caja-column-provider.h"
-
 #include "caja-column-utilities.h"
-#include "caja-extensions.h"
-#include "caja-module.h"
+
+#include <string.h>
+#include <eel/eel-glib-extensions.h>
+#include <glib/gi18n.h>
+#include <libcaja-extension/caja-column-provider.h>
+#include <libcaja-private/caja-extensions.h>
+#include <libcaja-private/caja-module.h>
 
 static GList *
 get_builtin_columns (void)

--- a/libcaja-private/caja-column-utilities.h
+++ b/libcaja-private/caja-column-utilities.h
@@ -25,9 +25,8 @@
 #ifndef CAJA_COLUMN_UTILITIES_H
 #define CAJA_COLUMN_UTILITIES_H
 
-#include "../libcaja-extension/caja-column.h"
-
-#include "caja-file.h"
+#include <libcaja-extension/caja-column.h>
+#include <libcaja-private/caja-file.h>
 
 GList *caja_get_all_columns       (void);
 GList *caja_get_common_columns    (void);

--- a/libcaja-private/caja-customization-data.c
+++ b/libcaja-private/caja-customization-data.c
@@ -26,6 +26,16 @@
    names and images */
 
 #include <config.h>
+#include "caja-customization-data.h"
+
+#include "caja-file-utilities.h"
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-xml-extensions.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <glib.h>
 #include <gtk/gtk.h>
@@ -33,17 +43,6 @@
 #include <libxml/parser.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "../eel/eel-gdk-extensions.h"
-#include "../eel/eel-gdk-extensions.h"
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-vfs-extensions.h"
-#include "../eel/eel-xml-extensions.h"
-
-#include "caja-customization-data.h"
-#include "caja-file-utilities.h"
 
 typedef enum
 {

--- a/libcaja-private/caja-desktop-directory-file.c
+++ b/libcaja-private/caja-desktop-directory-file.c
@@ -24,22 +24,21 @@
 */
 
 #include <config.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#include <string.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-
 #include "caja-desktop-directory-file.h"
+
 #include "caja-desktop-metadata.h"
 #include "caja-directory-notify.h"
 #include "caja-directory-private.h"
 #include "caja-file-attributes.h"
 #include "caja-file-private.h"
 #include "caja-file-utilities.h"
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-macros.h>
 #include "caja-desktop-directory.h"
 #include "caja-metadata.h"
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <string.h>
 
 struct CajaDesktopDirectoryFileDetails
 {

--- a/libcaja-private/caja-desktop-directory-file.h
+++ b/libcaja-private/caja-desktop-directory-file.h
@@ -26,7 +26,7 @@
 #ifndef CAJA_DESKTOP_DIRECTORY_FILE_H
 #define CAJA_DESKTOP_DIRECTORY_FILE_H
 
-#include "caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 #define CAJA_TYPE_DESKTOP_DIRECTORY_FILE caja_desktop_directory_file_get_type()
 #define CAJA_DESKTOP_DIRECTORY_FILE(obj) \

--- a/libcaja-private/caja-desktop-directory.c
+++ b/libcaja-private/caja-desktop-directory.c
@@ -25,17 +25,16 @@
 */
 
 #include <config.h>
-#include <gtk/gtk.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-
 #include "caja-desktop-directory.h"
+
 #include "caja-directory-private.h"
 #include "caja-file.h"
 #include "caja-file-private.h"
 #include "caja-file-utilities.h"
 #include "caja-global-preferences.h"
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <gtk/gtk.h>
 
 struct CajaDesktopDirectoryDetails
 {

--- a/libcaja-private/caja-desktop-directory.h
+++ b/libcaja-private/caja-desktop-directory.h
@@ -27,7 +27,7 @@
 #ifndef CAJA_DESKTOP_DIRECTORY_H
 #define CAJA_DESKTOP_DIRECTORY_H
 
-#include "caja-directory.h"
+#include <libcaja-private/caja-directory.h>
 
 #define CAJA_TYPE_DESKTOP_DIRECTORY caja_desktop_directory_get_type()
 #define CAJA_DESKTOP_DIRECTORY(obj) \

--- a/libcaja-private/caja-desktop-icon-file.c
+++ b/libcaja-private/caja-desktop-icon-file.c
@@ -24,13 +24,8 @@
 */
 
 #include <config.h>
-#include <glib/gi18n.h>
-#include <string.h>
-#include <gio/gio.h>
-
-#include "../eel/eel-glib-extensions.h"
-
 #include "caja-desktop-icon-file.h"
+
 #include "caja-desktop-metadata.h"
 #include "caja-desktop-directory-file.h"
 #include "caja-directory-notify.h"
@@ -39,7 +34,11 @@
 #include "caja-file-private.h"
 #include "caja-file-utilities.h"
 #include "caja-file-operations.h"
+#include <eel/eel-glib-extensions.h>
 #include "caja-desktop-directory.h"
+#include <glib/gi18n.h>
+#include <string.h>
+#include <gio/gio.h>
 
 struct _CajaDesktopIconFilePrivate
 {

--- a/libcaja-private/caja-desktop-icon-file.h
+++ b/libcaja-private/caja-desktop-icon-file.h
@@ -26,8 +26,8 @@
 #ifndef CAJA_DESKTOP_ICON_FILE_H
 #define CAJA_DESKTOP_ICON_FILE_H
 
-#include "caja-file.h"
-#include "caja-desktop-link.h"
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-desktop-link.h>
 
 #define CAJA_TYPE_DESKTOP_ICON_FILE caja_desktop_icon_file_get_type()
 #define CAJA_DESKTOP_ICON_FILE(obj) \

--- a/libcaja-private/caja-desktop-link-monitor.c
+++ b/libcaja-private/caja-desktop-link-monitor.c
@@ -23,24 +23,23 @@
 */
 
 #include <config.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#include <gio/gio.h>
-#include <string.h>
-
-#include "../eel/eel-debug.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-vfs-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-
 #include "caja-desktop-link-monitor.h"
 #include "caja-desktop-link.h"
 #include "caja-desktop-icon-file.h"
 #include "caja-directory.h"
 #include "caja-desktop-directory.h"
 #include "caja-global-preferences.h"
-#include "caja-trash-monitor.h"
+
+#include <eel/eel-debug.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <libcaja-private/caja-trash-monitor.h>
+#include <string.h>
 
 struct CajaDesktopLinkMonitorDetails
 {

--- a/libcaja-private/caja-desktop-link-monitor.h
+++ b/libcaja-private/caja-desktop-link-monitor.h
@@ -26,8 +26,7 @@
 #define CAJA_DESKTOP_LINK_MONITOR_H
 
 #include <gtk/gtk.h>
-
-#include "caja-desktop-link.h"
+#include <libcaja-private/caja-desktop-link.h>
 
 #define CAJA_TYPE_DESKTOP_LINK_MONITOR caja_desktop_link_monitor_get_type()
 #define CAJA_DESKTOP_LINK_MONITOR(obj) \

--- a/libcaja-private/caja-desktop-link.c
+++ b/libcaja-private/caja-desktop-link.c
@@ -23,19 +23,18 @@
 */
 
 #include <config.h>
-#include <glib/gi18n.h>
-#include <gio/gio.h>
-#include <string.h>
-
 #include "caja-desktop-link.h"
 #include "caja-desktop-link-monitor.h"
 #include "caja-desktop-icon-file.h"
 #include "caja-directory-private.h"
 #include "caja-desktop-directory.h"
 #include "caja-icon-names.h"
-#include "caja-file-utilities.h"
-#include "caja-trash-monitor.h"
-#include "caja-global-preferences.h"
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-trash-monitor.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <string.h>
 
 struct _CajaDesktopLinkPrivate
 {

--- a/libcaja-private/caja-desktop-link.h
+++ b/libcaja-private/caja-desktop-link.h
@@ -25,9 +25,8 @@
 #ifndef CAJA_DESKTOP_LINK_H
 #define CAJA_DESKTOP_LINK_H
 
+#include <libcaja-private/caja-file.h>
 #include <gio/gio.h>
-
-#include "caja-file.h"
 
 #define CAJA_TYPE_DESKTOP_LINK caja_desktop_link_get_type()
 #define CAJA_DESKTOP_LINK(obj) \

--- a/libcaja-private/caja-desktop-metadata.h
+++ b/libcaja-private/caja-desktop-metadata.h
@@ -29,7 +29,7 @@
 
 #include <glib.h>
 
-#include "caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 void caja_desktop_set_metadata_string (CajaFile *file,
                                        const gchar *name,

--- a/libcaja-private/caja-directory-async.c
+++ b/libcaja-private/caja-directory-async.c
@@ -23,12 +23,6 @@
 */
 
 #include <config.h>
-#include <gtk/gtk.h>
-#include <libxml/parser.h>
-#include <stdio.h>
-#include <stdlib.h>
-
-#include "../eel/eel-glib-extensions.h"
 
 #include "caja-directory-notify.h"
 #include "caja-directory-private.h"
@@ -39,6 +33,11 @@
 #include "caja-global-preferences.h"
 #include "caja-link.h"
 #include "caja-marshal.h"
+#include <eel/eel-glib-extensions.h>
+#include <gtk/gtk.h>
+#include <libxml/parser.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 /* turn this on to see messages about each load_directory call: */
 #if 0

--- a/libcaja-private/caja-directory-background.c
+++ b/libcaja-private/caja-directory-background.c
@@ -27,18 +27,17 @@
 */
 
 #include <config.h>
-#include <gtk/gtk.h>
-#include <string.h>
-
-#include "../eel/eel-gdk-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-background.h"
-
 #include "caja-directory-background.h"
+
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-background.h>
 #include "caja-dnd.h"
 #include "caja-global-preferences.h"
 #include "caja-metadata.h"
 #include "caja-file-attributes.h"
+#include <gtk/gtk.h>
+#include <string.h>
 
 static void caja_background_changed_cb (EelBackground *background,
                                         GdkDragAction  action,

--- a/libcaja-private/caja-directory-background.h
+++ b/libcaja-private/caja-directory-background.h
@@ -26,10 +26,9 @@
             Jasmine Hassan <jasmine.aura@gmail.com>
 */
 
-#include "../eel/eel-background.h"
-
-#include "caja-file.h"
-#include "caja-icon-container.h"
+#include <eel/eel-background.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-icon-container.h>
 
 void     caja_connect_background_to_file_metadata    (GtkWidget         *widget,
                                                       CajaFile          *file,

--- a/libcaja-private/caja-directory-notify.h
+++ b/libcaja-private/caja-directory-notify.h
@@ -23,8 +23,7 @@
 */
 
 #include <gdk/gdk.h>
-
-#include "caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 typedef struct
 {

--- a/libcaja-private/caja-directory-private.h
+++ b/libcaja-private/caja-directory-private.h
@@ -23,15 +23,13 @@
 */
 
 #include <gio/gio.h>
+#include <eel/eel-vfs-extensions.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-file-queue.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-monitor.h>
+#include <libcaja-extension/caja-info-provider.h>
 #include <libxml/tree.h>
-
-#include "../eel/eel-vfs-extensions.h"
-#include "../libcaja-extension/caja-info-provider.h"
-
-#include "caja-directory.h"
-#include "caja-file-queue.h"
-#include "caja-file.h"
-#include "caja-monitor.h"
 
 typedef struct LinkInfoReadState LinkInfoReadState;
 typedef struct TopLeftTextReadState TopLeftTextReadState;

--- a/libcaja-private/caja-directory.c
+++ b/libcaja-private/caja-directory.c
@@ -23,13 +23,8 @@
 */
 
 #include <config.h>
-#include <gtk/gtk.h>
-#include <string.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-
 #include "caja-directory-private.h"
+
 #include "caja-directory-notify.h"
 #include "caja-file-attributes.h"
 #include "caja-file-private.h"
@@ -40,6 +35,10 @@
 #include "caja-metadata.h"
 #include "caja-desktop-directory.h"
 #include "caja-vfs-directory.h"
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <gtk/gtk.h>
+#include <string.h>
 
 enum
 {

--- a/libcaja-private/caja-directory.h
+++ b/libcaja-private/caja-directory.h
@@ -27,8 +27,7 @@
 
 #include <gtk/gtk.h>
 #include <gio/gio.h>
-
-#include "caja-file-attributes.h"
+#include <libcaja-private/caja-file-attributes.h>
 
 G_BEGIN_DECLS
 

--- a/libcaja-private/caja-dnd.c
+++ b/libcaja-private/caja-dnd.c
@@ -27,23 +27,22 @@
 /* FIXME: This should really be back in Caja, not here in Eel. */
 
 #include <config.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#include <stdio.h>
-#include <string.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-vfs-extensions.h"
-
 #include "caja-dnd.h"
+
 #include "caja-program-choosing.h"
 #include "caja-link.h"
 #include "caja-window-slot-info.h"
 #include "caja-window-info.h"
 #include "caja-view.h"
-#include "caja-file-utilities.h"
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <stdio.h>
+#include <string.h>
 
 /* a set of defines stolen from the eel-icon-dnd.c file.
  * These are in microseconds.

--- a/libcaja-private/caja-dnd.h
+++ b/libcaja-private/caja-dnd.h
@@ -28,8 +28,7 @@
 #define CAJA_DND_H
 
 #include <gtk/gtk.h>
-
-#include "caja-window-slot-info.h"
+#include <libcaja-private/caja-window-slot-info.h>
 
 /* Drag & Drop target names. */
 #define CAJA_ICON_DND_MATE_ICON_LIST_TYPE	"x-special/mate-icon-list"

--- a/libcaja-private/caja-emblem-utils.c
+++ b/libcaja-private/caja-emblem-utils.c
@@ -37,8 +37,8 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-stock-dialogs.h>
 
 #include "caja-file.h"
 #include "caja-emblem-utils.h"

--- a/libcaja-private/caja-entry.c
+++ b/libcaja-private/caja-entry.c
@@ -25,16 +25,16 @@
  */
 
 #include <config.h>
+#include "caja-entry.h"
+
 #include <string.h>
+#include "caja-global-preferences.h"
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-gtk-macros.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 
-#include "../eel/eel-gdk-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-
-#include "caja-entry.h"
-#include "caja-global-preferences.h"
 
 struct CajaEntryDetails
 {

--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -24,16 +24,16 @@
 */
 
 #include <config.h>
+#include "caja-file-conflict-dialog.h"
+
 #include <string.h>
 #include <glib-object.h>
 #include <gio/gio.h>
 #include <glib/gi18n.h>
 #include <pango/pango.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-stock-dialogs.h>
 
-#include "../eel/eel-vfs-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-
-#include "caja-file-conflict-dialog.h"
 #include "caja-file.h"
 #include "caja-icon-info.h"
 

--- a/libcaja-private/caja-file-dnd.h
+++ b/libcaja-private/caja-file-dnd.h
@@ -25,8 +25,8 @@
 #ifndef CAJA_FILE_DND_H
 #define CAJA_FILE_DND_H
 
-#include "caja-dnd.h"
-#include "caja-file.h"
+#include <libcaja-private/caja-dnd.h>
+#include <libcaja-private/caja-file.h>
 
 #define CAJA_FILE_DND_ERASE_KEYWORD "erase"
 

--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -35,6 +35,20 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <stdlib.h>
+
+#include "caja-file-operations.h"
+
+#include "caja-debug-log.h"
+#include "caja-file-changes-queue.h"
+#include "caja-lib-self-check-functions.h"
+
+#include "caja-progress-info.h"
+
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-vfs-extensions.h>
+
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
 #include <gdk/gdk.h>
@@ -43,17 +57,6 @@
 #include <gio/gio.h>
 #include <glib.h>
 #include <libnotify/notify.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-vfs-extensions.h"
-
-#include "caja-file-operations.h"
-#include "caja-debug-log.h"
-#include "caja-file-changes-queue.h"
-#include "caja-lib-self-check-functions.h"
-#include "caja-progress-info.h"
 #include "caja-file-changes-queue.h"
 #include "caja-file-private.h"
 #include "caja-desktop-icon-file.h"

--- a/libcaja-private/caja-file-private.h
+++ b/libcaja-private/caja-file-private.h
@@ -25,13 +25,12 @@
 #ifndef CAJA_FILE_PRIVATE_H
 #define CAJA_FILE_PRIVATE_H
 
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-string.h"
-
-#include "caja-directory.h"
-#include "caja-file.h"
-#include "caja-monitor.h"
-#include "caja-undostack-manager.h"
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-monitor.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-string.h>
+#include <libcaja-private/caja-undostack-manager.h>
 
 #define CAJA_FILE_LARGE_TOP_LEFT_TEXT_MAXIMUM_CHARACTERS_PER_LINE 80
 #define CAJA_FILE_LARGE_TOP_LEFT_TEXT_MAXIMUM_LINES               24

--- a/libcaja-private/caja-file-queue.h
+++ b/libcaja-private/caja-file-queue.h
@@ -23,7 +23,7 @@
 #ifndef CAJA_FILE_QUEUE_H
 #define CAJA_FILE_QUEUE_H
 
-#include "caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 typedef struct CajaFileQueue CajaFileQueue;
 

--- a/libcaja-private/caja-file-utilities.c
+++ b/libcaja-private/caja-file-utilities.c
@@ -23,18 +23,8 @@
 */
 
 #include <config.h>
-#include <glib.h>
-#include <glib/gi18n.h>
-#include <glib/gstdio.h>
-#include <gio/gio.h>
-#include <stdlib.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-debug.h"
-
 #include "caja-file-utilities.h"
+
 #include "caja-global-preferences.h"
 #include "caja-lib-self-check-functions.h"
 #include "caja-metadata.h"
@@ -42,6 +32,15 @@
 #include "caja-file-operations.h"
 #include "caja-search-directory.h"
 #include "caja-signaller.h"
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <eel/eel-debug.h>
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include <stdlib.h>
 
 #define DEFAULT_CAJA_DIRECTORY_MODE (0755)
 

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -23,33 +23,8 @@
 */
 
 #include <config.h>
-#include <grp.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#include <glib/gstdio.h>
-#include <gio/gio.h>
-#include <glib.h>
-#include <libxml/parser.h>
-#include <pwd.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <sys/time.h>
-#include <time.h>
-#include <unistd.h>
-#include <sys/stat.h>
-
-#include "../eel/eel-debug.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-vfs-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-string.h"
-
-#include "../libcaja-extension/caja-file-info.h"
-#include "../libcaja-extension/caja-extension-private.h"
-#include "../libcaja-private/caja-extensions.h"
-
 #include "caja-file.h"
+
 #include "caja-directory-notify.h"
 #include "caja-directory-private.h"
 #include "caja-signaller.h"
@@ -71,6 +46,31 @@
 #include "caja-ui-utilities.h"
 #include "caja-vfs-file.h"
 #include "caja-saved-search-file.h"
+#include <eel/eel-debug.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-string.h>
+#include <grp.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include <glib.h>
+
+#include <libcaja-extension/caja-file-info.h>
+#include <libcaja-extension/caja-extension-private.h>
+#include <libcaja-private/caja-extensions.h>
+
+#include <libxml/parser.h>
+#include <pwd.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/stat.h>
 
 #ifdef HAVE_SELINUX
 #include <selinux/selinux.h>

--- a/libcaja-private/caja-file.h
+++ b/libcaja-private/caja-file.h
@@ -27,9 +27,8 @@
 
 #include <gtk/gtk.h>
 #include <gio/gio.h>
-
-#include "caja-file-attributes.h"
-#include "caja-icon-info.h"
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-icon-info.h>
 
 G_BEGIN_DECLS
 

--- a/libcaja-private/caja-global-preferences.c
+++ b/libcaja-private/caja-global-preferences.c
@@ -24,16 +24,15 @@
 */
 
 #include <config.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-string.h"
-
 #include "caja-global-preferences.h"
+
 #include "caja-file-utilities.h"
 #include "caja-file.h"
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <glib/gi18n.h>
 
 /*
  * Public functions

--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -24,7 +24,21 @@
 
 #include <config.h>
 #include <math.h>
+#include "caja-icon-canvas-item.h"
+
 #include <glib/gi18n.h>
+
+#include "caja-file-utilities.h"
+#include "caja-global-preferences.h"
+#include "caja-icon-private.h"
+#include <eel/eel-art-extensions.h>
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-graphic-effects.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-string.h>
+#include <eel/eel-accessibility.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
@@ -34,20 +48,6 @@
 #include <atk/atknoopobject.h>
 #include <stdio.h>
 #include <string.h>
-
-#include "../eel/eel-art-extensions.h"
-#include "../eel/eel-gdk-extensions.h"
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-graphic-effects.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-accessibility.h"
-
-#include "caja-icon-canvas-item.h"
-#include "caja-file-utilities.h"
-#include "caja-global-preferences.h"
-#include "caja-icon-private.h"
 
 #define EMBLEM_SPACING 2
 

--- a/libcaja-private/caja-icon-canvas-item.h
+++ b/libcaja-private/caja-icon-canvas-item.h
@@ -25,8 +25,8 @@
 #ifndef CAJA_ICON_CANVAS_ITEM_H
 #define CAJA_ICON_CANVAS_ITEM_H
 
-#include "../eel/eel-canvas.h"
-#include "../eel/eel-art-extensions.h"
+#include <eel/eel-canvas.h>
+#include <eel/eel-art-extensions.h>
 
 G_BEGIN_DECLS
 

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -27,32 +27,31 @@
 
 #include <config.h>
 #include <math.h>
+#include "caja-icon-container.h"
+
+#include "caja-debug-log.h"
+#include "caja-global-preferences.h"
+#include "caja-icon-private.h"
+#include "caja-lib-self-check-functions.h"
+#include "caja-marshal.h"
 #include <atk/atkaction.h>
+#include <eel/eel-accessibility.h>
+#include <eel/eel-background.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-mate-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-art-extensions.h>
+#include <eel/eel-editable-label.h>
+#include <eel/eel-string.h>
+#include <eel/eel-canvas.h>
+#include <eel/eel-canvas-rect-ellipse.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkx.h>
 #include <glib/gi18n.h>
 #include <stdio.h>
 #include <string.h>
-
-#include "../eel/eel-accessibility.h"
-#include "../eel/eel-background.h"
-#include "../eel/eel-vfs-extensions.h"
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-mate-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-art-extensions.h"
-#include "../eel/eel-editable-label.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-canvas.h"
-#include "../eel/eel-canvas-rect-ellipse.h"
-
-#include "caja-icon-container.h"
-#include "caja-debug-log.h"
-#include "caja-global-preferences.h"
-#include "caja-icon-private.h"
-#include "caja-lib-self-check-functions.h"
-#include "caja-marshal.h"
 
 #define TAB_NAVIGATION_DISABLED
 

--- a/libcaja-private/caja-icon-container.h
+++ b/libcaja-private/caja-icon-container.h
@@ -26,9 +26,8 @@
 #ifndef CAJA_ICON_CONTAINER_H
 #define CAJA_ICON_CONTAINER_H
 
-#include "../eel/eel-canvas.h"
-
-#include "caja-icon-info.h"
+#include <eel/eel-canvas.h>
+#include <libcaja-private/caja-icon-info.h>
 
 #define CAJA_TYPE_ICON_CONTAINER caja_icon_container_get_type()
 #define CAJA_ICON_CONTAINER(obj) \

--- a/libcaja-private/caja-icon-dnd.c
+++ b/libcaja-private/caja-icon-dnd.c
@@ -33,34 +33,32 @@
 
 #include <config.h>
 #include <math.h>
-#include <stdio.h>
-#include <string.h>
-
-#include <gdk/gdkkeysyms.h>
-#include <gdk/gdkx.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-background.h"
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-mate-extensions.h"
-#include "../eel/eel-graphic-effects.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-vfs-extensions.h"
-#include "../eel/eel-canvas-rect-ellipse.h"
-
 #include "caja-icon-dnd.h"
+
 #include "caja-debug-log.h"
 #include "caja-file-dnd.h"
 #include "caja-icon-private.h"
 #include "caja-link.h"
 #include "caja-metadata.h"
-#include "caja-file-utilities.h"
-#include "caja-file-changes-queue.h"
+#include <eel/eel-background.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-mate-extensions.h>
+#include <eel/eel-graphic-effects.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
+#include <gdk/gdkkeysyms.h>
+#include <gdk/gdkx.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <eel/eel-canvas-rect-ellipse.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-file-changes-queue.h>
+#include <stdio.h>
+#include <string.h>
 
 static const GtkTargetEntry drag_types [] =
 {

--- a/libcaja-private/caja-icon-dnd.h
+++ b/libcaja-private/caja-icon-dnd.h
@@ -28,8 +28,8 @@
 #ifndef CAJA_ICON_DND_H
 #define CAJA_ICON_DND_H
 
-#include "caja-icon-container.h"
-#include "caja-dnd.h"
+#include <libcaja-private/caja-icon-container.h>
+#include <libcaja-private/caja-dnd.h>
 
 /* DnD-related information. */
 typedef struct

--- a/libcaja-private/caja-icon-private.h
+++ b/libcaja-private/caja-icon-private.h
@@ -25,11 +25,10 @@
 #ifndef CAJA_ICON_CONTAINER_PRIVATE_H
 #define CAJA_ICON_CONTAINER_PRIVATE_H
 
-#include "../eel/eel-glib-extensions.h"
-
-#include "caja-icon-canvas-item.h"
-#include "caja-icon-container.h"
-#include "caja-icon-dnd.h"
+#include <eel/eel-glib-extensions.h>
+#include <libcaja-private/caja-icon-canvas-item.h>
+#include <libcaja-private/caja-icon-container.h>
+#include <libcaja-private/caja-icon-dnd.h>
 
 /* An Icon. */
 

--- a/libcaja-private/caja-lib-self-check-functions.h
+++ b/libcaja-private/caja-lib-self-check-functions.h
@@ -23,7 +23,7 @@
    Author: Darin Adler <darin@bentspoon.com>
 */
 
-#include "../eel/eel-self-checks.h"
+#include <eel/eel-self-checks.h>
 
 void caja_run_lib_self_checks (void);
 

--- a/libcaja-private/caja-link.c
+++ b/libcaja-private/caja-link.c
@@ -24,21 +24,19 @@
 */
 
 #include <config.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include <glib/gi18n.h>
-#include <gio/gio.h>
-
-#include "../eel/eel-vfs-extensions.h"
-
 #include "caja-link.h"
+
 #include "caja-directory-notify.h"
 #include "caja-directory.h"
 #include "caja-file-utilities.h"
 #include "caja-file.h"
 #include "caja-program-choosing.h"
 #include "caja-icon-names.h"
+#include <eel/eel-vfs-extensions.h>
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define MAIN_GROUP "Desktop Entry"
 

--- a/libcaja-private/caja-mime-actions.c
+++ b/libcaja-private/caja-mime-actions.c
@@ -23,17 +23,16 @@
 */
 
 #include <config.h>
-#include <string.h>
+#include "caja-mime-actions.h"
 
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
+#include <string.h>
 #include <gdk/gdkx.h>
 
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-string.h"
-
-#include "caja-mime-actions.h"
 #include "caja-file-attributes.h"
 #include "caja-file.h"
 #include "caja-autorun.h"

--- a/libcaja-private/caja-mime-actions.h
+++ b/libcaja-private/caja-mime-actions.h
@@ -27,9 +27,9 @@
 
 #include <gio/gio.h>
 
-#include "caja-file.h"
-#include "caja-window-info.h"
-#include "caja-window-slot-info.h"
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-window-info.h>
+#include <libcaja-private/caja-window-slot-info.h>
 
 CajaFileAttributes caja_mime_actions_get_required_file_attributes (void);
 

--- a/libcaja-private/caja-mime-application-chooser.c
+++ b/libcaja-private/caja-mime-application-chooser.c
@@ -26,19 +26,18 @@
 */
 
 #include <config.h>
-#include <string.h>
+#include "caja-mime-application-chooser.h"
 
+#include "caja-open-with-dialog.h"
+#include "caja-signaller.h"
+#include "caja-file.h"
+#include <eel/eel-stock-dialogs.h>
+
+#include <string.h>
 #include <glib/gi18n-lib.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gtk/gtk.h>
 #include <gio/gio.h>
-
-#include "../eel/eel-stock-dialogs.h"
-
-#include "caja-mime-application-chooser.h"
-#include "caja-open-with-dialog.h"
-#include "caja-signaller.h"
-#include "caja-file.h"
 
 struct _CajaMimeApplicationChooserDetails
 {

--- a/libcaja-private/caja-module.c
+++ b/libcaja-private/caja-module.c
@@ -22,13 +22,12 @@
  */
 
 #include <config.h>
-#include <gmodule.h>
-
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-debug.h"
-
 #include "caja-module.h"
-#include "caja-extensions.h"
+
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-debug.h>
+#include <gmodule.h>
+#include <libcaja-private/caja-extensions.h>
 
 #define CAJA_TYPE_MODULE    	(caja_module_get_type ())
 #define CAJA_MODULE(obj)		(G_TYPE_CHECK_INSTANCE_CAST ((obj), CAJA_TYPE_MODULE, CajaModule))

--- a/libcaja-private/caja-open-with-dialog.c
+++ b/libcaja-private/caja-open-with-dialog.c
@@ -26,17 +26,16 @@
 */
 
 #include <config.h>
-#include <string.h>
-#include <cairo-gobject.h>
+#include "caja-open-with-dialog.h"
+#include "caja-signaller.h"
 
+#include <eel/eel-stock-dialogs.h>
+
+#include <string.h>
 #include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
 #include <gio/gio.h>
-
-#include "../eel/eel-stock-dialogs.h"
-
-#include "caja-open-with-dialog.h"
-#include "caja-signaller.h"
+#include <cairo-gobject.h>
 
 #define sure_string(s)                    ((const char *)((s)!=NULL?(s):""))
 #define DESKTOP_ENTRY_GROUP		  "Desktop Entry"

--- a/libcaja-private/caja-program-choosing.c
+++ b/libcaja-private/caja-program-choosing.c
@@ -24,24 +24,23 @@
 */
 
 #include <config.h>
-#include <stdlib.h>
-
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#include <gio/gio.h>
-#include <gio/gdesktopappinfo.h>
-#include <gdk/gdk.h>
-#include <gdk/gdkx.h>
-
-#include "../eel/eel-mate-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-
 #include "caja-program-choosing.h"
+
 #include "caja-mime-actions.h"
 #include "caja-global-preferences.h"
 #include "caja-icon-info.h"
 #include "caja-recent.h"
 #include "caja-desktop-icon-file.h"
+#include <eel/eel-mate-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <gio/gdesktopappinfo.h>
+#include <stdlib.h>
+
+#include <gdk/gdk.h>
+#include <gdk/gdkx.h>
 
 /**
  * application_cannot_open_location

--- a/libcaja-private/caja-program-choosing.h
+++ b/libcaja-private/caja-program-choosing.h
@@ -28,8 +28,7 @@
 
 #include <gtk/gtk.h>
 #include <gio/gio.h>
-
-#include "caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 typedef void (*CajaApplicationChoiceCallback) (GAppInfo                      *application,
         gpointer			  callback_data);

--- a/libcaja-private/caja-progress-info.c
+++ b/libcaja-private/caja-progress-info.c
@@ -24,15 +24,12 @@
 
 #include <config.h>
 #include <math.h>
-#include <string.h>
-
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
-
-#include "../eel/eel-glib-extensions.h"
-
+#include <eel/eel-glib-extensions.h>
 #include "caja-progress-info.h"
 #include "caja-global-preferences.h"
+#include <string.h>
 
 enum
 {

--- a/libcaja-private/caja-query.c
+++ b/libcaja-private/caja-query.c
@@ -23,13 +23,12 @@
 
 #include <config.h>
 #include <string.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-glib-extensions.h"
 
 #include "caja-query.h"
-#include "caja-file-utilities.h"
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-glib-extensions.h>
+#include <glib/gi18n.h>
+#include <libcaja-private/caja-file-utilities.h>
 
 struct CajaQueryDetails
 {

--- a/libcaja-private/caja-recent.c
+++ b/libcaja-private/caja-recent.c
@@ -18,9 +18,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "../eel/eel-vfs-extensions.h"
-
 #include "caja-recent.h"
+
+#include <eel/eel-vfs-extensions.h>
 
 #define DEFAULT_APP_EXEC "gio open %u"
 

--- a/libcaja-private/caja-recent.h
+++ b/libcaja-private/caja-recent.h
@@ -4,9 +4,8 @@
 #define __CAJA_RECENT_H__
 
 #include <gtk/gtk.h>
+#include <libcaja-private/caja-file.h>
 #include <gio/gio.h>
-
-#include "caja-file.h"
 
 void caja_recent_add_file (CajaFile *file,
                            GAppInfo *application);

--- a/libcaja-private/caja-saved-search-file.h
+++ b/libcaja-private/caja-saved-search-file.h
@@ -26,7 +26,7 @@
 #ifndef CAJA_SAVED_SEARCH_FILE_H
 #define CAJA_SAVED_SEARCH_FILE_H
 
-#include "caja-vfs-file.h"
+#include <libcaja-private/caja-vfs-file.h>
 
 #define CAJA_TYPE_SAVED_SEARCH_FILE caja_saved_search_file_get_type()
 #define CAJA_SAVED_SEARCH_FILE(obj) \

--- a/libcaja-private/caja-search-directory-file.c
+++ b/libcaja-private/caja-search-directory-file.c
@@ -24,20 +24,18 @@
 */
 
 #include <config.h>
-#include <string.h>
-
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-glib-extensions.h"
-
 #include "caja-search-directory-file.h"
+
 #include "caja-directory-notify.h"
 #include "caja-directory-private.h"
 #include "caja-file-attributes.h"
 #include "caja-file-private.h"
 #include "caja-file-utilities.h"
+#include <eel/eel-glib-extensions.h>
 #include "caja-search-directory.h"
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <string.h>
 
 struct CajaSearchDirectoryFileDetails
 {

--- a/libcaja-private/caja-search-directory-file.h
+++ b/libcaja-private/caja-search-directory-file.h
@@ -26,7 +26,7 @@
 #ifndef CAJA_SEARCH_DIRECTORY_FILE_H
 #define CAJA_SEARCH_DIRECTORY_FILE_H
 
-#include "caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 #define CAJA_TYPE_SEARCH_DIRECTORY_FILE caja_search_directory_file_get_type()
 #define CAJA_SEARCH_DIRECTORY_FILE(obj) \

--- a/libcaja-private/caja-search-directory.c
+++ b/libcaja-private/caja-search-directory.c
@@ -21,21 +21,19 @@
 */
 
 #include <config.h>
-#include <string.h>
-
-#include <gtk/gtk.h>
-#include <gio/gio.h>
-#include <sys/time.h>
-
-#include "../eel/eel-glib-extensions.h"
-
 #include "caja-search-directory.h"
 #include "caja-search-directory-file.h"
+
 #include "caja-directory-private.h"
 #include "caja-file.h"
 #include "caja-file-private.h"
 #include "caja-file-utilities.h"
 #include "caja-search-engine.h"
+#include <eel/eel-glib-extensions.h>
+#include <gtk/gtk.h>
+#include <gio/gio.h>
+#include <string.h>
+#include <sys/time.h>
 
 struct CajaSearchDirectoryDetails
 {

--- a/libcaja-private/caja-search-directory.h
+++ b/libcaja-private/caja-search-directory.h
@@ -25,8 +25,8 @@
 #ifndef CAJA_SEARCH_DIRECTORY_H
 #define CAJA_SEARCH_DIRECTORY_H
 
-#include "caja-directory.h"
-#include "caja-query.h"
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-query.h>
 
 #define CAJA_TYPE_SEARCH_DIRECTORY caja_search_directory_get_type()
 #define CAJA_SEARCH_DIRECTORY(obj) \

--- a/libcaja-private/caja-search-engine-beagle.c
+++ b/libcaja-private/caja-search-engine-beagle.c
@@ -22,11 +22,10 @@
  */
 
 #include <config.h>
-#include <gmodule.h>
-
-#include "../eel/eel-gtk-macros.h"
-
 #include "caja-search-engine-beagle.h"
+
+#include <eel/eel-gtk-macros.h>
+#include <gmodule.h>
 
 typedef struct _BeagleHit BeagleHit;
 typedef struct _BeagleQuery BeagleQuery;

--- a/libcaja-private/caja-search-engine-beagle.h
+++ b/libcaja-private/caja-search-engine-beagle.h
@@ -24,7 +24,7 @@
 #ifndef CAJA_SEARCH_ENGINE_BEAGLE_H
 #define CAJA_SEARCH_ENGINE_BEAGLE_H
 
-#include "caja-search-engine.h"
+#include <libcaja-private/caja-search-engine.h>
 
 #define CAJA_TYPE_SEARCH_ENGINE_BEAGLE		(caja_search_engine_beagle_get_type ())
 #define CAJA_SEARCH_ENGINE_BEAGLE(obj)		(G_TYPE_CHECK_INSTANCE_CAST ((obj), CAJA_TYPE_SEARCH_ENGINE_BEAGLE, CajaSearchEngineBeagle))

--- a/libcaja-private/caja-search-engine-simple.c
+++ b/libcaja-private/caja-search-engine-simple.c
@@ -22,14 +22,13 @@
  */
 
 #include <config.h>
+#include "caja-search-engine-simple.h"
+
 #include <string.h>
 #include <glib.h>
 
+#include <eel/eel-gtk-macros.h>
 #include <gio/gio.h>
-
-#include "../eel/eel-gtk-macros.h"
-
-#include "caja-search-engine-simple.h"
 
 #define BATCH_SIZE 500
 

--- a/libcaja-private/caja-search-engine-simple.h
+++ b/libcaja-private/caja-search-engine-simple.h
@@ -24,7 +24,7 @@
 #ifndef CAJA_SEARCH_ENGINE_SIMPLE_H
 #define CAJA_SEARCH_ENGINE_SIMPLE_H
 
-#include "caja-search-engine.h"
+#include <libcaja-private/caja-search-engine.h>
 
 #define CAJA_TYPE_SEARCH_ENGINE_SIMPLE		(caja_search_engine_simple_get_type ())
 #define CAJA_SEARCH_ENGINE_SIMPLE(obj)		(G_TYPE_CHECK_INSTANCE_CAST ((obj), CAJA_TYPE_SEARCH_ENGINE_SIMPLE, CajaSearchEngineSimple))

--- a/libcaja-private/caja-search-engine-tracker.c
+++ b/libcaja-private/caja-search-engine-tracker.c
@@ -22,12 +22,10 @@
  */
 
 #include <config.h>
+#include "caja-search-engine-tracker.h"
+#include <eel/eel-gtk-macros.h>
 #include <gmodule.h>
 #include <string.h>
-
-#include "../eel/eel-gtk-macros.h"
-
-#include "caja-search-engine-tracker.h"
 
 typedef struct _TrackerClient TrackerClient;
 

--- a/libcaja-private/caja-search-engine-tracker.h
+++ b/libcaja-private/caja-search-engine-tracker.h
@@ -24,7 +24,7 @@
 #ifndef CAJA_SEARCH_ENGINE_TRACKER_H
 #define CAJA_SEARCH_ENGINE_TRACKER_H
 
-#include "caja-search-engine.h"
+#include <libcaja-private/caja-search-engine.h>
 
 #define CAJA_TYPE_SEARCH_ENGINE_TRACKER		(caja_search_engine_tracker_get_type ())
 #define CAJA_SEARCH_ENGINE_TRACKER(obj)		(G_TYPE_CHECK_INSTANCE_CAST ((obj), CAJA_TYPE_SEARCH_ENGINE_TRACKER, CajaSearchEngineTracker))

--- a/libcaja-private/caja-search-engine.c
+++ b/libcaja-private/caja-search-engine.c
@@ -22,13 +22,12 @@
  */
 
 #include <config.h>
-
-#include "../eel/eel-gtk-macros.h"
-
 #include "caja-search-engine.h"
 #include "caja-search-engine-beagle.h"
 #include "caja-search-engine-simple.h"
 #include "caja-search-engine-tracker.h"
+
+#include <eel/eel-gtk-macros.h>
 
 struct CajaSearchEngineDetails
 {

--- a/libcaja-private/caja-search-engine.h
+++ b/libcaja-private/caja-search-engine.h
@@ -25,8 +25,7 @@
 #define CAJA_SEARCH_ENGINE_H
 
 #include <glib-object.h>
-
-#include "caja-query.h"
+#include <libcaja-private/caja-query.h>
 
 #define CAJA_TYPE_SEARCH_ENGINE		(caja_search_engine_get_type ())
 #define CAJA_SEARCH_ENGINE(obj)		(G_TYPE_CHECK_INSTANCE_CAST ((obj), CAJA_TYPE_SEARCH_ENGINE, CajaSearchEngine))

--- a/libcaja-private/caja-sidebar-provider.h
+++ b/libcaja-private/caja-sidebar-provider.h
@@ -25,8 +25,8 @@
 #ifndef CAJA_SIDEBAR_PROVIDER_H
 #define CAJA_SIDEBAR_PROVIDER_H
 
-#include "caja-sidebar.h"
-#include "caja-window-info.h"
+#include <libcaja-private/caja-sidebar.h>
+#include <libcaja-private/caja-window-info.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/libcaja-private/caja-signaller.c
+++ b/libcaja-private/caja-signaller.c
@@ -27,10 +27,9 @@
  */
 
 #include <config.h>
-
-#include "../eel/eel-debug.h"
-
 #include "caja-signaller.h"
+
+#include <eel/eel-debug.h>
 
 typedef GObject CajaSignaller;
 typedef GObjectClass CajaSignallerClass;

--- a/libcaja-private/caja-thumbnails.c
+++ b/libcaja-private/caja-thumbnails.c
@@ -24,29 +24,28 @@
 */
 
 #include <config.h>
-#include <math.h>
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
-#include <unistd.h>
-#include <signal.h>
-
-#include <gtk/gtk.h>
-#include <sys/wait.h>
+#include "caja-thumbnails.h"
 
 #define MATE_DESKTOP_USE_UNSTABLE_API
-#include <libmate-desktop/mate-desktop-thumbnail.h>
 
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-graphic-effects.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-debug.h"
-#include "../eel/eel-vfs-extensions.h"
-
-#include "caja-thumbnails.h"
 #include "caja-directory-notify.h"
 #include "caja-global-preferences.h"
 #include "caja-file-utilities.h"
+#include <math.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-graphic-effects.h>
+#include <eel/eel-string.h>
+#include <eel/eel-debug.h>
+#include <eel/eel-vfs-extensions.h>
+#include <gtk/gtk.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <signal.h>
+#include <libmate-desktop/mate-desktop-thumbnail.h>
+
 #include "caja-file-private.h"
 
 /* turn this on to see messages about thumbnail creation */

--- a/libcaja-private/caja-thumbnails.h
+++ b/libcaja-private/caja-thumbnails.h
@@ -26,8 +26,7 @@
 #define CAJA_THUMBNAILS_H
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
-
-#include "caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 /* Returns NULL if there's no thumbnail yet. */
 void       caja_create_thumbnail                (CajaFile *file);

--- a/libcaja-private/caja-trash-monitor.c
+++ b/libcaja-private/caja-trash-monitor.c
@@ -24,17 +24,15 @@
 */
 
 #include <config.h>
-
-#include <gio/gio.h>
-#include <string.h>
-
-#include "../eel/eel-debug.h"
-
 #include "caja-trash-monitor.h"
+
 #include "caja-directory-notify.h"
 #include "caja-directory.h"
 #include "caja-file-attributes.h"
 #include "caja-icon-names.h"
+#include <eel/eel-debug.h>
+#include <gio/gio.h>
+#include <string.h>
 
 struct _CajaTrashMonitorPrivate
 {

--- a/libcaja-private/caja-tree-view-drag-dest.c
+++ b/libcaja-private/caja-tree-view-drag-dest.c
@@ -29,20 +29,18 @@
  */
 
 #include <config.h>
-#include <stdio.h>
-#include <string.h>
-
-#include <gtk/gtk.h>
-
-#include "../eel/eel-gtk-macros.h"
-
 #include "caja-tree-view-drag-dest.h"
+
+#include <eel/eel-gtk-macros.h>
+#include <gtk/gtk.h>
 #include "caja-file-dnd.h"
 #include "caja-file-changes-queue.h"
 #include "caja-icon-dnd.h"
 #include "caja-link.h"
 #include "caja-marshal.h"
 #include "caja-debug-log.h"
+#include <stdio.h>
+#include <string.h>
 
 #define AUTO_SCROLL_MARGIN 20
 

--- a/libcaja-private/caja-ui-utilities.c
+++ b/libcaja-private/caja-ui-utilities.c
@@ -23,17 +23,15 @@
 */
 
 #include <config.h>
-
-#include <gtk/gtk.h>
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gio/gio.h>
-
-#include "../eel/eel-debug.h"
-#include "../eel/eel-graphic-effects.h"
-
 #include "caja-ui-utilities.h"
 #include "caja-file-utilities.h"
 #include "caja-icon-info.h"
+#include <gio/gio.h>
+
+#include <gtk/gtk.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <eel/eel-debug.h>
+#include <eel/eel-graphic-effects.h>
 
 void
 caja_ui_unmerge_ui (GtkUIManager *ui_manager,

--- a/libcaja-private/caja-ui-utilities.h
+++ b/libcaja-private/caja-ui-utilities.h
@@ -25,8 +25,7 @@
 #define CAJA_UI_UTILITIES_H
 
 #include <gtk/gtk.h>
-
-#include "../libcaja-extension/caja-menu-item.h"
+#include <libcaja-extension/caja-menu-item.h>
 
 char *      caja_get_ui_directory              (void);
 char *      caja_ui_file                       (const char        *partial_path);

--- a/libcaja-private/caja-vfs-directory.c
+++ b/libcaja-private/caja-vfs-directory.c
@@ -24,11 +24,10 @@
 */
 
 #include <config.h>
-
-#include "../eel/eel-gtk-macros.h"
-
 #include "caja-vfs-directory.h"
+
 #include "caja-directory-private.h"
+#include <eel/eel-gtk-macros.h>
 #include "caja-file-private.h"
 
 static void caja_vfs_directory_init       (gpointer   object,

--- a/libcaja-private/caja-vfs-directory.h
+++ b/libcaja-private/caja-vfs-directory.h
@@ -26,7 +26,7 @@
 #ifndef CAJA_VFS_DIRECTORY_H
 #define CAJA_VFS_DIRECTORY_H
 
-#include "caja-directory.h"
+#include <libcaja-private/caja-directory.h>
 
 #define CAJA_TYPE_VFS_DIRECTORY caja_vfs_directory_get_type()
 #define CAJA_VFS_DIRECTORY(obj) \

--- a/libcaja-private/caja-vfs-file.c
+++ b/libcaja-private/caja-vfs-file.c
@@ -24,16 +24,14 @@
 */
 
 #include <config.h>
-
-#include <glib/gi18n.h>
-
-#include "../eel/eel-gtk-macros.h"
-
 #include "caja-vfs-file.h"
+
 #include "caja-directory-notify.h"
 #include "caja-directory-private.h"
 #include "caja-file-private.h"
 #include "caja-autorun.h"
+#include <eel/eel-gtk-macros.h>
+#include <glib/gi18n.h>
 
 static void caja_vfs_file_init       (gpointer   object,
                                       gpointer   klass);

--- a/libcaja-private/caja-vfs-file.h
+++ b/libcaja-private/caja-vfs-file.h
@@ -26,7 +26,7 @@
 #ifndef CAJA_VFS_FILE_H
 #define CAJA_VFS_FILE_H
 
-#include "caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 #define CAJA_TYPE_VFS_FILE caja_vfs_file_get_type()
 #define CAJA_VFS_FILE(obj) \

--- a/libcaja-private/caja-view-factory.h
+++ b/libcaja-private/caja-view-factory.h
@@ -27,10 +27,9 @@
 
 #include <string.h>
 
+#include <libcaja-private/caja-view.h>
+#include <libcaja-private/caja-window-slot-info.h>
 #include <gio/gio.h>
-
-#include "caja-view.h"
-#include "caja-window-slot-info.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/libcaja-private/caja-view.h
+++ b/libcaja-private/caja-view.h
@@ -29,7 +29,7 @@
 #include <gtk/gtk.h>
 
 /* For CajaZoomLevel */
-#include "caja-icon-info.h"
+#include <libcaja-private/caja-icon-info.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/libcaja-private/caja-window-info.h
+++ b/libcaja-private/caja-window-info.h
@@ -26,10 +26,8 @@
 #define CAJA_WINDOW_INFO_H
 
 #include <glib-object.h>
-
+#include <libcaja-private/caja-view.h>
 #include <gtk/gtk.h>
-
-#include "caja-view.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -27,48 +27,15 @@
  */
 
 #include <config.h>
-#include <fcntl.h>
-#include <string.h>
-#include <unistd.h>
-#include <fcntl.h>
+#include "caja-application.h"
 
-#include <libxml/xmlsave.h>
-#include <glib/gstdio.h>
-#include <glib/gi18n.h>
-#include <gio/gio.h>
-#include <gdk/gdkx.h>
-#include <gtk/gtk.h>
-#include <libnotify/notify.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#define MATE_DESKTOP_USE_UNSTABLE_API
-#include <libmate-desktop/mate-bg.h>
-
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-stock-dialogs.h"
-
-#include "../libcaja-private/caja-debug-log.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-lib-self-check-functions.h"
-#include "../libcaja-private/caja-extensions.h"
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-desktop-link-monitor.h"
-#include "../libcaja-private/caja-directory-private.h"
-#include "../libcaja-private/caja-signaller.h"
-#include "../libcaja-extension/caja-menu-provider.h"
-#include "../libcaja-private/caja-autorun.h"
-
-#if ENABLE_EMPTY_VIEW
-#include "file-manager/fm-empty-view.h"
-#endif /* ENABLE_EMPTY_VIEW */
 #include "file-manager/fm-desktop-icon-view.h"
 #include "file-manager/fm-icon-view.h"
 #include "file-manager/fm-list-view.h"
 #include "file-manager/fm-tree-view.h"
-
-#include "caja-application.h"
+#if ENABLE_EMPTY_VIEW
+#include "file-manager/fm-empty-view.h"
+#endif /* ENABLE_EMPTY_VIEW */
 #include "caja-information-panel.h"
 #include "caja-history-sidebar.h"
 #include "caja-places-sidebar.h"
@@ -76,6 +43,9 @@
 #include "caja-notes-viewer.h"
 #include "caja-emblem-sidebar.h"
 #include "caja-image-properties-page.h"
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
 #include "caja-desktop-window.h"
 #include "caja-spatial-window.h"
 #include "caja-navigation-window.h"
@@ -86,6 +56,33 @@
 #include "caja-window-private.h"
 #include "caja-window-manage-views.h"
 #include "caja-freedesktop-dbus.h"
+#include <libxml/xmlsave.h>
+#include <glib/gstdio.h>
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-stock-dialogs.h>
+#include <gdk/gdkx.h>
+#include <gtk/gtk.h>
+#include <libnotify/notify.h>
+#include <libcaja-private/caja-debug-log.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-lib-self-check-functions.h>
+#include <libcaja-private/caja-extensions.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-desktop-link-monitor.h>
+#include <libcaja-private/caja-directory-private.h>
+#include <libcaja-private/caja-signaller.h>
+#include <libcaja-extension/caja-menu-provider.h>
+#include <libcaja-private/caja-autorun.h>
+#define MATE_DESKTOP_USE_UNSTABLE_API
+#include <libmate-desktop/mate-bg.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 /* Keep window from shrinking down ridiculously small; numbers are somewhat arbitrary */
 #define APPLICATION_WINDOW_MIN_WIDTH	300

--- a/src/caja-application.h
+++ b/src/caja-application.h
@@ -32,7 +32,7 @@
 #include <gio/gio.h>
 #include <gtk/gtk.h>
 
-#include "../libegg/eggsmclient.h"
+#include <libegg/eggsmclient.h>
 
 #define CAJA_DESKTOP_ICON_VIEW_IID "OAFIID:Caja_File_Manager_Desktop_Icon_View"
 

--- a/src/caja-autorun-software.c
+++ b/src/caja-autorun-software.c
@@ -24,17 +24,18 @@
 
 
 #include <config.h>
+
 #include <unistd.h>
 #include <string.h>
 #include <time.h>
 #include <errno.h>
-
 #include <gtk/gtk.h>
 #include <gio/gio.h>
+
 #include <glib/gi18n.h>
 
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-icon-info.h"
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-icon-info.h>
 
 typedef struct
 {

--- a/src/caja-bookmark-list.c
+++ b/src/caja-bookmark-list.c
@@ -26,15 +26,14 @@
  */
 
 #include <config.h>
-#include <string.h>
+#include "caja-bookmark-list.h"
+
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-icon-names.h>
 
 #include <gio/gio.h>
-
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-file.h"
-#include "../libcaja-private/caja-icon-names.h"
-
-#include "caja-bookmark-list.h"
+#include <string.h>
 
 #define LOAD_JOB 1
 #define SAVE_JOB 2

--- a/src/caja-bookmark-list.h
+++ b/src/caja-bookmark-list.h
@@ -28,9 +28,8 @@
 #ifndef CAJA_BOOKMARK_LIST_H
 #define CAJA_BOOKMARK_LIST_H
 
+#include <libcaja-private/caja-bookmark.h>
 #include <gio/gio.h>
-
-#include "../libcaja-private/caja-bookmark.h"
 
 typedef struct CajaBookmarkList CajaBookmarkList;
 typedef struct CajaBookmarkListClass CajaBookmarkListClass;

--- a/src/caja-bookmarks-window.c
+++ b/src/caja-bookmarks-window.c
@@ -26,20 +26,16 @@
  */
 
 #include <config.h>
-#include <cairo-gobject.h>
-
-#include <gtk/gtk.h>
-#include <gdk/gdkkeysyms.h>
-
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-mate-extensions.h"
-
-#include "../libcaja-private/caja-global-preferences.h"
-
 #include "caja-bookmarks-window.h"
 #include "caja-window.h"
 #include "caja-navigation-window.h"
 #include "caja-spatial-window.h"
+#include <libcaja-private/caja-global-preferences.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-mate-extensions.h>
+#include <gtk/gtk.h>
+#include <gdk/gdkkeysyms.h>
+#include <cairo-gobject.h>
 
 /* Static variables to keep track of window state. If there were
  * more than one bookmark-editing window, these would be struct or

--- a/src/caja-connect-server-dialog-main.c
+++ b/src/caja-connect-server-dialog-main.c
@@ -26,16 +26,18 @@
  */
 
 #include <config.h>
-#include <stdlib.h>
 
 #include <glib/gi18n.h>
+
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
 
-#include "../eel/eel-stock-dialogs.h"
+#include <stdlib.h>
 
-#include "../libcaja-private/caja-icon-names.h"
-#include "../libcaja-private/caja-global-preferences.h"
+#include <eel/eel-stock-dialogs.h>
+
+#include <libcaja-private/caja-icon-names.h>
+#include <libcaja-private/caja-global-preferences.h>
 
 #include "caja-connect-server-dialog.h"
 

--- a/src/caja-connect-server-dialog-nonmain.c
+++ b/src/caja-connect-server-dialog-nonmain.c
@@ -22,12 +22,9 @@
  */
 
 #include <config.h>
-
 #include <gio/gio.h>
-
-#include "../libcaja-private/caja-global-preferences.h"
-
 #include "caja-connect-server-dialog.h"
+#include <libcaja-private/caja-global-preferences.h>
 
 /* This file contains the glue for the calls from the connect to server dialog
  * to the main caja binary. A different version of this glue is in

--- a/src/caja-connect-server-dialog.c
+++ b/src/caja-connect-server-dialog.c
@@ -23,22 +23,22 @@
  */
 
 #include <config.h>
-#include <string.h>
 
+#include "caja-connect-server-dialog.h"
+
+#include <string.h>
+#include <eel/eel-stock-dialogs.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>
 
-#include "../eel/eel-stock-dialogs.h"
-
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-icon-names.h"
-
-#include "caja-connect-server-dialog.h"
 #include "caja-application.h"
 #include "caja-bookmark-list.h"
 #include "caja-connect-server-operation.h"
 #include "caja-window.h"
+
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-icon-names.h>
 
 /* TODO:
  * - name entry + pre-fill

--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -23,22 +23,19 @@
  */
 
 #include <config.h>
+#include "caja-desktop-window.h"
+#include "caja-window-private.h"
+#include "caja-actions.h"
 
 #include <X11/Xatom.h>
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
+#include <eel/eel-background.h>
+#include <eel/eel-vfs-extensions.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-icon-names.h>
 #include <gio/gio.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-background.h"
-#include "../eel/eel-vfs-extensions.h"
-
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-icon-names.h"
-
-#include "caja-desktop-window.h"
-#include "caja-window-private.h"
-#include "caja-actions.h"
+#include <glib/gi18n.h>    
 
 /* Tell screen readers that this is a desktop window */
 

--- a/src/caja-emblem-sidebar.c
+++ b/src/caja-emblem-sidebar.c
@@ -29,27 +29,24 @@
  */
 
 #include <config.h>
-#include <stdio.h>
+#include "caja-emblem-sidebar.h"
 
+#include <stdio.h>
+#include <eel/eel-wrap-table.h>
+#include <eel/eel-labeled-image.h>
+#include <eel/eel-graphic-effects.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-gtk-extensions.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
-
-#include "../eel/eel-wrap-table.h"
-#include "../eel/eel-labeled-image.h"
-#include "../eel/eel-graphic-effects.h"
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-gtk-extensions.h"
-
-#include "../libcaja-private/caja-icon-dnd.h"
-#include "../libcaja-private/caja-emblem-utils.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-sidebar-provider.h"
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-signaller.h"
-
-#include "caja-emblem-sidebar.h"
+#include <libcaja-private/caja-icon-dnd.h>
+#include <libcaja-private/caja-emblem-utils.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-sidebar-provider.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-signaller.h>
 
 struct CajaEmblemSidebarDetails
 {

--- a/src/caja-file-management-properties-main.c
+++ b/src/caja-file-management-properties-main.c
@@ -27,8 +27,8 @@
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-module.h"
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-module.h>
 
 #include "caja-file-management-properties.h"
 

--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -23,25 +23,27 @@
 */
 
 #include <config.h>
-#include <string.h>
-#include <time.h>
-
-#include <gtk/gtk.h>
-#include <gio/gio.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-glib-extensions.h"
-
-#include "../libcaja-private/caja-column-chooser.h"
-#include "../libcaja-private/caja-column-utilities.h"
-#include "../libcaja-private/caja-extensions.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-autorun.h"
-
-#include "../libcaja-extension/caja-configurable.h"
 
 #include "caja-file-management-properties.h"
+
+#include <string.h>
+#include <time.h>
+#include <gtk/gtk.h>
+#include <gio/gio.h>
+
+#include <glib/gi18n.h>
+
+#include <eel/eel-glib-extensions.h>
+
+#include <libcaja-private/caja-column-chooser.h>
+#include <libcaja-private/caja-column-utilities.h>
+#include <libcaja-private/caja-extensions.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-module.h>
+
+#include <libcaja-private/caja-autorun.h>
+
+#include <libcaja-extension/caja-configurable.h>
 
 /* string enum preferences */
 #define CAJA_FILE_MANAGEMENT_PROPERTIES_DEFAULT_VIEW_WIDGET "default_view_combobox"

--- a/src/caja-freedesktop-dbus.c
+++ b/src/caja-freedesktop-dbus.c
@@ -23,15 +23,15 @@
 
 #include <config.h>
 
-#include <gio/gio.h>
-
-#include "../libcaja-private/caja-debug-log.h"
-
-#include "file-manager/fm-properties-window.h"
-
 #include "caja-application.h"
 #include "caja-freedesktop-dbus.h"
 #include "caja-freedesktop-generated.h"
+
+#include <libcaja-private/caja-debug-log.h>
+
+#include "file-manager/fm-properties-window.h"
+
+#include <gio/gio.h>
 
 struct _CajaFreedesktopDBus {
     GObject parent;

--- a/src/caja-history-sidebar.c
+++ b/src/caja-history-sidebar.c
@@ -27,19 +27,17 @@
 
 #include <config.h>
 
+#include <eel/eel-gtk-extensions.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <cairo-gobject.h>
-
-#include "../eel/eel-gtk-extensions.h"
-
-#include "../libcaja-private/caja-bookmark.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-sidebar-provider.h"
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-signaller.h"
-#include "../libcaja-private/caja-window-info.h"
-#include "../libcaja-private/caja-window-slot-info.h"
+#include <libcaja-private/caja-bookmark.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-sidebar-provider.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-signaller.h>
+#include <libcaja-private/caja-window-info.h>
+#include <libcaja-private/caja-window-slot-info.h>
 
 #include "caja-history-sidebar.h"
 

--- a/src/caja-history-sidebar.h
+++ b/src/caja-history-sidebar.h
@@ -28,9 +28,8 @@
 #define _CAJA_HISTORY_SIDEBAR_H
 
 #include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-view.h"
-#include "../libcaja-private/caja-window-info.h"
+#include <libcaja-private/caja-view.h>
+#include <libcaja-private/caja-window-info.h>
 
 #define CAJA_HISTORY_SIDEBAR_ID    "history"
 

--- a/src/caja-image-properties-page.c
+++ b/src/caja-image-properties-page.c
@@ -24,11 +24,16 @@
  */
 
 #include <config.h>
-#include <string.h>
+#include "caja-image-properties-page.h"
 
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
+#include <eel/eel-vfs-extensions.h>
+#include <libcaja-extension/caja-property-page-provider.h>
+#include <libcaja-private/caja-module.h>
+#include <string.h>
+
 #ifdef HAVE_EXIF
 #include <libexif/exif-data.h>
 #include <libexif/exif-ifd.h>
@@ -38,13 +43,6 @@
 #include <exempi/xmp.h>
 #include <exempi/xmpconsts.h>
 #endif /*HAVE_EXEMPI*/
-
-#include "../eel/eel-vfs-extensions.h"
-
-#include "../libcaja-extension/caja-property-page-provider.h"
-#include "../libcaja-private/caja-module.h"
-
-#include "caja-image-properties-page.h"
 
 #define LOAD_BUFFER_SIZE 8192
 

--- a/src/caja-information-panel.c
+++ b/src/caja-information-panel.c
@@ -24,32 +24,30 @@
  */
 
 #include <config.h>
+#include "caja-information-panel.h"
 
+#include "caja-sidebar-title.h"
+
+#include <eel/eel-background.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
-
-#include "../eel/eel-background.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-vfs-extensions.h"
-
-#include "../libcaja-private/caja-dnd.h"
-#include "../libcaja-private/caja-directory.h"
-#include "../libcaja-private/caja-file-dnd.h"
-#include "../libcaja-private/caja-file.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-keep-last-vertical-box.h"
-#include "../libcaja-private/caja-metadata.h"
-#include "../libcaja-private/caja-mime-actions.h"
-#include "../libcaja-private/caja-program-choosing.h"
-#include "../libcaja-private/caja-sidebar-provider.h"
-#include "../libcaja-private/caja-module.h"
-
-#include "caja-information-panel.h"
-#include "caja-sidebar-title.h"
+#include <libcaja-private/caja-dnd.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-file-dnd.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-keep-last-vertical-box.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-mime-actions.h>
+#include <libcaja-private/caja-program-choosing.h>
+#include <libcaja-private/caja-sidebar-provider.h>
+#include <libcaja-private/caja-module.h>
 
 struct _CajaInformationPanelPrivate
 {

--- a/src/caja-information-panel.h
+++ b/src/caja-information-panel.h
@@ -28,7 +28,7 @@
 #ifndef CAJA_INFORMATION_PANEL_H
 #define CAJA_INFORMATION_PANEL_H
 
-#include "../eel/eel-background-box.h"
+#include <eel/eel-background-box.h>
 
 #define CAJA_TYPE_INFORMATION_PANEL caja_information_panel_get_type()
 #define CAJA_INFORMATION_PANEL(obj) \

--- a/src/caja-location-bar.c
+++ b/src/caja-location-bar.c
@@ -31,28 +31,25 @@
  */
 
 #include <config.h>
-#include <stdio.h>
-#include <string.h>
-
-#include <gdk/gdkkeysyms.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-accessibility.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-vfs-extensions.h"
-
-#include "../libcaja-private/caja-icon-dnd.h"
-#include "../libcaja-private/caja-clipboard.h"
-
 #include "caja-location-bar.h"
+
 #include "caja-location-entry.h"
 #include "caja-window-private.h"
 #include "caja-window.h"
 #include "caja-navigation-window-pane.h"
+#include <eel/eel-accessibility.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
+#include <gdk/gdkkeysyms.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <libcaja-private/caja-icon-dnd.h>
+#include <libcaja-private/caja-clipboard.h>
+#include <stdio.h>
+#include <string.h>
 
 #define CAJA_DND_URI_LIST_TYPE 	  "text/uri-list"
 #define CAJA_DND_TEXT_PLAIN_TYPE 	  "text/plain"

--- a/src/caja-location-bar.h
+++ b/src/caja-location-bar.h
@@ -30,12 +30,10 @@
 #ifndef CAJA_LOCATION_BAR_H
 #define CAJA_LOCATION_BAR_H
 
-#include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-entry.h"
-
 #include "caja-navigation-window.h"
 #include "caja-navigation-window-pane.h"
+#include <libcaja-private/caja-entry.h>
+#include <gtk/gtk.h>
 
 #define CAJA_TYPE_LOCATION_BAR caja_location_bar_get_type()
 #define CAJA_LOCATION_BAR(obj) \

--- a/src/caja-location-dialog.c
+++ b/src/caja-location-dialog.c
@@ -22,18 +22,15 @@
  */
 
 #include <config.h>
-
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-stock-dialogs.h"
-
-#include "../libcaja-private/caja-file-utilities.h"
-
 #include "caja-location-dialog.h"
+
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-stock-dialogs.h>
+#include <gtk/gtk.h>
+#include <libcaja-private/caja-file-utilities.h>
 #include "caja-location-entry.h"
 #include "caja-desktop-window.h"
+#include <glib/gi18n.h>
 
 struct _CajaLocationDialogDetails
 {

--- a/src/caja-location-entry.c
+++ b/src/caja-location-entry.c
@@ -31,27 +31,24 @@
  */
 
 #include <config.h>
-#include <stdio.h>
-#include <string.h>
+#include "caja-location-entry.h"
 
+#include "caja-window-private.h"
+#include "caja-window.h"
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-string.h"
-
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-entry.h"
-#include "../libcaja-private/caja-icon-dnd.h"
-#include "../libcaja-private/caja-clipboard.h"
-
-#include "caja-location-entry.h"
-#include "caja-window-private.h"
-#include "caja-window.h"
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-entry.h>
+#include <libcaja-private/caja-icon-dnd.h>
+#include <libcaja-private/caja-clipboard.h>
+#include <stdio.h>
+#include <string.h>
 
 struct CajaLocationEntryDetails
 {

--- a/src/caja-location-entry.h
+++ b/src/caja-location-entry.h
@@ -27,7 +27,7 @@
 #ifndef CAJA_LOCATION_ENTRY_H
 #define CAJA_LOCATION_ENTRY_H
 
-#include "../libcaja-private/caja-entry.h"
+#include <libcaja-private/caja-entry.h>
 
 #define CAJA_TYPE_LOCATION_ENTRY caja_location_entry_get_type()
 #define CAJA_LOCATION_ENTRY(obj) \

--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -28,38 +28,35 @@
 /* caja-main.c: Implementation of the routines that drive program lifecycle and main window creation/destruction. */
 
 #include <config.h>
+#include "caja-window.h"
 #include <dlfcn.h>
 #include <signal.h>
+#include <eel/eel-debug.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-self-checks.h>
+#include <libegg/eggdesktopfile.h>
+#include <gdk/gdkx.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <gio/gdesktopappinfo.h>
+#include <libcaja-private/caja-debug-log.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-icon-names.h>
+#include <libxml/parser.h>
 #ifdef HAVE_LOCALE_H
-#include <locale.h>
+	#include <locale.h>
 #endif
 #ifdef HAVE_MALLOC_H
-#include <malloc.h>
+	#include <malloc.h>
 #endif
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-#include <gdk/gdkx.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#include <gio/gdesktopappinfo.h>
-#include <libxml/parser.h>
 #ifdef HAVE_EXEMPI
-#include <exempi/xmp.h>
+	#include <exempi/xmp.h>
 #endif
 
-#include "../eel/eel-debug.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-self-checks.h"
-
-#include "../libcaja-private/caja-debug-log.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-icon-names.h"
-
-#include "../libegg/eggdesktopfile.h"
-
-#include "caja-window.h"
 
 static void dump_debug_log (void)
 {

--- a/src/caja-navigation-action.c
+++ b/src/caja-navigation-action.c
@@ -29,14 +29,12 @@
 
 #include <config.h>
 
-#include <gtk/gtk.h>
-
-#include "../eel/eel-gtk-extensions.h"
-
 #include "caja-navigation-action.h"
 #include "caja-navigation-window.h"
 #include "caja-window-private.h"
 #include "caja-navigation-window-slot.h"
+#include <gtk/gtk.h>
+#include <eel/eel-gtk-extensions.h>
 
 static void caja_navigation_action_init       (CajaNavigationAction *action);
 static void caja_navigation_action_class_init (CajaNavigationActionClass *class);

--- a/src/caja-navigation-window-menus.c
+++ b/src/caja-navigation-window-menus.c
@@ -26,22 +26,8 @@
  *                           split into separate file just for convenience.
  */
 #include <config.h>
+
 #include <locale.h>
-
-#include <libxml/parser.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-mate-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-string.h"
-
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-ui-utilities.h"
-#include "../libcaja-private/caja-search-engine.h"
-#include "../libcaja-private/caja-signaller.h"
 
 #include "caja-actions.h"
 #include "caja-notebook.h"
@@ -57,6 +43,18 @@
 #include "caja-window-private.h"
 #include "caja-window-bookmarks.h"
 #include "caja-navigation-window-pane.h"
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-mate-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <libxml/parser.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-ui-utilities.h>
+#include <libcaja-private/caja-search-engine.h>
+#include <libcaja-private/caja-signaller.h>
 
 #define MENU_PATH_HISTORY_PLACEHOLDER			"/MenuBar/Other Menus/Go/History Placeholder"
 

--- a/src/caja-navigation-window-pane.c
+++ b/src/caja-navigation-window-pane.c
@@ -22,13 +22,6 @@
    Author: Holger Berndt <berndth@gmx.de>
 */
 
-#include "../eel/eel-gtk-extensions.h"
-
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-window-slot-info.h"
-#include "../libcaja-private/caja-view-factory.h"
-#include "../libcaja-private/caja-entry.h"
-
 #include "caja-navigation-window-pane.h"
 #include "caja-window-private.h"
 #include "caja-window-manage-views.h"
@@ -36,6 +29,14 @@
 #include "caja-location-bar.h"
 #include "caja-notebook.h"
 #include "caja-window-slot.h"
+
+#include <eel/eel-gtk-extensions.h>
+
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-window-slot-info.h>
+#include <libcaja-private/caja-view-factory.h>
+#include <libcaja-private/caja-entry.h>
+
 
 static void caja_navigation_window_pane_init       (CajaNavigationWindowPane *pane);
 static void caja_navigation_window_pane_class_init (CajaNavigationWindowPaneClass *class);

--- a/src/caja-navigation-window-slot.c
+++ b/src/caja-navigation-window-slot.c
@@ -22,16 +22,14 @@
    Author: Christian Neumair <cneumair@gnome.org>
 */
 
-#include "../eel/eel-gtk-macros.h"
-
-#include "../libcaja-private/caja-window-slot-info.h"
-#include "../libcaja-private/caja-file.h"
-
 #include "caja-window-slot.h"
 #include "caja-navigation-window-slot.h"
 #include "caja-window-private.h"
 #include "caja-search-bar.h"
 #include "caja-navigation-window-pane.h"
+#include <libcaja-private/caja-window-slot-info.h>
+#include <libcaja-private/caja-file.h>
+#include <eel/eel-gtk-macros.h>
 
 static void caja_navigation_window_slot_init       (CajaNavigationWindowSlot *slot);
 static void caja_navigation_window_slot_class_init (CajaNavigationWindowSlotClass *class);

--- a/src/caja-navigation-window.c
+++ b/src/caja-navigation-window.c
@@ -29,38 +29,8 @@
 /* caja-window.c: Implementation of the main window object */
 
 #include <config.h>
-#include <math.h>
-
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdkx.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#ifdef HAVE_X11_XF86KEYSYM_H
-#include <X11/XF86keysym.h>
-#endif
-#include <sys/time.h>
-
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-string.h"
-
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-file-attributes.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-icon-info.h"
-#include "../libcaja-private/caja-metadata.h"
-#include "../libcaja-private/caja-mime-actions.h"
-#include "../libcaja-private/caja-program-choosing.h"
-#include "../libcaja-private/caja-sidebar.h"
-#include "../libcaja-private/caja-view-factory.h"
-#include "../libcaja-private/caja-clipboard.h"
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-sidebar-provider.h"
-#include "../libcaja-private/caja-search-directory.h"
-#include "../libcaja-private/caja-signaller.h"
-
-#include "caja-navigation-window.h"
 #include "caja-window-private.h"
+
 #include "caja-actions.h"
 #include "caja-application.h"
 #include "caja-bookmarks-window.h"
@@ -71,6 +41,32 @@
 #include "caja-notebook.h"
 #include "caja-window-manage-views.h"
 #include "caja-navigation-window-pane.h"
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-string.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdkx.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#ifdef HAVE_X11_XF86KEYSYM_H
+#include <X11/XF86keysym.h>
+#endif
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-icon-info.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-mime-actions.h>
+#include <libcaja-private/caja-program-choosing.h>
+#include <libcaja-private/caja-sidebar.h>
+#include <libcaja-private/caja-view-factory.h>
+#include <libcaja-private/caja-clipboard.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-sidebar-provider.h>
+#include <libcaja-private/caja-search-directory.h>
+#include <libcaja-private/caja-signaller.h>
+#include <math.h>
+#include <sys/time.h>
 
 #define MAX_TITLE_LENGTH 180
 

--- a/src/caja-navigation-window.h
+++ b/src/caja-navigation-window.h
@@ -31,12 +31,9 @@
 #define CAJA_NAVIGATION_WINDOW_H
 
 #include <gtk/gtk.h>
-
-#include "../eel/eel-glib-extensions.h"
-
-#include "../libcaja-private/caja-bookmark.h"
-#include "../libcaja-private/caja-sidebar.h"
-
+#include <eel/eel-glib-extensions.h>
+#include <libcaja-private/caja-bookmark.h>
+#include <libcaja-private/caja-sidebar.h>
 #include "caja-application.h"
 #include "caja-information-panel.h"
 #include "caja-side-pane.h"

--- a/src/caja-notebook.c
+++ b/src/caja-notebook.c
@@ -24,13 +24,7 @@
  *
  */
 
-#include <config.h>
-
-#include <glib/gi18n.h>
-#include <gio/gio.h>
-#include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-dnd.h"
+#include "config.h"
 
 #include "caja-notebook.h"
 #include "caja-navigation-window.h"
@@ -38,6 +32,11 @@
 #include "caja-window-private.h"
 #include "caja-window-slot.h"
 #include "caja-navigation-window-pane.h"
+#include <libcaja-private/caja-dnd.h>
+
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <gtk/gtk.h>
 
 #define AFTER_ALL_TABS -1
 

--- a/src/caja-notes-viewer.c
+++ b/src/caja-notes-viewer.c
@@ -27,25 +27,23 @@
 
 #include <config.h>
 
+#include "caja-notes-viewer.h"
+
+#include <eel/eel-debug.h>
+#include <eel/eel-gtk-extensions.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
-
-#include "../eel/eel-debug.h"
-#include "../eel/eel-gtk-extensions.h"
-
-#include "../libcaja-private/caja-file-attributes.h"
-#include "../libcaja-private/caja-file.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-metadata.h"
-#include "../libcaja-private/caja-clipboard.h"
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-sidebar-provider.h"
-#include "../libcaja-private/caja-window-info.h"
-#include "../libcaja-private/caja-window-slot-info.h"
-#include "../libcaja-extension/caja-property-page-provider.h"
-
-#include "caja-notes-viewer.h"
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-clipboard.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-sidebar-provider.h>
+#include <libcaja-private/caja-window-info.h>
+#include <libcaja-private/caja-window-slot-info.h>
+#include <libcaja-extension/caja-property-page-provider.h>
 
 #define SAVE_TIMEOUT 3
 

--- a/src/caja-notes-viewer.h
+++ b/src/caja-notes-viewer.h
@@ -27,9 +27,8 @@
 #define _CAJA_NOTES_VIEWER_H
 
 #include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-view.h"
-#include "../libcaja-private/caja-window-info.h"
+#include <libcaja-private/caja-view.h>
+#include <libcaja-private/caja-window-info.h>
 
 #define CAJA_NOTES_SIDEBAR_ID    "notes"
 

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -20,19 +20,16 @@
 
 #include <config.h>
 #include <string.h>
-
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-
-#include "../libcaja-private/caja-file.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-icon-names.h"
-#include "../libcaja-private/caja-trash-monitor.h"
-#include "../libcaja-private/caja-dnd.h"
-#include "../libcaja-private/caja-icon-dnd.h"
-
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-icon-names.h>
+#include <libcaja-private/caja-trash-monitor.h>
+#include <libcaja-private/caja-dnd.h>
+#include <libcaja-private/caja-icon-dnd.h>
 #include "caja-pathbar.h"
 
 enum

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -23,40 +23,37 @@
  */
 
 #include <config.h>
-#include <cairo-gobject.h>
 
+#include <eel/eel-debug.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-graphic-effects.h>
+#include <eel/eel-string.h>
+#include <eel/eel-stock-dialogs.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
+#include <libcaja-private/caja-debug-log.h>
+#include <libcaja-private/caja-dnd.h>
+#include <libcaja-private/caja-bookmark.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-sidebar-provider.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-file-operations.h>
+#include <libcaja-private/caja-trash-monitor.h>
+#include <libcaja-private/caja-icon-names.h>
+#include <libcaja-private/caja-autorun.h>
+#include <libcaja-private/caja-window-info.h>
+#include <libcaja-private/caja-window-slot-info.h>
 #include <gio/gio.h>
 #include <libnotify/notify.h>
-
-#include "../eel/eel-debug.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-graphic-effects.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-stock-dialogs.h"
-
-#include "../libcaja-private/caja-debug-log.h"
-#include "../libcaja-private/caja-dnd.h"
-#include "../libcaja-private/caja-bookmark.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-sidebar-provider.h"
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-file.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-file-operations.h"
-#include "../libcaja-private/caja-trash-monitor.h"
-#include "../libcaja-private/caja-icon-names.h"
-#include "../libcaja-private/caja-autorun.h"
-#include "../libcaja-private/caja-window-info.h"
-#include "../libcaja-private/caja-window-slot-info.h"
+#include <cairo-gobject.h>
 
 #include "caja-bookmark-list.h"
 #include "caja-places-sidebar.h"
 #include "caja-window.h"
-
 #define EJECT_BUTTON_XPAD 6
 #define ICON_CELL_XPAD 6
 

--- a/src/caja-places-sidebar.h
+++ b/src/caja-places-sidebar.h
@@ -24,10 +24,9 @@
 #ifndef _CAJA_PLACES_SIDEBAR_H
 #define _CAJA_PLACES_SIDEBAR_H
 
+#include <libcaja-private/caja-view.h>
+#include <libcaja-private/caja-window-info.h>
 #include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-view.h"
-#include "../libcaja-private/caja-window-info.h"
 
 #define CAJA_PLACES_SIDEBAR_ID    "places"
 

--- a/src/caja-property-browser.c
+++ b/src/caja-property-browser.c
@@ -30,34 +30,31 @@
 
 #include <config.h>
 #include <math.h>
+#include "caja-property-browser.h"
 
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-image-table.h>
+#include <eel/eel-labeled-image.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-xml-extensions.h>
 #include <libxml/parser.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
 #include <gio/gio.h>
+#include <libcaja-private/caja-customization-data.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-emblem-utils.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-signaller.h>
 #include <atk/atkrelationset.h>
-
-#include "../eel/eel-gdk-extensions.h"
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-image-table.h"
-#include "../eel/eel-labeled-image.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-vfs-extensions.h"
-#include "../eel/eel-xml-extensions.h"
-
-#include "../libcaja-private/caja-customization-data.h"
-#include "../libcaja-private/caja-directory.h"
-#include "../libcaja-private/caja-emblem-utils.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-file.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-metadata.h"
-#include "../libcaja-private/caja-signaller.h"
-
-#include "caja-property-browser.h"
 
 /* property types */
 

--- a/src/caja-query-editor.c
+++ b/src/caja-query-editor.c
@@ -22,22 +22,19 @@
  */
 
 #include <config.h>
-#include <string.h>
-
-#include <glib/gi18n.h>
-#include <gio/gio.h>
-#include <gdk/gdkkeysyms.h>
-#include <gtk/gtk.h>
-
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-stock-dialogs.h"
-
-#include "../libcaja-private/caja-global-preferences.h"
-
 #include "caja-query-editor.h"
 #include "caja-src-marshal.h"
 #include "caja-window-slot.h"
+
+#include <string.h>
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-stock-dialogs.h>
+#include <gdk/gdkkeysyms.h>
+#include <gtk/gtk.h>
+#include <libcaja-private/caja-global-preferences.h>
 
 enum
 {

--- a/src/caja-query-editor.h
+++ b/src/caja-query-editor.h
@@ -24,12 +24,11 @@
 #ifndef CAJA_QUERY_EDITOR_H
 #define CAJA_QUERY_EDITOR_H
 
-#include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-query.h"
-#include "../libcaja-private/caja-window-info.h"
-
 #include "caja-search-bar.h"
+
+#include <gtk/gtk.h>
+#include <libcaja-private/caja-query.h>
+#include <libcaja-private/caja-window-info.h>
 
 #define CAJA_TYPE_QUERY_EDITOR caja_query_editor_get_type()
 #define CAJA_QUERY_EDITOR(obj) \

--- a/src/caja-search-bar.c
+++ b/src/caja-search-bar.c
@@ -22,16 +22,13 @@
  */
 
 #include <config.h>
+#include "caja-search-bar.h"
 
 #include <glib/gi18n.h>
+#include <eel/eel-gtk-macros.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
-
-#include "../eel/eel-gtk-macros.h"
-
-#include "../libcaja-private/caja-clipboard.h"
-
-#include "caja-search-bar.h"
+#include <libcaja-private/caja-clipboard.h>
 
 struct CajaSearchBarDetails
 {

--- a/src/caja-search-bar.h
+++ b/src/caja-search-bar.h
@@ -25,9 +25,7 @@
 #define CAJA_SEARCH_BAR_H
 
 #include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-query.h"
-
+#include <libcaja-private/caja-query.h>
 #include "caja-window.h"
 
 #define CAJA_TYPE_SEARCH_BAR caja_search_bar_get_type()

--- a/src/caja-side-pane.c
+++ b/src/caja-side-pane.c
@@ -22,16 +22,14 @@
  */
 
 #include <config.h>
+#include "caja-side-pane.h"
 
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
-
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-
-#include "caja-side-pane.h"
 
 typedef struct
 {

--- a/src/caja-sidebar-title.c
+++ b/src/caja-sidebar-title.c
@@ -26,26 +26,24 @@
 
 #include <config.h>
 #include <math.h>
-#include <string.h>
-#include <stdlib.h>
+#include "caja-sidebar-title.h"
 
+#include "caja-window.h"
+
+#include <eel/eel-background.h>
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
 #include <gtk/gtk.h>
 #include <pango/pango.h>
 #include <glib/gi18n.h>
-
-#include "../eel/eel-background.h"
-#include "../eel/eel-gdk-extensions.h"
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-
-#include "../libcaja-private/caja-file-attributes.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-metadata.h"
-#include "../libcaja-private/caja-sidebar.h"
-
-#include "caja-sidebar-title.h"
-#include "caja-window.h"
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-sidebar.h>
+#include <string.h>
+#include <stdlib.h>
 
 /* maximum allowable size to be displayed as the title */
 #define MAX_TITLE_SIZE 		256

--- a/src/caja-sidebar-title.h
+++ b/src/caja-sidebar-title.h
@@ -30,10 +30,8 @@
 #define CAJA_SIDEBAR_TITLE_H
 
 #include <gtk/gtk.h>
-
-#include "../eel/eel-background.h"
-
-#include "../libcaja-private/caja-file.h"
+#include <eel/eel-background.h>
+#include <libcaja-private/caja-file.h>
 
 #define CAJA_TYPE_SIDEBAR_TITLE caja_sidebar_title_get_type()
 #define CAJA_SIDEBAR_TITLE(obj) \

--- a/src/caja-spatial-window.c
+++ b/src/caja-spatial-window.c
@@ -28,32 +28,10 @@
 /* caja-window.c: Implementation of the main window object */
 
 #include <config.h>
-
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdkkeysyms.h>
-#include <gdk/gdkx.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-string.h"
-
-#include "../libcaja-private/caja-dnd.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-ui-utilities.h"
-#include "../libcaja-private/caja-file-attributes.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-metadata.h"
-#include "../libcaja-private/caja-mime-actions.h"
-#include "../libcaja-private/caja-program-choosing.h"
-#include "../libcaja-private/caja-search-directory.h"
-#include "../libcaja-private/caja-search-engine.h"
-#include "../libcaja-private/caja-signaller.h"
-
 #include "caja-spatial-window.h"
 #include "caja-window-private.h"
 #include "caja-window-bookmarks.h"
+
 #include "caja-actions.h"
 #include "caja-application.h"
 #include "caja-desktop-window.h"
@@ -62,6 +40,25 @@
 #include "caja-query-editor.h"
 #include "caja-search-bar.h"
 #include "caja-window-manage-views.h"
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-string.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdkkeysyms.h>
+#include <gdk/gdkx.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <libcaja-private/caja-dnd.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-ui-utilities.h>
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-mime-actions.h>
+#include <libcaja-private/caja-program-choosing.h>
+#include <libcaja-private/caja-search-directory.h>
+#include <libcaja-private/caja-search-engine.h>
+#include <libcaja-private/caja-signaller.h>
 
 #define MAX_TITLE_LENGTH 180
 #define MAX_SHORTNAME_PATH 16

--- a/src/caja-trash-bar.c
+++ b/src/caja-trash-bar.c
@@ -20,18 +20,18 @@
  *
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
 
-#include "../libcaja-private/caja-file-operations.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-file.h"
-#include "../libcaja-private/caja-trash-monitor.h"
-
 #include "caja-trash-bar.h"
+
 #include "caja-window.h"
+#include <libcaja-private/caja-file-operations.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-trash-monitor.h>
 
 #define CAJA_TRASH_BAR_GET_PRIVATE(o)\
 	(G_TYPE_INSTANCE_GET_PRIVATE ((o), CAJA_TYPE_TRASH_BAR, CajaTrashBarPrivate))

--- a/src/caja-view-as-action.c
+++ b/src/caja-view-as-action.c
@@ -25,16 +25,13 @@
 
 #include <config.h>
 
-#include <gtk/gtk.h>
-
-#include "../eel/eel-gtk-extensions.h"
-
-#include "../libcaja-private/caja-view-factory.h"
-
 #include "caja-view-as-action.h"
 #include "caja-navigation-window.h"
 #include "caja-window-private.h"
 #include "caja-navigation-window-slot.h"
+#include <gtk/gtk.h>
+#include <eel/eel-gtk-extensions.h>
+#include <libcaja-private/caja-view-factory.h>
 
 static void caja_view_as_action_init       (CajaViewAsAction *action);
 static void caja_view_as_action_class_init (CajaViewAsActionClass *class);

--- a/src/caja-window-bookmarks.c
+++ b/src/caja-window-bookmarks.c
@@ -25,20 +25,19 @@
  */
 
 #include <config.h>
+
 #include <locale.h>
-
-#include <glib/gi18n.h>
-
-#include "../eel/eel-debug.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-vfs-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
 
 #include "caja-actions.h"
 #include "caja-bookmark-list.h"
 #include "caja-bookmarks-window.h"
 #include "caja-window-bookmarks.h"
 #include "caja-window-private.h"
+#include <eel/eel-debug.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <glib/gi18n.h>
 
 #define MENU_ITEM_MAX_WIDTH_CHARS 32
 

--- a/src/caja-window-bookmarks.h
+++ b/src/caja-window-bookmarks.h
@@ -25,10 +25,10 @@
 #ifndef CAJA_WINDOW_BOOKMARKS_H
 #define CAJA_WINDOW_BOOKMARKS_H
 
-#include "../libcaja-private/caja-bookmark.h"
-
 #include "caja-bookmark-list.h"
 #include "caja-window.h"
+
+#include <libcaja-private/caja-bookmark.h>
 
 void                  caja_bookmarks_exiting                        (void);
 void                  caja_window_add_bookmark_for_current_location (CajaWindow *window);

--- a/src/caja-window-manage-views.c
+++ b/src/caja-window-manage-views.c
@@ -26,40 +26,8 @@
  */
 
 #include <config.h>
-
-#include <gtk/gtk.h>
-#include <gdk/gdkx.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-accessibility.h"
-#include "../eel/eel-debug.h"
-#include "../eel/eel-gdk-extensions.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-stock-dialogs.h"
-#include "../eel/eel-string.h"
-#include "../eel/eel-vfs-extensions.h"
-
-#include "../libcaja-private/caja-debug-log.h"
-#include "../libcaja-private/caja-extensions.h"
-#include "../libcaja-private/caja-file-attributes.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-file.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-metadata.h"
-#include "../libcaja-private/caja-mime-actions.h"
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-monitor.h"
-#include "../libcaja-private/caja-search-directory.h"
-#include "../libcaja-private/caja-view-factory.h"
-#include "../libcaja-private/caja-window-info.h"
-#include "../libcaja-private/caja-window-slot-info.h"
-#include "../libcaja-private/caja-autorun.h"
-
-#include "../libcaja-extension/caja-location-widget-provider.h"
-
 #include "caja-window-manage-views.h"
+
 #include "caja-actions.h"
 #include "caja-application.h"
 #include "caja-location-bar.h"
@@ -71,6 +39,34 @@
 #include "caja-trash-bar.h"
 #include "caja-x-content-bar.h"
 #include "caja-navigation-window-pane.h"
+#include <eel/eel-accessibility.h>
+#include <eel/eel-debug.h>
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
+#include <gtk/gtk.h>
+#include <gdk/gdkx.h>
+#include <glib/gi18n.h>
+#include <libcaja-extension/caja-location-widget-provider.h>
+#include <libcaja-private/caja-debug-log.h>
+#include <libcaja-private/caja-extensions.h>
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-mime-actions.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-monitor.h>
+#include <libcaja-private/caja-search-directory.h>
+#include <libcaja-private/caja-view-factory.h>
+#include <libcaja-private/caja-window-info.h>
+#include <libcaja-private/caja-window-slot-info.h>
+#include <libcaja-private/caja-autorun.h>
 
 /* FIXME bugzilla.gnome.org 41243:
  * We should use inheritance instead of these special cases

--- a/src/caja-window-menus.c
+++ b/src/caja-window-menus.c
@@ -26,26 +26,8 @@
  *                           split into separate file just for convenience.
  */
 #include <config.h>
+
 #include <locale.h>
-#include <string.h>
-
-#include <gtk/gtk.h>
-#include <gio/gio.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-gtk-extensions.h"
-
-#include "../libcaja-extension/caja-menu-provider.h"
-#include "../libcaja-private/caja-extensions.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-icon-names.h"
-#include "../libcaja-private/caja-ui-utilities.h"
-#include "../libcaja-private/caja-module.h"
-#include "../libcaja-private/caja-search-directory.h"
-#include "../libcaja-private/caja-search-engine.h"
-#include "../libcaja-private/caja-signaller.h"
-#include "../libcaja-private/caja-trash-monitor.h"
 
 #include "caja-actions.h"
 #include "caja-application.h"
@@ -57,6 +39,22 @@
 #include "caja-window-private.h"
 #include "caja-desktop-window.h"
 #include "caja-search-bar.h"
+#include <gtk/gtk.h>
+#include <gio/gio.h>
+#include <glib/gi18n.h>
+#include <eel/eel-gtk-extensions.h>
+#include <libcaja-extension/caja-menu-provider.h>
+#include <libcaja-private/caja-extensions.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-icon-names.h>
+#include <libcaja-private/caja-ui-utilities.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-search-directory.h>
+#include <libcaja-private/caja-search-engine.h>
+#include <libcaja-private/caja-signaller.h>
+#include <libcaja-private/caja-trash-monitor.h>
+#include <string.h>
 
 #define MENU_PATH_EXTENSION_ACTIONS                     "/MenuBar/File/Extension Actions"
 #define POPUP_PATH_EXTENSION_ACTIONS                     "/background/Before Zoom Items/Extension Actions"

--- a/src/caja-window-pane.c
+++ b/src/caja-window-pane.c
@@ -22,12 +22,11 @@
    Author: Holger Berndt <berndth@gmx.de>
 */
 
-#include "../eel/eel-gtk-macros.h"
-
 #include "caja-window-pane.h"
 #include "caja-window-private.h"
 #include "caja-navigation-window-pane.h"
 #include "caja-window-manage-views.h"
+#include <eel/eel-gtk-macros.h>
 
 static void caja_window_pane_init       (CajaWindowPane *pane);
 static void caja_window_pane_class_init (CajaWindowPaneClass *class);

--- a/src/caja-window-private.h
+++ b/src/caja-window-private.h
@@ -28,14 +28,14 @@
 #ifndef CAJA_WINDOW_PRIVATE_H
 #define CAJA_WINDOW_PRIVATE_H
 
-#include "../libcaja-private/caja-directory.h"
-
 #include "caja-window.h"
 #include "caja-window-slot.h"
 #include "caja-window-pane.h"
 #include "caja-spatial-window.h"
 #include "caja-navigation-window.h"
 #include "caja-bookmark-list.h"
+
+#include <libcaja-private/caja-directory.h>
 
 struct _CajaNavigationWindowPane;
 

--- a/src/caja-window-slot.c
+++ b/src/caja-window-slot.c
@@ -21,19 +21,17 @@
 
    Author: Christian Neumair <cneumair@gnome.org>
 */
-
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-string.h"
-
-#include "../libcaja-private/caja-file.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-window-slot-info.h"
-
 #include "caja-window-slot.h"
 #include "caja-navigation-window-slot.h"
+
 #include "caja-desktop-window.h"
 #include "caja-window-private.h"
 #include "caja-window-manage-views.h"
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-window-slot-info.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-string.h>
 
 static void caja_window_slot_init       (CajaWindowSlot *slot);
 static void caja_window_slot_class_init (CajaWindowSlotClass *class);

--- a/src/caja-window-toolbars.c
+++ b/src/caja-window-toolbars.c
@@ -27,28 +27,25 @@
  */
 
 #include <config.h>
+
 #include <unistd.h>
-
-#include <gtk/gtk.h>
-#include <gdk/gdkkeysyms.h>
-#include <glib/gi18n.h>
-
-#include "../eel/eel-mate-extensions.h"
-#include "../eel/eel-gtk-extensions.h"
-#include "../eel/eel-string.h"
-
-#include "../libcaja-extension/caja-menu-provider.h"
-#include "../libcaja-private/caja-bookmark.h"
-#include "../libcaja-private/caja-extensions.h"
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-ui-utilities.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-module.h"
-
 #include "caja-application.h"
 #include "caja-window-manage-views.h"
 #include "caja-window-private.h"
 #include "caja-window.h"
+#include <eel/eel-mate-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-string.h>
+#include <gtk/gtk.h>
+#include <gdk/gdkkeysyms.h>
+#include <glib/gi18n.h>
+#include <libcaja-extension/caja-menu-provider.h>
+#include <libcaja-private/caja-bookmark.h>
+#include <libcaja-private/caja-extensions.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-ui-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-module.h>
 
 /* FIXME bugzilla.gnome.org 41243:
  * We should use inheritance instead of these special cases

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -26,32 +26,8 @@
 /* caja-window.c: Implementation of the main window object */
 
 #include <config.h>
-
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdkx.h>
-#include <gdk/gdkkeysyms.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#ifdef HAVE_X11_XF86KEYSYM_H
-#include <X11/XF86keysym.h>
-#endif
-
-#include "../eel/eel-debug.h"
-#include "../eel/eel-gtk-macros.h"
-#include "../eel/eel-string.h"
-
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-file-attributes.h"
-#include "../libcaja-private/caja-global-preferences.h"
-#include "../libcaja-private/caja-metadata.h"
-#include "../libcaja-private/caja-mime-actions.h"
-#include "../libcaja-private/caja-program-choosing.h"
-#include "../libcaja-private/caja-view-factory.h"
-#include "../libcaja-private/caja-clipboard.h"
-#include "../libcaja-private/caja-search-directory.h"
-#include "../libcaja-private/caja-signaller.h"
-
 #include "caja-window-private.h"
+
 #include "caja-actions.h"
 #include "caja-application.h"
 #include "caja-bookmarks-window.h"
@@ -63,6 +39,27 @@
 #include "caja-search-bar.h"
 #include "caja-navigation-window-pane.h"
 #include "caja-src-marshal.h"
+#include <eel/eel-debug.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-string.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdkx.h>
+#include <gdk/gdkkeysyms.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#ifdef HAVE_X11_XF86KEYSYM_H
+#include <X11/XF86keysym.h>
+#endif
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-mime-actions.h>
+#include <libcaja-private/caja-program-choosing.h>
+#include <libcaja-private/caja-view-factory.h>
+#include <libcaja-private/caja-clipboard.h>
+#include <libcaja-private/caja-search-directory.h>
+#include <libcaja-private/caja-signaller.h>
 
 #define MAX_HISTORY_ITEMS 50
 

--- a/src/caja-window.h
+++ b/src/caja-window.h
@@ -28,14 +28,11 @@
 #define CAJA_WINDOW_H
 
 #include <gtk/gtk.h>
-
-#include "../eel/eel-glib-extensions.h"
-
-#include "../libcaja-private/caja-bookmark.h"
-#include "../libcaja-private/caja-entry.h"
-#include "../libcaja-private/caja-window-info.h"
-#include "../libcaja-private/caja-search-directory.h"
-
+#include <eel/eel-glib-extensions.h>
+#include <libcaja-private/caja-bookmark.h>
+#include <libcaja-private/caja-entry.h>
+#include <libcaja-private/caja-window-info.h>
+#include <libcaja-private/caja-search-directory.h>
 #include "caja-application.h"
 #include "caja-information-panel.h"
 #include "caja-side-pane.h"

--- a/src/caja-x-content-bar.c
+++ b/src/caja-x-content-bar.c
@@ -22,16 +22,15 @@
  *
  */
 
-#include <config.h>
-#include <string.h>
+#include "config.h"
 
 #include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-autorun.h"
-#include "../libcaja-private/caja-icon-info.h"
+#include <string.h>
 
 #include "caja-x-content-bar.h"
+#include <libcaja-private/caja-autorun.h>
+#include <libcaja-private/caja-icon-info.h>
 
 struct _CajaXContentBarPrivate
 {

--- a/src/caja-zoom-action.c
+++ b/src/caja-zoom-action.c
@@ -25,15 +25,13 @@
 
 #include <config.h>
 
-#include <gtk/gtk.h>
-
-#include "../eel/eel-gtk-extensions.h"
-
 #include "caja-zoom-action.h"
 #include "caja-zoom-control.h"
 #include "caja-navigation-window.h"
 #include "caja-window-private.h"
 #include "caja-navigation-window-slot.h"
+#include <gtk/gtk.h>
+#include <eel/eel-gtk-extensions.h>
 
 static void caja_zoom_action_init       (CajaZoomAction *action);
 static void caja_zoom_action_class_init (CajaZoomActionClass *class);

--- a/src/caja-zoom-control.c
+++ b/src/caja-zoom-control.c
@@ -28,25 +28,22 @@
  */
 
 #include <config.h>
-#include <math.h>
-#include <stdlib.h>
-#include <string.h>
+#include "caja-zoom-control.h"
 
 #include <atk/atkaction.h>
 #include <glib/gi18n.h>
+#include <eel/eel-accessibility.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-graphic-effects.h>
+#include <eel/eel-gtk-extensions.h>
 #include <gtk/gtk.h>
 #include <gtk/gtk-a11y.h>
 #include <gdk/gdkkeysyms.h>
-
-#include "../eel/eel-accessibility.h"
-#include "../eel/eel-glib-extensions.h"
-#include "../eel/eel-graphic-effects.h"
-#include "../eel/eel-gtk-extensions.h"
-
-#include "../libcaja-private/caja-file-utilities.h"
-#include "../libcaja-private/caja-global-preferences.h"
-
-#include "caja-zoom-control.h"
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 enum
 {

--- a/src/caja-zoom-control.h
+++ b/src/caja-zoom-control.h
@@ -29,8 +29,7 @@
 #define CAJA_ZOOM_CONTROL_H
 
 #include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-icon-info.h" /* For CajaZoomLevel */
+#include <libcaja-private/caja-icon-info.h> /* For CajaZoomLevel */
 
 #define CAJA_TYPE_ZOOM_CONTROL caja_zoom_control_get_type()
 #define CAJA_ZOOM_CONTROL(obj) \

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -25,42 +25,39 @@
 */
 
 #include <config.h>
+#include "fm-icon-container.h"
+#include "fm-desktop-icon-view.h"
+#include "fm-actions.h"
+
+#include <X11/Xatom.h>
+#include <gtk/gtk.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-vfs-extensions.h>
 #include <fcntl.h>
+#include <gdk/gdkx.h>
+#include <glib/gi18n.h>
+#include <libcaja-private/caja-desktop-icon-file.h>
+#include <libcaja-private/caja-directory-background.h>
+#include <libcaja-private/caja-directory-notify.h>
+#include <libcaja-private/caja-file-changes-queue.h>
+#include <libcaja-private/caja-file-operations.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-ui-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-view-factory.h>
+#include <libcaja-private/caja-link.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-monitor.h>
+#include <libcaja-private/caja-program-choosing.h>
+#include <libcaja-private/caja-trash-monitor.h>
 #include <limits.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
-
-#include <X11/Xatom.h>
-#include <gtk/gtk.h>
-#include <gdk/gdkx.h>
-#include <glib/gi18n.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-
-#include "../../eel/eel-glib-extensions.h"
-#include "../../eel/eel-gtk-extensions.h"
-#include "../../eel/eel-vfs-extensions.h"
-
-#include "../../libcaja-private/caja-desktop-icon-file.h"
-#include "../../libcaja-private/caja-directory-background.h"
-#include "../../libcaja-private/caja-directory-notify.h"
-#include "../../libcaja-private/caja-file-changes-queue.h"
-#include "../../libcaja-private/caja-file-operations.h"
-#include "../../libcaja-private/caja-file-utilities.h"
-#include "../../libcaja-private/caja-ui-utilities.h"
-#include "../../libcaja-private/caja-global-preferences.h"
-#include "../../libcaja-private/caja-view-factory.h"
-#include "../../libcaja-private/caja-link.h"
-#include "../../libcaja-private/caja-metadata.h"
-#include "../../libcaja-private/caja-monitor.h"
-#include "../../libcaja-private/caja-program-choosing.h"
-#include "../../libcaja-private/caja-trash-monitor.h"
-
-#include "fm-icon-container.h"
-#include "fm-desktop-icon-view.h"
-#include "fm-actions.h"
+#include <unistd.h>
 
 /* Timeout to check the desktop directory for updates */
 #define RESCAN_TIMEOUT 4

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -29,65 +29,63 @@
 
 #include <config.h>
 #include <math.h>
+#include "fm-directory-view.h"
+#include "fm-list-view.h"
+#include "fm-desktop-icon-view.h"
 
+#include "fm-actions.h"
+#include "fm-error-reporting.h"
+#include "fm-marshal.h"
+#include "fm-properties-window.h"
+#include "libcaja-private/caja-open-with-dialog.h"
+
+#include <eel/eel-background.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-mate-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
 #include <gdk/gdkkeysyms.h>
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
 #include <gio/gio.h>
+#include <libcaja-private/caja-recent.h>
+#include <libcaja-extension/caja-menu-provider.h>
+#include <libcaja-private/caja-clipboard.h>
+#include <libcaja-private/caja-clipboard-monitor.h>
+#include <libcaja-private/caja-debug-log.h>
+#include <libcaja-private/caja-desktop-icon-file.h>
+#include <libcaja-private/caja-desktop-directory.h>
+#include <libcaja-private/caja-extensions.h>
+#include <libcaja-private/caja-search-directory.h>
+#include <libcaja-private/caja-directory-background.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-dnd.h>
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-file-changes-queue.h>
+#include <libcaja-private/caja-file-dnd.h>
+#include <libcaja-private/caja-file-operations.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-file-private.h> /* for caja_file_get_existing_by_uri */
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-link.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-mime-actions.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-program-choosing.h>
+#include <libcaja-private/caja-trash-monitor.h>
+#include <libcaja-private/caja-ui-utilities.h>
+#include <libcaja-private/caja-signaller.h>
+#include <libcaja-private/caja-autorun.h>
+#include <libcaja-private/caja-icon-names.h>
+#include <libcaja-private/caja-undostack-manager.h>
 
 #define MATE_DESKTOP_USE_UNSTABLE_API
 #include <libmate-desktop/mate-desktop-utils.h>
-
-#include "../../eel/eel-background.h"
-#include "../../eel/eel-glib-extensions.h"
-#include "../../eel/eel-mate-extensions.h"
-#include "../../eel/eel-gtk-extensions.h"
-#include "../../eel/eel-gtk-macros.h"
-#include "../../eel/eel-stock-dialogs.h"
-#include "../../eel/eel-string.h"
-#include "../../eel/eel-vfs-extensions.h"
-
-#include "../../libcaja-private/caja-recent.h"
-#include "../../libcaja-extension/caja-menu-provider.h"
-#include "../../libcaja-private/caja-clipboard.h"
-#include "../../libcaja-private/caja-clipboard-monitor.h"
-#include "../../libcaja-private/caja-debug-log.h"
-#include "../../libcaja-private/caja-desktop-icon-file.h"
-#include "../../libcaja-private/caja-desktop-directory.h"
-#include "../../libcaja-private/caja-extensions.h"
-#include "../../libcaja-private/caja-search-directory.h"
-#include "../../libcaja-private/caja-directory-background.h"
-#include "../../libcaja-private/caja-directory.h"
-#include "../../libcaja-private/caja-dnd.h"
-#include "../../libcaja-private/caja-file-attributes.h"
-#include "../../libcaja-private/caja-file-changes-queue.h"
-#include "../../libcaja-private/caja-file-dnd.h"
-#include "../../libcaja-private/caja-file-operations.h"
-#include "../../libcaja-private/caja-file-utilities.h"
-#include "../../libcaja-private/caja-file-private.h" /* for caja_file_get_existing_by_uri */
-#include "../../libcaja-private/caja-global-preferences.h"
-#include "../../libcaja-private/caja-link.h"
-#include "../../libcaja-private/caja-metadata.h"
-#include "../../libcaja-private/caja-mime-actions.h"
-#include "../../libcaja-private/caja-module.h"
-#include "../../libcaja-private/caja-program-choosing.h"
-#include "../../libcaja-private/caja-trash-monitor.h"
-#include "../../libcaja-private/caja-ui-utilities.h"
-#include "../../libcaja-private/caja-signaller.h"
-#include "../../libcaja-private/caja-autorun.h"
-#include "../../libcaja-private/caja-icon-names.h"
-#include "../../libcaja-private/caja-undostack-manager.h"
-
-#include "fm-directory-view.h"
-#include "fm-list-view.h"
-#include "fm-desktop-icon-view.h"
-#include "fm-actions.h"
-#include "fm-error-reporting.h"
-#include "fm-marshal.h"
-#include "fm-properties-window.h"
-#include "libcaja-private/caja-open-with-dialog.h"
 
 /* Minimum starting update inverval */
 #define UPDATE_INTERVAL_MIN 100

--- a/src/file-manager/fm-directory-view.h
+++ b/src/file-manager/fm-directory-view.h
@@ -29,17 +29,15 @@
 #define FM_DIRECTORY_VIEW_H
 
 #include <gtk/gtk.h>
+#include <eel/eel-background.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-icon-container.h>
+#include <libcaja-private/caja-link.h>
+#include <libcaja-private/caja-view.h>
+#include <libcaja-private/caja-window-info.h>
+#include <libcaja-private/caja-window-slot-info.h>
 #include <gio/gio.h>
-
-#include "../../eel/eel-background.h"
-
-#include "../../libcaja-private/caja-directory.h"
-#include "../../libcaja-private/caja-file.h"
-#include "../../libcaja-private/caja-icon-container.h"
-#include "../../libcaja-private/caja-link.h"
-#include "../../libcaja-private/caja-view.h"
-#include "../../libcaja-private/caja-window-info.h"
-#include "../../libcaja-private/caja-window-slot-info.h"
 
 typedef struct FMDirectoryView FMDirectoryView;
 typedef struct FMDirectoryViewClass FMDirectoryViewClass;

--- a/src/file-manager/fm-ditem-page.c
+++ b/src/file-manager/fm-ditem-page.c
@@ -22,19 +22,17 @@
  */
 
 #include <config.h>
+#include "fm-ditem-page.h"
+
 #include <string.h>
 
+#include <eel/eel-glib-extensions.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
-
-#include "../../eel/eel-glib-extensions.h"
-
-#include "../../libcaja-extension/caja-extension-types.h"
-#include "../../libcaja-extension/caja-file-info.h"
-#include "../../libcaja-private/caja-file.h"
-#include "../../libcaja-private/caja-file-attributes.h"
-
-#include "fm-ditem-page.h"
+#include <libcaja-extension/caja-extension-types.h>
+#include <libcaja-extension/caja-file-info.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-file-attributes.h>
 
 #define MAIN_GROUP "Desktop Entry"
 

--- a/src/file-manager/fm-empty-view.c
+++ b/src/file-manager/fm-empty-view.c
@@ -23,17 +23,15 @@
 */
 
 #include <config.h>
-#include <string.h>
-
-#include "../../eel/eel-glib-extensions.h"
-#include "../../eel/eel-gtk-macros.h"
-#include "../../eel/eel-vfs-extensions.h"
-
-#include "../../libcaja-private/caja-file-utilities.h"
-#include "../../libcaja-private/caja-view.h"
-#include "../../libcaja-private/caja-view-factory.h"
-
 #include "fm-empty-view.h"
+
+#include <string.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-view.h>
+#include <libcaja-private/caja-view-factory.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-vfs-extensions.h>
 
 struct FMEmptyViewDetails
 {

--- a/src/file-manager/fm-error-reporting.c
+++ b/src/file-manager/fm-error-reporting.c
@@ -24,17 +24,14 @@
 */
 
 #include <config.h>
-#include <string.h>
-
-#include <glib/gi18n.h>
-
-#include "../../eel/eel-string.h"
-#include "../../eel/eel-stock-dialogs.h"
-
-#include "../../libcaja-private/caja-debug-log.h"
-#include "../../libcaja-private/caja-file.h"
-
 #include "fm-error-reporting.h"
+
+#include <string.h>
+#include <glib/gi18n.h>
+#include <libcaja-private/caja-debug-log.h>
+#include <libcaja-private/caja-file.h>
+#include <eel/eel-string.h>
+#include <eel/eel-stock-dialogs.h>
 
 #define NEW_NAME_TAG "Caja: new name"
 #define MAXIMUM_DISPLAYED_FILE_NAME_LENGTH	50

--- a/src/file-manager/fm-error-reporting.h
+++ b/src/file-manager/fm-error-reporting.h
@@ -27,8 +27,7 @@
 #define FM_ERROR_REPORTING_H
 
 #include <gtk/gtk.h>
-
-#include "../../libcaja-private/caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 void fm_report_error_loading_directory	 (CajaFile   *file,
         GError         *error,

--- a/src/file-manager/fm-icon-container.c
+++ b/src/file-manager/fm-icon-container.c
@@ -22,17 +22,15 @@
    Author: Michael Meeks <michael@ximian.com>
 */
 #include <config.h>
-#include <string.h>
 
+#include <string.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-
-#include "../../eel/eel-glib-extensions.h"
-
-#include "../../libcaja-private/caja-global-preferences.h"
-#include "../../libcaja-private/caja-file-attributes.h"
-#include "../../libcaja-private/caja-thumbnails.h"
-#include "../../libcaja-private/caja-desktop-icon-file.h"
+#include <eel/eel-glib-extensions.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-thumbnails.h>
+#include <libcaja-private/caja-desktop-icon-file.h>
 
 #include "fm-icon-container.h"
 

--- a/src/file-manager/fm-icon-container.h
+++ b/src/file-manager/fm-icon-container.h
@@ -25,8 +25,7 @@
 #ifndef FM_ICON_CONTAINER_H
 #define FM_ICON_CONTAINER_H
 
-#include "../../libcaja-private/caja-icon-container.h"
-
+#include <libcaja-private/caja-icon-container.h>
 #include "fm-icon-view.h"
 
 typedef struct FMIconContainer FMIconContainer;

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -23,48 +23,46 @@
 */
 
 #include <config.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <locale.h>
-#include <signal.h>
-#include <stdio.h>
-#include <unistd.h>
-
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
-#include <gio/gio.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-
-#include "../../eel/eel-background.h"
-#include "../../eel/eel-glib-extensions.h"
-#include "../../eel/eel-gtk-extensions.h"
-#include "../../eel/eel-gtk-macros.h"
-#include "../../eel/eel-stock-dialogs.h"
-#include "../../eel/eel-string.h"
-#include "../../eel/eel-vfs-extensions.h"
-
-#include "../../libcaja-private/caja-clipboard-monitor.h"
-#include "../../libcaja-private/caja-directory-background.h"
-#include "../../libcaja-private/caja-directory.h"
-#include "../../libcaja-private/caja-dnd.h"
-#include "../../libcaja-private/caja-file-utilities.h"
-#include "../../libcaja-private/caja-ui-utilities.h"
-#include "../../libcaja-private/caja-global-preferences.h"
-#include "../../libcaja-private/caja-icon-container.h"
-#include "../../libcaja-private/caja-icon-dnd.h"
-#include "../../libcaja-private/caja-link.h"
-#include "../../libcaja-private/caja-metadata.h"
-#include "../../libcaja-private/caja-view-factory.h"
-#include "../../libcaja-private/caja-clipboard.h"
-#include "../../libcaja-private/caja-desktop-icon-file.h"
-
 #include "fm-icon-view.h"
+
 #include "fm-actions.h"
 #include "fm-icon-container.h"
 #include "fm-desktop-icon-view.h"
 #include "fm-error-reporting.h"
+#include <stdlib.h>
+#include <eel/eel-background.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <libcaja-private/caja-clipboard-monitor.h>
+#include <libcaja-private/caja-directory-background.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-dnd.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-ui-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-icon-container.h>
+#include <libcaja-private/caja-icon-dnd.h>
+#include <libcaja-private/caja-link.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-view-factory.h>
+#include <libcaja-private/caja-clipboard.h>
+#include <libcaja-private/caja-desktop-icon-file.h>
+#include <locale.h>
+#include <signal.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include "caja-audio-mime-types.h"
 
 #define POPUP_PATH_ICON_APPEARANCE		"/selection/Icon Appearance Items"

--- a/src/file-manager/fm-list-model.c
+++ b/src/file-manager/fm-list-model.c
@@ -25,20 +25,16 @@
 */
 
 #include <config.h>
-#include <glib.h>
-#include <string.h>
-#include <cairo-gobject.h>
+#include "fm-list-model.h"
+#include <libegg/eggtreemultidnd.h>
 
+#include <string.h>
+#include <eel/eel-graphic-effects.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
-
-#include "../../libegg/eggtreemultidnd.h"
-
-#include "../../eel/eel-graphic-effects.h"
-
-#include "../../libcaja-private/caja-dnd.h"
-
-#include "fm-list-model.h"
+#include <libcaja-private/caja-dnd.h>
+#include <glib.h>
+#include <cairo-gobject.h>
 
 enum
 {

--- a/src/file-manager/fm-list-model.h
+++ b/src/file-manager/fm-list-model.h
@@ -24,11 +24,9 @@
 
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
-
-#include "../../libcaja-private/caja-file.h"
-#include "../../libcaja-private/caja-directory.h"
-
-#include "../../libcaja-extension/caja-column.h"
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-extension/caja-column.h>
 
 #ifndef FM_LIST_MODEL_H
 #define FM_LIST_MODEL_H

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -26,44 +26,41 @@
 */
 
 #include <config.h>
-#include <string.h>
+#include "fm-list-view.h"
 
+#include <string.h>
+#include "fm-error-reporting.h"
+#include "fm-list-model.h"
+#include <string.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-gdk-extensions.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-gtk-macros.h>
+#include <eel/eel-stock-dialogs.h>
 #include <gdk/gdk.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
+#include <libegg/eggtreemultidnd.h>
 #include <glib/gi18n.h>
 #include <glib-object.h>
-
-#include "../../eel/eel-vfs-extensions.h"
-#include "../../eel/eel-gdk-extensions.h"
-#include "../../eel/eel-glib-extensions.h"
-#include "../../eel/eel-gtk-macros.h"
-#include "../../eel/eel-stock-dialogs.h"
-
-#include "../../libegg/eggtreemultidnd.h"
-
-#include "../../libcaja-extension/caja-column-provider.h"
-#include "../../libcaja-private/caja-clipboard-monitor.h"
-#include "../../libcaja-private/caja-column-chooser.h"
-#include "../../libcaja-private/caja-column-utilities.h"
-#include "../../libcaja-private/caja-debug-log.h"
-#include "../../libcaja-private/caja-directory-background.h"
-#include "../../libcaja-private/caja-dnd.h"
-#include "../../libcaja-private/caja-file-dnd.h"
-#include "../../libcaja-private/caja-file-utilities.h"
-#include "../../libcaja-private/caja-ui-utilities.h"
-#include "../../libcaja-private/caja-global-preferences.h"
-#include "../../libcaja-private/caja-icon-dnd.h"
-#include "../../libcaja-private/caja-metadata.h"
-#include "../../libcaja-private/caja-module.h"
-#include "../../libcaja-private/caja-tree-view-drag-dest.h"
-#include "../../libcaja-private/caja-view-factory.h"
-#include "../../libcaja-private/caja-clipboard.h"
-#include "../../libcaja-private/caja-cell-renderer-text-ellipsized.h"
-
-#include "fm-list-view.h"
-#include "fm-error-reporting.h"
-#include "fm-list-model.h"
+#include <libcaja-extension/caja-column-provider.h>
+#include <libcaja-private/caja-clipboard-monitor.h>
+#include <libcaja-private/caja-column-chooser.h>
+#include <libcaja-private/caja-column-utilities.h>
+#include <libcaja-private/caja-debug-log.h>
+#include <libcaja-private/caja-directory-background.h>
+#include <libcaja-private/caja-dnd.h>
+#include <libcaja-private/caja-file-dnd.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-ui-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-icon-dnd.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-tree-view-drag-dest.h>
+#include <libcaja-private/caja-view-factory.h>
+#include <libcaja-private/caja-clipboard.h>
+#include <libcaja-private/caja-cell-renderer-text-ellipsized.h>
 
 struct FMListViewDetails
 {

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -23,45 +23,41 @@
 */
 
 #include <config.h>
-#include <string.h>
-#include <cairo.h>
+#include "fm-properties-window.h"
+#include "fm-ditem-page.h"
 
+#define MATE_DESKTOP_USE_UNSTABLE_API
+
+#include "fm-error-reporting.h"
+#include "libcaja-private/caja-mime-application-chooser.h"
+#include <eel/eel-accessibility.h>
+#include <eel/eel-gdk-pixbuf-extensions.h>
+#include <eel/eel-glib-extensions.h>
+#include <eel/eel-mate-extensions.h>
+#include <eel/eel-gtk-extensions.h>
+#include <eel/eel-labeled-image.h>
+#include <eel/eel-stock-dialogs.h>
+#include <eel/eel-vfs-extensions.h>
+#include <eel/eel-wrap-table.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 #include <glib/gi18n.h>
-#include <sys/stat.h>
-
-#define MATE_DESKTOP_USE_UNSTABLE_API
 #include <libmate-desktop/mate-desktop-thumbnail.h>
-
-#include "../../eel/eel-accessibility.h"
-#include "../../eel/eel-gdk-pixbuf-extensions.h"
-#include "../../eel/eel-glib-extensions.h"
-#include "../../eel/eel-mate-extensions.h"
-#include "../../eel/eel-gtk-extensions.h"
-#include "../../eel/eel-labeled-image.h"
-#include "../../eel/eel-stock-dialogs.h"
-#include "../../eel/eel-vfs-extensions.h"
-#include "../../eel/eel-wrap-table.h"
-
-#include "../../libcaja-extension/caja-property-page-provider.h"
-
-#include "../../libcaja-private/caja-mime-application-chooser.h"
-#include "../../libcaja-private/caja-entry.h"
-#include "../../libcaja-private/caja-extensions.h"
-#include "../../libcaja-private/caja-file-attributes.h"
-#include "../../libcaja-private/caja-file-operations.h"
-#include "../../libcaja-private/caja-desktop-icon-file.h"
-#include "../../libcaja-private/caja-global-preferences.h"
-#include "../../libcaja-private/caja-emblem-utils.h"
-#include "../../libcaja-private/caja-link.h"
-#include "../../libcaja-private/caja-metadata.h"
-#include "../../libcaja-private/caja-module.h"
-#include "../../libcaja-private/caja-mime-actions.h"
-
-#include "fm-properties-window.h"
-#include "fm-ditem-page.h"
-#include "fm-error-reporting.h"
+#include <libcaja-extension/caja-property-page-provider.h>
+#include <libcaja-private/caja-entry.h>
+#include <libcaja-private/caja-extensions.h>
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-file-operations.h>
+#include <libcaja-private/caja-desktop-icon-file.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-emblem-utils.h>
+#include <libcaja-private/caja-link.h>
+#include <libcaja-private/caja-metadata.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-mime-actions.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <cairo.h>
 
 #if HAVE_SYS_VFS_H
 #include <sys/vfs.h>

--- a/src/file-manager/fm-properties-window.h
+++ b/src/file-manager/fm-properties-window.h
@@ -27,8 +27,7 @@
 #define FM_PROPERTIES_WINDOW_H
 
 #include <gtk/gtk.h>
-
-#include "../../libcaja-private/caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 typedef struct FMPropertiesWindow FMPropertiesWindow;
 

--- a/src/file-manager/fm-tree-model.c
+++ b/src/file-manager/fm-tree-model.c
@@ -27,19 +27,16 @@
 /* fm-tree-model.c - model for the tree view */
 
 #include <config.h>
+#include "fm-tree-model.h"
+
+#include <eel/eel-graphic-effects.h>
+#include <glib/gi18n.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-file.h>
+#include <gtk/gtk.h>
 #include <string.h>
 #include <cairo-gobject.h>
-
-#include <glib/gi18n.h>
-#include <gtk/gtk.h>
-
-#include "../../eel/eel-graphic-effects.h"
-
-#include "../../libcaja-private/caja-directory.h"
-#include "../../libcaja-private/caja-file-attributes.h"
-#include "../../libcaja-private/caja-file.h"
-
-#include "fm-tree-model.h"
 
 enum
 {

--- a/src/file-manager/fm-tree-model.h
+++ b/src/file-manager/fm-tree-model.h
@@ -28,11 +28,9 @@
 #define FM_TREE_MODEL_H
 
 #include <glib-object.h>
-
 #include <gtk/gtk.h>
 #include <gio/gio.h>
-
-#include "../../libcaja-private/caja-file.h"
+#include <libcaja-private/caja-file.h>
 
 #define FM_TYPE_TREE_MODEL fm_tree_model_get_type()
 #define FM_TREE_MODEL(obj) \

--- a/src/file-manager/fm-tree-view.c
+++ b/src/file-manager/fm-tree-view.c
@@ -30,39 +30,36 @@
  */
 
 #include <config.h>
-#include <string.h>
-#include <cairo-gobject.h>
+#include "fm-tree-view.h"
 
+#include "fm-tree-model.h"
+#include "fm-properties-window.h"
+#include <string.h>
+#include <eel/eel-gtk-extensions.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-
-#include "../../eel/eel-gtk-extensions.h"
-
-#include "../../libcaja-private/caja-clipboard.h"
-#include "../../libcaja-private/caja-clipboard-monitor.h"
-#include "../../libcaja-private/caja-desktop-icon-file.h"
-#include "../../libcaja-private/caja-debug-log.h"
-#include "../../libcaja-private/caja-file-attributes.h"
-#include "../../libcaja-private/caja-file-operations.h"
-#include "../../libcaja-private/caja-file-utilities.h"
-#include "../../libcaja-private/caja-global-preferences.h"
-#include "../../libcaja-private/caja-icon-names.h"
-#include "../../libcaja-private/caja-mime-actions.h"
-#include "../../libcaja-private/caja-program-choosing.h"
-#include "../../libcaja-private/caja-tree-view-drag-dest.h"
-#include "../../libcaja-private/caja-sidebar-provider.h"
-#include "../../libcaja-private/caja-module.h"
-#include "../../libcaja-private/caja-window-info.h"
-#include "../../libcaja-private/caja-window-slot-info.h"
-#include "../../libcaja-private/caja-directory.h"
-#include "../../libcaja-private/caja-directory-private.h"
-#include "../../libcaja-private/caja-file.h"
-#include "../../libcaja-private/caja-file-private.h"
-
-#include "fm-tree-view.h"
-#include "fm-tree-model.h"
-#include "fm-properties-window.h"
+#include <cairo-gobject.h>
+#include <libcaja-private/caja-clipboard.h>
+#include <libcaja-private/caja-clipboard-monitor.h>
+#include <libcaja-private/caja-desktop-icon-file.h>
+#include <libcaja-private/caja-debug-log.h>
+#include <libcaja-private/caja-file-attributes.h>
+#include <libcaja-private/caja-file-operations.h>
+#include <libcaja-private/caja-file-utilities.h>
+#include <libcaja-private/caja-global-preferences.h>
+#include <libcaja-private/caja-icon-names.h>
+#include <libcaja-private/caja-mime-actions.h>
+#include <libcaja-private/caja-program-choosing.h>
+#include <libcaja-private/caja-tree-view-drag-dest.h>
+#include <libcaja-private/caja-sidebar-provider.h>
+#include <libcaja-private/caja-module.h>
+#include <libcaja-private/caja-window-info.h>
+#include <libcaja-private/caja-window-slot-info.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-directory-private.h>
+#include <libcaja-private/caja-file.h>
+#include <libcaja-private/caja-file-private.h>
 
 typedef struct
 {

--- a/test/test-caja-directory-async.c
+++ b/test/test-caja-directory-async.c
@@ -1,9 +1,8 @@
 #include <gtk/gtk.h>
+#include <libcaja-private/caja-directory.h>
+#include <libcaja-private/caja-search-directory.h>
+#include <libcaja-private/caja-file.h>
 #include <unistd.h>
-
-#include "../libcaja-private/caja-directory.h"
-#include "../libcaja-private/caja-search-directory.h"
-#include "../libcaja-private/caja-file.h"
 
 void *client1, *client2;
 

--- a/test/test-caja-search-engine.c
+++ b/test/test-caja-search-engine.c
@@ -1,6 +1,5 @@
+#include <libcaja-private/caja-search-engine.h>
 #include <gtk/gtk.h>
-
-#include "../libcaja-private/caja-search-engine.h"
 
 static void
 hits_added_cb (CajaSearchEngine *engine, GSList *hits)

--- a/test/test-caja-wrap-table.c
+++ b/test/test-caja-wrap-table.c
@@ -1,10 +1,10 @@
-#include "../eel/eel-wrap-table.h"
-#include "../eel/eel-labeled-image.h"
-#include "../eel/eel-vfs-extensions.h"
-#include "../libcaja-private/caja-customization-data.h"
-#include "../libcaja-private/caja-icon-info.h"
-
 #include "test.h"
+
+#include <eel/eel-wrap-table.h>
+#include <eel/eel-labeled-image.h>
+#include <eel/eel-vfs-extensions.h>
+#include <libcaja-private/caja-customization-data.h>
+#include <libcaja-private/caja-icon-info.h>
 
 int 
 main (int argc, char* argv[])

--- a/test/test-copy.c
+++ b/test/test-copy.c
@@ -1,7 +1,7 @@
-#include "../libcaja-private/caja-file-operations.h"
-#include "../libcaja-private/caja-progress-info.h"
-
 #include "test.h"
+
+#include <libcaja-private/caja-file-operations.h>
+#include <libcaja-private/caja-progress-info.h>
 
 static void
 copy_done (GHashTable *debuting_uris, gpointer data)

--- a/test/test-eel-background.c
+++ b/test/test-eel-background.c
@@ -1,8 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
 
+#include <eel/eel-background.h>
 #include <gtk/gtk.h>
-
-#include "../eel/eel-background.h"
 
 #define PATTERNS_DIR "/mate-source/eel/data/patterns"
 

--- a/test/test-eel-editable-label.c
+++ b/test/test-eel-editable-label.c
@@ -4,7 +4,7 @@
 
 #include <gtk/gtk.h>
 
-#include "../eel/eel-editable-label.h"
+#include <eel/eel-editable-label.h>
 
 static void
 quit (GtkWidget *widget, gpointer data)

--- a/test/test-eel-image-table.c
+++ b/test/test-eel-image-table.c
@@ -1,9 +1,8 @@
-#include <stdlib.h>
-#include <gtk/gtk.h>
-
-#include "../eel/eel-image-table.h"
-
 #include "test.h"
+
+#include <eel/eel-image-table.h>
+#include <gtk/gtk.h>
+#include <stdlib.h>
 
 static const char pixbuf_name[] = "/usr/share/pixmaps/mate-about-logo.png";
 

--- a/test/test-eel-labeled-image.c
+++ b/test/test-eel-labeled-image.c
@@ -1,6 +1,6 @@
-#include "../eel/eel-labeled-image.h"
-
 #include "test.h"
+
+#include <eel/eel-labeled-image.h>
 
 static const char pixbuf_name[] = "/usr/share/pixmaps/mate-globe.png";
 

--- a/test/test-eel-pixbuf-scale.c
+++ b/test/test-eel-pixbuf-scale.c
@@ -1,8 +1,9 @@
+#include "test.h"
+
+#include <eel/eel-gdk-pixbuf-extensions.h>
+
 #include <sys/time.h>
 
-#include "../eel/eel-gdk-pixbuf-extensions.h"
-
-#include "test.h"
 
 #define N_SCALES 100
 

--- a/test/test.h
+++ b/test/test.h
@@ -2,12 +2,11 @@
 #define TEST_H
 
 #include <config.h>
-
 #include <gtk/gtk.h>
 
-#include "../eel/eel-debug.h"
-#include "../eel/eel.h"
-#include "../libcaja-private/caja-file-utilities.h"
+#include <eel/eel-debug.h>
+#include <eel/eel.h>
+#include <libcaja-private/caja-file-utilities.h>
 
 void       test_init                            (int                         *argc,
 						 char                      ***argv);


### PR DESCRIPTION
Reverts mate-desktop/caja#1204

I misread one of the comments reviewing  "local #include files inside "" instead <>" and mistook it for a statement that the change was correct, not that it should not be applied to libraries. We can revert this entirely, or if only some of the local #include files are libraries those and those alone could be put back into <>
