### PR TITLE
caja-location-dialog: Fix 'cppcheck' and 'clang' warnings

### DIFF
--- a/src/caja-location-dialog.c
+++ b/src/caja-location-dialog.c
@@ -217,11 +217,9 @@ caja_location_dialog_init (CajaLocationDialog *dialog)
 GtkWidget *
 caja_location_dialog_new (CajaWindow *window)
 {
-    CajaWindowSlot *slot;
     CajaLocationDialog *loc_dialog;
     GtkWidget *dialog;
     GFile *location;
-    char *formatted_location;
 
     dialog = gtk_widget_new (CAJA_TYPE_LOCATION_DIALOG, NULL);
     loc_dialog = CAJA_LOCATION_DIALOG (dialog);
@@ -232,13 +230,15 @@ caja_location_dialog_new (CajaWindow *window)
         gtk_window_set_screen (GTK_WINDOW (dialog),
                                gtk_window_get_screen (GTK_WINDOW (window)));
         loc_dialog->details->window = window;
+        location = window->details->active_pane->active_slot->location;
     }
+    else
+        location = NULL;
 
-    slot = window->details->active_pane->active_slot;
-
-    location = slot->location;
     if (location != NULL)
     {
+        char *formatted_location;
+
         if (CAJA_IS_DESKTOP_WINDOW (window))
         {
             formatted_location = g_strdup_printf ("%s/", g_get_home_dir ());


### PR DESCRIPTION
Fixes 'cppcheck' warnings:

```
[src/caja-location-dialog.c:229] -> [src/caja-location-dialog.c:237]: (warning) Either the condition 'window' is redundant or there is possible null pointer dereference: window.
[src/caja-location-dialog.c:224]: (style) The scope of the variable 'formatted_location' can be reduced.
```

Fixes Clang static analyzer warning:

```
caja-location-dialog.c:237:12: warning: Access to field 'details' results in a dereference of a null pointer (loaded from variable 'window')
    slot = window->details->active_pane->active_slot;
           ^~~~~~~~~~~~~~~
```