### PR TITLE
eel: reduce the scope of some variables

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -160,9 +160,9 @@ static void
 make_color_inactive (EelBackground *self,
                      GdkRGBA       *color)
 {
-    double intensity, saturation;
-
     if (!self->details->is_active) {
+        double intensity, saturation;
+
         saturation = 0.7;
         intensity = color->red * 0.30 + color->green * 0.59 + color->blue * 0.11;
         color->red = SATURATE (color->red);
@@ -193,7 +193,7 @@ eel_bg_get_desktop_color (EelBackground *self)
 {
     MateBGColorType type;
     GdkRGBA    primary, secondary;
-    char      *start_color, *end_color, *color_spec;
+    char      *start_color, *color_spec;
     gboolean   use_gradient = TRUE;
     gboolean   is_horizontal = FALSE;
 
@@ -216,6 +216,8 @@ eel_bg_get_desktop_color (EelBackground *self)
 
     if (use_gradient)
     {
+        char *end_color;
+
         end_color  = eel_gdk_rgb_to_color_spec (eel_gdk_rgba_to_rgb (&secondary));
         color_spec = eel_gradient_new (start_color, end_color, is_horizontal);
         g_free (end_color);

--- a/eel/eel-canvas-rect-ellipse.c
+++ b/eel/eel-canvas-rect-ellipse.c
@@ -597,7 +597,6 @@ eel_canvas_rect_point (EelCanvasItem *item, double x, double y, int cx, int cy, 
     double x1, y1, x2, y2;
     double hwidth;
     double dx, dy;
-    double tmp;
 
 #ifdef VERBOSE
     g_print ("eel_canvas_rect_point\n");
@@ -632,6 +631,8 @@ eel_canvas_rect_point (EelCanvasItem *item, double x, double y, int cx, int cy, 
 
     if ((x >= x1) && (y >= y1) && (x <= x2) && (y <= y2))
     {
+        double tmp;
+
         if (re->fill_set || !re->outline_set)
             return 0.0;
 
@@ -702,8 +703,6 @@ eel_canvas_rect_update (EelCanvasItem *item, double i2w_dx, double i2w_dy, gint 
     double x1, y1, x2, y2;
     int cx1, cy1, cx2, cy2;
     int repaint_rects_count, i;
-    int width_pixels;
-    int width_lt, width_rb;
     Rect update_rect, repaint_rects[4];
     EelCanvasRectPrivate *priv;
 
@@ -734,6 +733,9 @@ eel_canvas_rect_update (EelCanvasItem *item, double i2w_dx, double i2w_dy, gint 
 
     if (re->outline_set)
     {
+        int width_pixels;
+        int width_lt, width_rb;
+
         /* Outline and bounding box */
         if (re->width_pixels)
             width_pixels = (int) re->width;

--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -1417,8 +1417,8 @@ static void
 eel_canvas_group_destroy (EelCanvasItem *object)
 {
     EelCanvasGroup *group;
-    EelCanvasItem *child;
     GList *list;
+    EelCanvasItem *child = NULL;
 
     g_return_if_fail (EEL_IS_CANVAS_GROUP (object));
 
@@ -1490,7 +1490,7 @@ eel_canvas_group_unrealize (EelCanvasItem *item)
 {
     EelCanvasGroup *group;
     GList *list;
-    EelCanvasItem *i;
+    EelCanvasItem *i = NULL;
 
     group = EEL_CANVAS_GROUP (item);
 
@@ -1515,7 +1515,7 @@ eel_canvas_group_map (EelCanvasItem *item)
 {
     EelCanvasGroup *group;
     GList *list;
-    EelCanvasItem *i;
+    EelCanvasItem *i = NULL;
 
     group = EEL_CANVAS_GROUP (item);
 
@@ -1542,7 +1542,7 @@ eel_canvas_group_unmap (EelCanvasItem *item)
 {
     EelCanvasGroup *group;
     GList *list;
-    EelCanvasItem *i;
+    EelCanvasItem *i = NULL;
 
     group = EEL_CANVAS_GROUP (item);
 
@@ -1594,13 +1594,14 @@ static double
 eel_canvas_group_point (EelCanvasItem *item, double x, double y, int cx, int cy,
                         EelCanvasItem **actual_item)
 {
-    EelCanvasGroup *group;
-    GList *list;
-    EelCanvasItem *child, *point_item;
     int x1, y1, x2, y2;
     double gx, gy;
     double dist, best;
     int has_point;
+    EelCanvasGroup *group;
+    GList *list;
+    EelCanvasItem *point_item;
+    EelCanvasItem *child = NULL;
 
     group = EEL_CANVAS_GROUP (item);
 
@@ -2595,7 +2596,6 @@ pick_current_item (EelCanvas *canvas, GdkEvent *event)
 {
     int button_down;
     double x, y;
-    int cx, cy;
     int retval;
 
     retval = FALSE;
@@ -2674,6 +2674,7 @@ pick_current_item (EelCanvas *canvas, GdkEvent *event)
         }
 
         /* canvas pixel coords */
+        int cx, cy;
 
         cx = (int) (x + 0.5);
         cy = (int) (y + 0.5);

--- a/eel/eel-debug.c
+++ b/eel/eel-debug.c
@@ -77,7 +77,7 @@ eel_make_warnings_and_criticals_stop_in_debugger (void)
 void
 eel_debug_shut_down (void)
 {
-    ShutdownFunction *f;
+    ShutdownFunction *f = NULL;
 
     while (shutdown_functions != NULL)
     {

--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -1490,7 +1490,6 @@ eel_editable_label_draw_cursor (EelEditableLabel  *label, cairo_t *cr, gint xoff
         else /* Block cursor */
         {
             GdkRGBA fg_color;
-            cairo_region_t *clip;
 
             gtk_style_context_get_color (context, GTK_STATE_FLAG_NORMAL, &fg_color);
 
@@ -1507,6 +1506,7 @@ eel_editable_label_draw_cursor (EelEditableLabel  *label, cairo_t *cr, gint xoff
             {
                 GdkRGBA color;
                 GdkRGBA *c;
+                cairo_region_t *clip;
 
                 clip = gdk_pango_layout_get_clip_region (label->layout,
 							 xoffset, yoffset,
@@ -1568,7 +1568,6 @@ eel_editable_label_draw (GtkWidget *widget,
         if (label->selection_anchor != label->selection_end)
         {
             gint range[2];
-            const char *text;
             cairo_region_t *clip;
             GtkStateType state;
 
@@ -1582,6 +1581,8 @@ eel_editable_label_draw (GtkWidget *widget,
             if (label->preedit_length > 0 &&
                 range[1] > label->selection_anchor)
             {
+                const char *text;
+
                 text = pango_layout_get_text (label->layout) + label->selection_anchor;
                 range[1] += g_utf8_offset_to_pointer (text, label->preedit_length) - text;
             }
@@ -2267,8 +2268,6 @@ eel_editable_label_delete_text (EelEditableLabel *label,
                                 int start_pos,
                                 int end_pos)
 {
-    int anchor, end;
-
     if (start_pos < 0)
         start_pos = 0;
     if (end_pos < 0 || end_pos > label->n_bytes)
@@ -2276,6 +2275,8 @@ eel_editable_label_delete_text (EelEditableLabel *label,
 
     if (start_pos < end_pos)
     {
+        int anchor, end;
+
         memmove (label->text + start_pos, label->text + end_pos, label->n_bytes + 1 - end_pos);
         label->n_bytes -= (end_pos - start_pos);
 
@@ -3051,7 +3052,6 @@ popup_targets_received (GtkClipboard     *clipboard,
                         GtkSelectionData *data,
                         gpointer          user_data)
 {
-    GtkWidget *menuitem;
     gboolean have_selection;
     gboolean clipboard_contains_text;
     PopupInfo *info;
@@ -3062,6 +3062,8 @@ popup_targets_received (GtkClipboard     *clipboard,
 
     if (gtk_widget_get_realized (GTK_WIDGET (label)))
     {
+        GtkWidget *menuitem;
+
         if (label->popup_menu)
             gtk_widget_destroy (label->popup_menu);
 
@@ -3397,7 +3399,6 @@ eel_editable_label_accessible_get_character_at_offset (AtkText *text,
     GtkWidget *widget;
     EelEditableLabelAccessiblePrivate *priv;
     gchar *string;
-    gchar *index;
     gunichar unichar;
 
     widget = gtk_accessible_get_widget (GTK_ACCESSIBLE (text));
@@ -3413,6 +3414,8 @@ eel_editable_label_accessible_get_character_at_offset (AtkText *text,
     }
     else
     {
+        gchar *index;
+
         index = g_utf8_offset_to_pointer (string, offset);
 
         unichar = g_utf8_get_char(index);

--- a/eel/eel-gdk-pixbuf-extensions.c
+++ b/eel/eel-gdk-pixbuf-extensions.c
@@ -82,13 +82,14 @@ pixbuf_loader_size_prepared (GdkPixbufLoader *loader,
                              gpointer         desired_size_ptr)
 {
     int size, desired_size;
-    float scale;
 
     size = MAX (width, height);
     desired_size = GPOINTER_TO_INT (desired_size_ptr);
 
     if (size != desired_size)
     {
+        float scale;
+
         scale = (float) desired_size / size;
         gdk_pixbuf_loader_set_size (loader,
                                     floor (scale * width + 0.5),
@@ -280,8 +281,8 @@ eel_gdk_pixbuf_scale_down (GdkPixbuf *pixbuf,
                            int dest_height)
 {
     int source_width, source_height;
-    int s_x1, s_y1, s_x2, s_y2;
-    int s_xfrac, s_yfrac;
+    int s_y1, s_x2;
+    int s_yfrac;
     int dx, dx_frac, dy, dy_frac;
     div_t ddx, ddy;
     int x, y;
@@ -327,6 +328,9 @@ eel_gdk_pixbuf_scale_down (GdkPixbuf *pixbuf,
     s_yfrac = -dest_height/2;
     while (s_y1 < source_height)
     {
+        int s_x1, s_y2;
+        int s_xfrac;
+
         s_y2 = s_y1 + dy;
         s_yfrac += dy_frac;
         if (s_yfrac > 0)

--- a/eel/eel-glib-extensions.c
+++ b/eel/eel-glib-extensions.c
@@ -436,7 +436,6 @@ eel_g_lists_sort_and_check_for_intersection (GList **list_1,
 
 {
     GList *node_1, *node_2;
-    int compare_result;
 
     *list_1 = g_list_sort (*list_1, compare_pointers);
     *list_2 = g_list_sort (*list_2, compare_pointers);
@@ -446,6 +445,8 @@ eel_g_lists_sort_and_check_for_intersection (GList **list_1,
 
     while (node_1 != NULL && node_2 != NULL)
     {
+        int compare_result;
+
         compare_result = compare_pointers (node_1->data, node_2->data);
         if (compare_result == 0)
         {
@@ -558,8 +559,8 @@ static void
 free_hash_tables_at_exit (void)
 {
     GList *p;
-    HashTableToFree *hash_table_to_free;
     guint size;
+    HashTableToFree *hash_table_to_free = NULL;
 
     for (p = hash_tables_to_free_at_exit; p != NULL; p = p->next)
     {

--- a/eel/eel-graphic-effects.c
+++ b/eel/eel-graphic-effects.c
@@ -71,7 +71,6 @@ eel_create_spotlight_pixbuf (GdkPixbuf* src)
     int i, j;
     int width, height, has_alpha, src_row_stride, dst_row_stride;
     guchar *target_pixels, *original_pixels;
-    guchar *pixsrc, *pixdest;
 
     g_return_val_if_fail (gdk_pixbuf_get_colorspace (src) == GDK_COLORSPACE_RGB, NULL);
     g_return_val_if_fail ((!gdk_pixbuf_get_has_alpha (src)
@@ -92,6 +91,8 @@ eel_create_spotlight_pixbuf (GdkPixbuf* src)
 
     for (i = 0; i < height; i++)
     {
+        guchar *pixsrc, *pixdest;
+
         pixdest = target_pixels + i * dst_row_stride;
         pixsrc = original_pixels + i * src_row_stride;
         for (j = 0; j < width; j++)
@@ -134,7 +135,6 @@ eel_create_darkened_pixbuf (GdkPixbuf *src, int saturation, int darken)
     gint width, height, src_row_stride, dest_row_stride;
     gboolean has_alpha;
     guchar *target_pixels, *original_pixels;
-    guchar *pixsrc, *pixdest;
     guchar intensity;
     guchar alpha;
     guchar negalpha;
@@ -160,6 +160,8 @@ eel_create_darkened_pixbuf (GdkPixbuf *src, int saturation, int darken)
 
     for (i = 0; i < height; i++)
     {
+        guchar *pixsrc, *pixdest;
+
         pixdest = target_pixels + i * dest_row_stride;
         pixsrc = original_pixels + i * src_row_stride;
         for (j = 0; j < width; j++)
@@ -192,8 +194,6 @@ eel_create_colorized_pixbuf (GdkPixbuf *src,
     int width, height, has_alpha, src_row_stride, dst_row_stride;
     guchar *target_pixels;
     guchar *original_pixels;
-    guchar *pixsrc;
-    guchar *pixdest;
     GdkPixbuf *dest;
 
     gint red_value, green_value, blue_value;
@@ -221,6 +221,9 @@ eel_create_colorized_pixbuf (GdkPixbuf *src,
 
     for (i = 0; i < height; i++)
     {
+        guchar *pixdest;
+        guchar *pixsrc;
+
         pixdest = target_pixels + i*dst_row_stride;
         pixsrc = original_pixels + i*src_row_stride;
         for (j = 0; j < width; j++)
@@ -242,12 +245,14 @@ eel_create_colorized_pixbuf (GdkPixbuf *src,
 static void
 draw_frame_row (GdkPixbuf *frame_image, int target_width, int source_width, int source_v_position, int dest_v_position, GdkPixbuf *result_pixbuf, int left_offset, int height)
 {
-    int remaining_width, h_offset, slab_width;
+    int remaining_width, h_offset;
 
     remaining_width = target_width;
     h_offset = 0;
     while (remaining_width > 0)
     {
+        int slab_width;
+
         slab_width = remaining_width > source_width ? source_width : remaining_width;
         gdk_pixbuf_copy_area (frame_image, left_offset, source_v_position, slab_width, height, result_pixbuf, left_offset + h_offset, dest_v_position);
         remaining_width -= slab_width;
@@ -259,12 +264,15 @@ draw_frame_row (GdkPixbuf *frame_image, int target_width, int source_width, int 
 static void
 draw_frame_column (GdkPixbuf *frame_image, int target_height, int source_height, int source_h_position, int dest_h_position, GdkPixbuf *result_pixbuf, int top_offset, int width)
 {
-    int remaining_height, v_offset, slab_height;
+    int remaining_height, v_offset;
 
     remaining_height = target_height;
     v_offset = 0;
+
     while (remaining_height > 0)
     {
+        int slab_height;
+
         slab_height = remaining_height > source_height ? source_height : remaining_height;
         gdk_pixbuf_copy_area (frame_image, source_h_position, top_offset, width, slab_height, result_pixbuf, dest_h_position, top_offset + v_offset);
         remaining_height -= slab_height;
@@ -279,7 +287,7 @@ eel_stretch_frame_image (GdkPixbuf *frame_image, int left_offset, int top_offset
     GdkPixbuf *result_pixbuf;
     guchar *pixels_ptr;
     int frame_width, frame_height;
-    int y, row_stride;
+    int row_stride;
     int target_width, target_frame_width;
     int target_height, target_frame_height;
 
@@ -300,6 +308,8 @@ eel_stretch_frame_image (GdkPixbuf *frame_image, int left_offset, int top_offset
     /* clear the new pixbuf */
     if (!fill_flag)
     {
+        int y;
+
         for (y = 0; y < dest_height; y++)
         {
             memset (pixels_ptr, 255, row_stride);

--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -162,10 +162,7 @@ eel_gtk_window_set_initial_geometry (GtkWindow *window,
                                      guint width,
                                      guint height)
 {
-    GdkScreen *screen;
     int real_left, real_top;
-    int screen_width, screen_height;
-    int scale;
 
     g_return_if_fail (GTK_IS_WINDOW (window));
 
@@ -177,6 +174,10 @@ eel_gtk_window_set_initial_geometry (GtkWindow *window,
 
     if ((geometry_flags & EEL_GDK_X_VALUE) && (geometry_flags & EEL_GDK_Y_VALUE))
     {
+        GdkScreen *screen;
+        int screen_width, screen_height;
+        int scale;
+
         real_left = left;
         real_top = top;
 

--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -1048,11 +1048,11 @@ labeled_image_update_alignments (EelLabeledImage *labeled_image)
 
     if (labeled_image->details->label != NULL)
     {
-        float x_alignment;
-        float y_alignment;
-
         if (labeled_image->details->fill)
         {
+            float x_alignment;
+            float y_alignment;
+
             x_alignment = gtk_label_get_xalign (GTK_LABEL (labeled_image->details->label));
             y_alignment = gtk_label_get_yalign (GTK_LABEL (labeled_image->details->label));
 
@@ -1097,11 +1097,11 @@ labeled_image_update_alignments (EelLabeledImage *labeled_image)
 
     if (labeled_image->details->image != NULL)
     {
-        float x_alignment;
-        float y_alignment;
-
         if (labeled_image->details->fill)
         {
+            float x_alignment;
+            float y_alignment;
+
             x_alignment = gtk_widget_get_halign (labeled_image->details->image);
             y_alignment = gtk_widget_get_valign (labeled_image->details->image);
 

--- a/eel/eel-mate-extensions.c
+++ b/eel/eel-mate-extensions.c
@@ -70,7 +70,7 @@ try_terminal_command_argv (int argc,
 {
     GString *string;
     int i;
-    char *quoted, *result;
+    char *result;
 
     if (argc == 0)
     {
@@ -85,6 +85,8 @@ try_terminal_command_argv (int argc,
     string = g_string_new (argv[1]);
     for (i = 2; i < argc; i++)
     {
+        char *quoted;
+
         quoted = g_shell_quote (argv[i]);
         g_string_append_c (string, ' ');
         g_string_append (string, quoted);

--- a/eel/eel-stock-dialogs.c
+++ b/eel/eel-stock-dialogs.c
@@ -406,7 +406,6 @@ eel_run_simple_dialog (GtkWidget *parent, gboolean ignore_close_box,
                        const char *secondary_text, ...)
 {
     va_list button_title_args;
-    const char *button_title;
     GtkWidget *dialog;
     GtkWidget *top_widget, *chosen_parent;
     int result;
@@ -439,6 +438,8 @@ eel_run_simple_dialog (GtkWidget *parent, gboolean ignore_close_box,
     response_id = 0;
     while (1)
     {
+        const char *button_title;
+
         button_title = va_arg (button_title_args, const char *);
         if (button_title == NULL)
         {

--- a/eel/eel-string.c
+++ b/eel/eel-string.c
@@ -412,13 +412,14 @@ get_arg_type_from_format (EelPrintfHandler *custom_handlers,
                           const char *format,
                           int len)
 {
-    int i;
     char c;
 
     c = format[len-1];
 
     if (custom_handlers != NULL)
     {
+        int i;
+
         for (i = 0; custom_handlers[i].character != 0; i++)
         {
             if (custom_handlers[i].character == c)
@@ -539,7 +540,6 @@ eel_strdup_vprintf_with_custom (EelPrintfHandler *custom,
     const char *p;
     int num_args, i, j;
     ArgType *args;
-    ArgType type;
     ConversionInfo *conversions;
     GString *f, *str;
     const char *flags, *width, *prec, *mod, *pos;
@@ -676,6 +676,8 @@ eel_strdup_vprintf_with_custom (EelPrintfHandler *custom,
     p = format;
     for (i = 0; i < num_args; i++)
     {
+        ArgType type;
+
         g_string_append_len (str, p, conversions[i].start - p);
         p = conversions[i].end;
 

--- a/eel/eel-vfs-extensions.c
+++ b/eel/eel-vfs-extensions.c
@@ -62,7 +62,7 @@ eel_make_valid_utf8 (const char *name)
 {
     GString *string;
     const char *remainder, *invalid;
-    int remaining_bytes, valid_bytes;
+    int remaining_bytes;
 
     string = NULL;
     remainder = name;
@@ -70,6 +70,8 @@ eel_make_valid_utf8 (const char *name)
 
     while (remaining_bytes != 0)
     {
+        int valid_bytes;
+
         if (g_utf8_validate (remainder, remaining_bytes, &invalid))
         {
             break;

--- a/eel/eel-wrap-table.c
+++ b/eel/eel-wrap-table.c
@@ -763,7 +763,6 @@ wrap_table_child_focus_in (GtkWidget *widget,
 {
     gint x, y;
     GtkWidget *container, *viewport = NULL;
-    GtkAdjustment *hadj, *vadj;
 
     container = gtk_widget_get_parent (widget);
     if (container)
@@ -776,6 +775,8 @@ wrap_table_child_focus_in (GtkWidget *widget,
 
     if (!wrap_table_child_visible_in (widget, viewport))
     {
+        GtkAdjustment *hadj, *vadj;
+
         hadj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (viewport));
         vadj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (viewport));
 


### PR DESCRIPTION
Fixes 'cppcheck' warnings:

```
[eel/eel-background.c:163]: (style) The scope of the variable 'intensity' can be reduced.
[eel/eel-background.c:163]: (style) The scope of the variable 'saturation' can be reduced.
[eel/eel-background.c:196]: (style) The scope of the variable 'end_color' can be reduced.

[eel/eel-canvas-rect-ellipse.c:600]: (style) The scope of the variable 'tmp' can be reduced.
[eel/eel-canvas-rect-ellipse.c:705]: (style) The scope of the variable 'width_pixels' can be reduced.
[eel/eel-canvas-rect-ellipse.c:706]: (style) The scope of the variable 'width_lt' can be reduced.
[eel/eel-canvas-rect-ellipse.c:706]: (style) The scope of the variable 'width_rb' can be reduced.

[eel/eel-canvas.c:1420]: (style) The scope of the variable 'child' can be reduced.
[eel/eel-canvas.c:1493]: (style) The scope of the variable 'i' can be reduced.
[eel/eel-canvas.c:1518]: (style) The scope of the variable 'i' can be reduced.
[eel/eel-canvas.c:1545]: (style) The scope of the variable 'i' can be reduced.
[eel/eel-canvas.c:1599]: (style) The scope of the variable 'child' can be reduced.
[eel/eel-canvas.c:2598]: (style) The scope of the variable 'cx' can be reduced.
[eel/eel-canvas.c:2598]: (style) The scope of the variable 'cy' can be reduced.

[eel/eel-debug.c:80]: (style) The scope of the variable 'f' can be reduced.

[eel/eel-editable-label.c:1493]: (style) The scope of the variable 'clip' can be reduced.
[eel/eel-editable-label.c:1571]: (style) The scope of the variable 'text' can be reduced.
[eel/eel-editable-label.c:2270]: (style) The scope of the variable 'anchor' can be reduced.
[eel/eel-editable-label.c:2270]: (style) The scope of the variable 'end' can be reduced.
[eel/eel-editable-label.c:3054]: (style) The scope of the variable 'menuitem' can be reduced.
[eel/eel-editable-label.c:3400]: (style) The scope of the variable 'index' can be reduced.

[eel/eel-gdk-pixbuf-extensions.c:85]: (style) The scope of the variable 'scale' can be reduced.
[eel/eel-gdk-pixbuf-extensions.c:283]: (style) The scope of the variable 's_x1' can be reduced.
[eel/eel-gdk-pixbuf-extensions.c:283]: (style) The scope of the variable 's_y2' can be reduced.
[eel/eel-gdk-pixbuf-extensions.c:284]: (style) The scope of the variable 's_xfrac' can be reduced.

[eel/eel-glib-extensions.c:439]: (style) The scope of the variable 'compare_result' can be reduced.
[eel/eel-glib-extensions.c:561]: (style) The scope of the variable 'hash_table_to_free' can be reduced.

[eel/eel-graphic-effects.c:74]: (style) The scope of the variable 'pixsrc' can be reduced.
[eel/eel-graphic-effects.c:74]: (style) The scope of the variable 'pixdest' can be reduced.
[eel/eel-graphic-effects.c:137]: (style) The scope of the variable 'pixsrc' can be reduced.
[eel/eel-graphic-effects.c:137]: (style) The scope of the variable 'pixdest' can be reduced.
[eel/eel-graphic-effects.c:195]: (style) The scope of the variable 'pixsrc' can be reduced.
[eel/eel-graphic-effects.c:196]: (style) The scope of the variable 'pixdest' can be reduced.
[eel/eel-graphic-effects.c:245]: (style) The scope of the variable 'slab_width' can be reduced.
[eel/eel-graphic-effects.c:262]: (style) The scope of the variable 'slab_height' can be reduced.
[eel/eel-graphic-effects.c:282]: (style) The scope of the variable 'y' can be reduced.

[eel/eel-gtk-extensions.c:165]: (style) The scope of the variable 'screen' can be reduced.
[eel/eel-gtk-extensions.c:167]: (style) The scope of the variable 'screen_width' can be reduced.
[eel/eel-gtk-extensions.c:167]: (style) The scope of the variable 'screen_height' can be reduced.
[eel/eel-gtk-extensions.c:168]: (style) The scope of the variable 'scale' can be reduced.

[eel/eel-labeled-image.c:1051]: (style) The scope of the variable 'x_alignment' can be reduced.
[eel/eel-labeled-image.c:1052]: (style) The scope of the variable 'y_alignment' can be reduced.
[eel/eel-labeled-image.c:1100]: (style) The scope of the variable 'x_alignment' can be reduced.
[eel/eel-labeled-image.c:1101]: (style) The scope of the variable 'y_alignment' can be reduced.

[eel/eel-mate-extensions.c:73]: (style) The scope of the variable 'quoted' can be reduced.

[eel/eel-stock-dialogs.c:409]: (style) The scope of the variable 'button_title' can be reduced.

[eel/eel-string.c:415]: (style) The scope of the variable 'i' can be reduced.
[eel/eel-string.c:542]: (style) The scope of the variable 'type' can be reduced.

[eel/eel-vfs-extensions.c:65]: (style) The scope of the variable 'valid_bytes' can be reduced.

[eel/eel-wrap-table.c:766]: (style) The scope of the variable 'hadj' can be reduced.
[eel/eel-wrap-table.c:766]: (style) The scope of the variable 'vadj' can be reduced.
```