### PR TITLE
eel: remove date & time functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,25 +259,6 @@ fi
 
 AC_SUBST(WARNING_CFLAGS)
 
-dnl ===========================================================================
-
-dnl strftime checks
-
-AC_TRY_RUN([#include <time.h>
-                int main ()
-                {
-                  char buf[100];
-                  struct tm tm = {0};
-                  tm.tm_year = 99;
-                  if (strftime(buf, 100, "%EY", &tm) == 4 &&
-                      strcmp (buf, "1999")==0)
-                    return 0;
-                  return 1;
-                }
-            ],
-    AC_DEFINE(HAVE_STRFTIME_EXTENSION, 1, [Define if strftime supports %E and %O modifiers.])
-)
-
 dnl ==========================================================================
 
 dnl libegg

--- a/eel/eel-glib-extensions.c
+++ b/eel/eel-glib-extensions.c
@@ -33,17 +33,6 @@
 #include <glib-object.h>
 #include <math.h>
 #include <stdlib.h>
-#include <sys/time.h>
-#include <sys/utsname.h>
-#include <time.h>
-#include <locale.h>
-
-/* Legal conversion specifiers, as specified in the C standard. */
-#define C_STANDARD_STRFTIME_CHARACTERS "aAbBcdHIjmMpSUwWxXyYZ"
-#define C_STANDARD_NUMERIC_STRFTIME_CHARACTERS "dHIjmMSUwWyY"
-#define SUS_EXTENDED_STRFTIME_MODIFIERS "EO"
-
-#define SAFE_SHELL_CHARACTERS "-_0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 typedef struct
 {
@@ -53,200 +42,6 @@ typedef struct
 } HashTableToFree;
 
 static GList *hash_tables_to_free_at_exit;
-
-/**
- * eel_g_date_new_tm:
- *
- * Get a new GDate * for the date represented by a tm struct.
- * The caller is responsible for g_free-ing the result.
- * @time_pieces: Pointer to a tm struct representing the date to be converted.
- *
- * Returns: Newly allocated date.
- *
- **/
-GDate *
-eel_g_date_new_tm (struct tm *time_pieces)
-{
-    /* tm uses 0-based months; GDate uses 1-based months.
-     * tm_year needs 1900 added to get the full year.
-     */
-    return g_date_new_dmy (time_pieces->tm_mday,
-                           time_pieces->tm_mon + 1,
-                           time_pieces->tm_year + 1900);
-}
-
-/**
- * eel_strdup_strftime:
- *
- * Cover for standard date-and-time-formatting routine strftime that returns
- * a newly-allocated string of the correct size. The caller is responsible
- * for g_free-ing the returned string.
- *
- * Besides the buffer management, there are two differences between this
- * and the library strftime:
- *
- *   1) The modifiers "-" and "_" between a "%" and a numeric directive
- *      are defined as for the GNU version of strftime. "-" means "do not
- *      pad the field" and "_" means "pad with spaces instead of zeroes".
- *   2) Non-ANSI extensions to strftime are flagged at runtime with a
- *      warning, so it's easy to notice use of the extensions without
- *      testing with multiple versions of the library.
- *
- * @format: format string to pass to strftime. See strftime documentation
- * for details.
- * @time_pieces: date/time, in struct format.
- *
- * Return value: Newly allocated string containing the formatted time.
- **/
-char *
-eel_strdup_strftime (const char *format, struct tm *time_pieces)
-{
-    GString *string;
-    const char *remainder, *percent;
-    char code[4], buffer[512];
-    char *piece, *result, *converted;
-    size_t string_length;
-    gboolean strip_leading_zeros, turn_leading_zeros_to_spaces;
-    char modifier;
-    int i;
-
-    /* Format could be translated, and contain UTF-8 chars,
-     * so convert to locale encoding which strftime uses */
-    converted = g_locale_from_utf8 (format, -1, NULL, NULL, NULL);
-    g_return_val_if_fail (converted != NULL, NULL);
-
-    string = g_string_new ("");
-    remainder = converted;
-
-    /* Walk from % character to % character. */
-    for (;;)
-    {
-        percent = strchr (remainder, '%');
-        if (percent == NULL)
-        {
-            g_string_append (string, remainder);
-            break;
-        }
-        g_string_append_len (string, remainder,
-                             percent - remainder);
-
-        /* Handle the "%" character. */
-        remainder = percent + 1;
-        switch (*remainder)
-        {
-        case '-':
-            strip_leading_zeros = TRUE;
-            turn_leading_zeros_to_spaces = FALSE;
-            remainder++;
-            break;
-        case '_':
-            strip_leading_zeros = FALSE;
-            turn_leading_zeros_to_spaces = TRUE;
-            remainder++;
-            break;
-        case '%':
-            g_string_append_c (string, '%');
-            remainder++;
-            continue;
-        case '\0':
-            g_warning ("Trailing %% passed to eel_strdup_strftime");
-            g_string_append_c (string, '%');
-            continue;
-        default:
-            strip_leading_zeros = FALSE;
-            turn_leading_zeros_to_spaces = FALSE;
-            break;
-        }
-
-        modifier = 0;
-        if (strchr (SUS_EXTENDED_STRFTIME_MODIFIERS, *remainder) != NULL)
-        {
-            modifier = *remainder;
-            remainder++;
-
-            if (*remainder == 0)
-            {
-                g_warning ("Unfinished %%%c modifier passed to eel_strdup_strftime", modifier);
-                break;
-            }
-        }
-
-        if (strchr (C_STANDARD_STRFTIME_CHARACTERS, *remainder) == NULL)
-        {
-            g_warning ("eel_strdup_strftime does not support "
-                       "non-standard escape code %%%c",
-                       *remainder);
-        }
-
-        /* Convert code to strftime format. We have a fixed
-         * limit here that each code can expand to a maximum
-         * of 512 bytes, which is probably OK. There's no
-         * limit on the total size of the result string.
-         */
-        i = 0;
-        code[i++] = '%';
-        if (modifier != 0)
-        {
-#ifdef HAVE_STRFTIME_EXTENSION
-            code[i++] = modifier;
-#endif
-        }
-        code[i++] = *remainder;
-        code[i++] = '\0';
-        string_length = strftime (buffer, sizeof (buffer),
-                                  code, time_pieces);
-        if (string_length == 0)
-        {
-            /* We could put a warning here, but there's no
-             * way to tell a successful conversion to
-             * empty string from a failure.
-             */
-            buffer[0] = '\0';
-        }
-
-        /* Strip leading zeros if requested. */
-        piece = buffer;
-        if (strip_leading_zeros || turn_leading_zeros_to_spaces)
-        {
-            if (strchr (C_STANDARD_NUMERIC_STRFTIME_CHARACTERS, *remainder) == NULL)
-            {
-                g_warning ("eel_strdup_strftime does not support "
-                           "modifier for non-numeric escape code %%%c%c",
-                           remainder[-1],
-                           *remainder);
-            }
-            if (*piece == '0')
-            {
-                do
-                {
-                    piece++;
-                }
-                while (*piece == '0');
-                if (!g_ascii_isdigit (*piece))
-                {
-                    piece--;
-                }
-            }
-            if (turn_leading_zeros_to_spaces)
-            {
-                memset (buffer, ' ', piece - buffer);
-                piece = buffer;
-            }
-        }
-        remainder++;
-
-        /* Add this piece. */
-        g_string_append (string, piece);
-    }
-
-    /* Convert the string back into utf-8. */
-    result = g_locale_to_utf8 (string->str, -1, NULL, NULL, NULL);
-
-    g_string_free (string, TRUE);
-    g_free (converted);
-
-    return result;
-}
 
 /**
  * eel_g_list_exactly_one_item
@@ -531,20 +326,6 @@ eel_g_list_partition (GList *list,
 
     *failed = predicate_false;
     return predicate_true;
-}
-
-/**
- * eel_get_system_time
- *
- * Return value: number of microseconds since the machine was turned on
- */
-gint64
-eel_get_system_time (void)
-{
-    struct timeval tmp;
-
-    gettimeofday (&tmp, NULL);
-    return (gint64)tmp.tv_usec + (gint64)tmp.tv_sec * G_GINT64_CONSTANT (1000000);
 }
 
 static void
@@ -890,56 +671,11 @@ eel_g_settings_add_auto_strv_as_quarks (GSettings *settings,
 
 #if !defined (EEL_OMIT_SELF_CHECK)
 
-static void
-check_tm_to_g_date (time_t time)
-{
-    struct tm *before_conversion;
-    struct tm after_conversion;
-    GDate *date;
-
-    before_conversion = localtime (&time);
-    date = eel_g_date_new_tm (before_conversion);
-
-    g_date_to_struct_tm (date, &after_conversion);
-
-    g_date_free (date);
-
-    EEL_CHECK_INTEGER_RESULT (after_conversion.tm_mday,
-                              before_conversion->tm_mday);
-    EEL_CHECK_INTEGER_RESULT (after_conversion.tm_mon,
-                              before_conversion->tm_mon);
-    EEL_CHECK_INTEGER_RESULT (after_conversion.tm_year,
-                              before_conversion->tm_year);
-}
-
 static gboolean
 eel_test_predicate (gpointer data,
                     gpointer callback_data)
 {
     return g_ascii_strcasecmp (data, callback_data) <= 0;
-}
-
-static char *
-test_strftime (const char *format,
-               int year,
-               int month,
-               int day,
-               int hour,
-               int minute,
-               int second)
-{
-    struct tm time_pieces;
-
-    time_pieces.tm_sec = second;
-    time_pieces.tm_min = minute;
-    time_pieces.tm_hour = hour;
-    time_pieces.tm_mday = day;
-    time_pieces.tm_mon = month - 1;
-    time_pieces.tm_year = year - 1900;
-    time_pieces.tm_isdst = -1;
-    mktime (&time_pieces);
-
-    return eel_strdup_strftime (format, &time_pieces);
 }
 
 void
@@ -951,17 +687,11 @@ eel_self_check_glib_extensions (void)
     GList *compare_list_3;
     GList *compare_list_4;
     GList *compare_list_5;
-    gint64 time1, time2;
     GList *list_to_partition;
     GList *expected_passed;
     GList *expected_failed;
     GList *actual_passed;
     GList *actual_failed;
-    char *huge_string;
-
-    check_tm_to_g_date (0);			/* lower limit */
-    check_tm_to_g_date ((time_t) -1);	/* upper limit */
-    check_tm_to_g_date (time (NULL));	/* current time */
 
     strv = g_strsplit ("zero|one|two|three|four", "|", 0);
     EEL_CHECK_INTEGER_RESULT (eel_g_strv_find (strv, "zero"), 0);
@@ -971,12 +701,6 @@ eel_self_check_glib_extensions (void)
     EEL_CHECK_INTEGER_RESULT (eel_g_strv_find (strv, ""), -1);
     EEL_CHECK_INTEGER_RESULT (eel_g_strv_find (strv, "o"), -1);
     g_strfreev (strv);
-
-    /* eel_get_system_time */
-    time1 = eel_get_system_time ();
-    time2 = eel_get_system_time ();
-    EEL_CHECK_BOOLEAN_RESULT (time1 - time2 > -1000, TRUE);
-    EEL_CHECK_BOOLEAN_RESULT (time1 - time2 <= 0, TRUE);
 
     /* eel_g_str_list_equal */
 
@@ -1050,25 +774,6 @@ eel_self_check_glib_extensions (void)
     g_list_free (actual_passed);
     g_list_free (expected_failed);
     g_list_free (actual_failed);
-
-    /* eel_strdup_strftime */
-    huge_string = g_new (char, 10000+1);
-    memset (huge_string, 'a', 10000);
-    huge_string[10000] = '\0';
-
-    setlocale (LC_TIME, "C");
-
-    EEL_CHECK_STRING_RESULT (test_strftime ("", 2000, 1, 1, 0, 0, 0), "");
-    EEL_CHECK_STRING_RESULT (test_strftime (huge_string, 2000, 1, 1, 0, 0, 0), huge_string);
-    EEL_CHECK_STRING_RESULT (test_strftime ("%%", 2000, 1, 1, 1, 0, 0), "%");
-    EEL_CHECK_STRING_RESULT (test_strftime ("%%%%", 2000, 1, 1, 1, 0, 0), "%%");
-    EEL_CHECK_STRING_RESULT (test_strftime ("%m/%d/%y, %I:%M %p", 2000, 1, 1, 1, 0, 0), "01/01/00, 01:00 AM");
-    EEL_CHECK_STRING_RESULT (test_strftime ("%-m/%-d/%y, %-I:%M %p", 2000, 1, 1, 1, 0, 0), "1/1/00, 1:00 AM");
-    EEL_CHECK_STRING_RESULT (test_strftime ("%_m/%_d/%y, %_I:%M %p", 2000, 1, 1, 1, 0, 0), " 1/ 1/00,  1:00 AM");
-
-    setlocale (LC_TIME, "");
-
-    g_free (huge_string);
 }
 
 #endif /* !EEL_OMIT_SELF_CHECK */

--- a/eel/eel-glib-extensions.h
+++ b/eel/eel-glib-extensions.h
@@ -37,11 +37,6 @@ typedef guint eel_boolean_bit;
 typedef gboolean (* EelPredicateFunction) (gpointer data,
         gpointer callback_data);
 
-/* Date & time functions. */
-GDate *     eel_g_date_new_tm                           (struct tm             *time_pieces);
-char *      eel_strdup_strftime                         (const char            *format,
-        struct tm             *time_pieces);
-
 /* GList functions. */
 gboolean    eel_g_list_exactly_one_item                 (GList                 *list);
 gboolean    eel_g_list_more_than_one_item               (GList                 *list);
@@ -77,9 +72,6 @@ int         eel_g_strv_find                             (char                 **
         const char            *find_me);
 gboolean    eel_g_strv_equal                            (char                 **a,
         char                 **b);
-
-/* return the time in microseconds since the machine was started */
-gint64      eel_get_system_time                         (void);
 
 /* math */
 int         eel_round                                   (double                 d);

--- a/eel/eel-stock-dialogs.c
+++ b/eel/eel-stock-dialogs.c
@@ -137,7 +137,7 @@ timed_wait_free (TimedWait *wait)
                                               wait);
 
         /* compute time up in milliseconds */
-        time_up = (eel_get_system_time () - wait->dialog_creation_time) / 1000;
+        time_up = (g_get_monotonic_time () - wait->dialog_creation_time) / 1000;
 
         if (time_up < TIMED_WAIT_MIN_TIME_UP)
         {
@@ -305,7 +305,7 @@ timed_wait_callback (gpointer callback_data)
     gtk_window_set_default_size (GTK_WINDOW (dialog),
                                  TIMED_WAIT_MINIMUM_DIALOG_WIDTH,
                                  -1);
-    wait->dialog_creation_time = eel_get_system_time ();
+    wait->dialog_creation_time = g_get_monotonic_time ();
     gtk_widget_show (GTK_WIDGET (dialog));
 
     /* FIXME bugzilla.eazel.com 2441:

--- a/libcaja-private/caja-dnd.c
+++ b/libcaja-private/caja-dnd.c
@@ -1006,7 +1006,7 @@ caja_drag_autoscroll_start (CajaDragInfo *drag_info,
         if (drag_info->auto_scroll_timeout_id == 0)
         {
             drag_info->waiting_to_autoscroll = TRUE;
-            drag_info->start_auto_scroll_in = eel_get_system_time()
+            drag_info->start_auto_scroll_in = g_get_monotonic_time()
                                               + AUTOSCROLL_INITIAL_DELAY;
 
             drag_info->auto_scroll_timeout_id = g_timeout_add

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -4806,40 +4806,32 @@ caja_file_fit_date_as_string (CajaFile *file,
 				  void *measure_context)
 {
 	time_t file_time_raw;
-	struct tm *file_time;
 	const char **formats;
 	const char *width_template;
 	const char *format;
 	char *date_string;
-	char *result;
-	GDate *today;
-	GDate *file_date;
-	guint32 file_date_age;
+	gchar *result = NULL;
 	int i;
+	GDateTime *date_time, *today;
+	GTimeSpan file_date_age;
 
 	if (!caja_file_get_date (file, date_type, &file_time_raw)) {
 		return NULL;
 	}
 
-	file_time = localtime (&file_time_raw);
+	date_time = g_date_time_new_from_unix_local (file_time_raw);
 
 	if (date_format_pref == CAJA_DATE_FORMAT_LOCALE) {
-		return eel_strdup_strftime ("%c", file_time);
+		result = g_date_time_format (date_time, "%c");
+		goto out;
 	} else if (date_format_pref == CAJA_DATE_FORMAT_ISO) {
-		return eel_strdup_strftime ("%Y-%m-%d %H:%M:%S", file_time);
+		result = g_date_time_format (date_time, "%Y-%m-%d %H:%M:%S");
+		goto out;
 	}
 
-	file_date = eel_g_date_new_tm (file_time);
-
-	today = g_date_new ();
-	g_date_set_time_t (today, time (NULL));
-
-	/* Overflow results in a large number; fine for our purposes. */
-	file_date_age = (g_date_get_julian (today) -
-			 g_date_get_julian (file_date));
-
-	g_date_free (file_date);
-	g_date_free (today);
+	today = g_date_time_new_now_local ();
+	file_date_age = g_date_time_difference (today, date_time);
+	g_date_time_unref (today);
 
 	/* Format varies depending on how old the date is. This minimizes
 	 * the length (and thus clutter & complication) of typical dates
@@ -4849,9 +4841,9 @@ caja_file_fit_date_as_string (CajaFile *file,
 	 * internationalization's sake.
 	 */
 
-	if (file_date_age == 0)	{
+	if (file_date_age < G_TIME_SPAN_DAY) {
 		formats = TODAY_TIME_FORMATS;
-	} else if (file_date_age == 1) {
+	} else if (file_date_age < 2 * G_TIME_SPAN_DAY) {
 		formats = YESTERDAY_TIME_FORMATS;
 	} else {
 		formats = CURRENT_WEEK_TIME_FORMATS;
@@ -4874,15 +4866,16 @@ caja_file_fit_date_as_string (CajaFile *file,
 			 * shortest format
 			 */
 
-			date_string = eel_strdup_strftime (format, file_time);
+			date_string = g_date_time_format (date_time, format);
 
 			if (truncate_callback == NULL) {
-				return date_string;
+				result = date_string;
+				break;
 			}
 
 			result = (* truncate_callback) (date_string, width, measure_context);
 			g_free (date_string);
-			return result;
+			break;
 		}
 
 		format = _(formats [i + 1]);
@@ -4898,8 +4891,13 @@ caja_file_fit_date_as_string (CajaFile *file,
 		}
 	}
 
-	return eel_strdup_strftime (format, file_time);
+	if (result == NULL) {
+		result = g_date_time_format (date_time, format);
+	}
 
+out:
+	g_date_time_unref (date_time);
+	return result;
 }
 
 /**

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -4797,7 +4797,7 @@ caja_icon_container_did_not_drag (CajaIconContainer *container,
         g_object_get (G_OBJECT (gtk_widget_get_settings (GTK_WIDGET (container))),
                       "gtk-double-click-time", &double_click_time,
                       NULL);
-        current_time = eel_get_system_time ();
+        current_time = g_get_monotonic_time ();
         if (current_time - last_click_time < double_click_time * 1000)
         {
             click_count++;
@@ -4852,7 +4852,7 @@ clicked_within_double_click_interval (CajaIconContainer *container)
     g_object_get (G_OBJECT (gtk_widget_get_settings (GTK_WIDGET (container))),
                   "gtk-double-click-time", &double_click_time,
                   NULL);
-    current_time = eel_get_system_time ();
+    current_time = g_get_monotonic_time ();
     if (current_time - last_click_time < double_click_time * 1000)
     {
         click_count++;

--- a/libcaja-private/caja-icon-dnd.c
+++ b/libcaja-private/caja-icon-dnd.c
@@ -855,7 +855,7 @@ auto_scroll_timeout_callback (gpointer data)
     container = CAJA_ICON_CONTAINER (widget);
 
     if (container->details->dnd_info->drag_info.waiting_to_autoscroll
-            && container->details->dnd_info->drag_info.start_auto_scroll_in > eel_get_system_time())
+            && container->details->dnd_info->drag_info.start_auto_scroll_in > g_get_monotonic_time())
     {
         /* not yet */
         return TRUE;

--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -508,27 +508,27 @@ create_date_format_menu (GtkBuilder *builder)
 {
     GtkComboBoxText *combo_box;
     gchar *date_string;
-    time_t now_raw;
-    struct tm* now;
+    GDateTime *now;
 
     combo_box = GTK_COMBO_BOX_TEXT
             (gtk_builder_get_object (builder,
                                      CAJA_FILE_MANAGEMENT_PROPERTIES_DATE_FORMAT_WIDGET));
 
-    now_raw = time (NULL);
-    now = localtime (&now_raw);
+    now = g_date_time_new_now_local ();
 
-    date_string = eel_strdup_strftime ("%c", now);
+    date_string = g_date_time_format (now, "%c");
     gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_box), date_string);
     g_free (date_string);
 
-    date_string = eel_strdup_strftime ("%Y-%m-%d %H:%M:%S", now);
+    date_string = g_date_time_format (now, "%Y-%m-%d %H:%M:%S");
     gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_box), date_string);
     g_free (date_string);
 
-    date_string = eel_strdup_strftime (_("today at %-I:%M:%S %p"), now);
+    date_string = g_date_time_format (now, _("today at %-I:%M:%S %p"));
     gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_box), date_string);
     g_free (date_string);
+
+    g_date_time_unref (now);
 }
 
 static void

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -3198,7 +3198,7 @@ changes_timeout_callback (gpointer data)
 
 	g_object_ref (G_OBJECT (view));
 
-	now = eel_get_system_time();
+	now = g_get_monotonic_time();
 	time_delta = now - view->details->last_queued;
 
 	if (time_delta < UPDATE_INTERVAL_RESET*1000) {
@@ -3223,7 +3223,7 @@ static void
 schedule_changes (FMDirectoryView *view)
 {
 	/* Remember when the change was queued */
-	view->details->last_queued = eel_get_system_time();
+	view->details->last_queued = g_get_monotonic_time();
 
 	/* No need to schedule if there are already changes pending or during loading */
 	if (view->details->changes_timeout_id != 0 ||

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -697,7 +697,7 @@ button_press_callback (GtkWidget *widget, GdkEventButton *event, gpointer callba
                   NULL);
 
     /* Determine click count */
-    current_time = eel_get_system_time ();
+    current_time = g_get_monotonic_time ();
     if (current_time - last_click_time < double_click_time * 1000)
     {
         click_count++;


### PR DESCRIPTION
Do not need to extend glib library, since it now incorporates these functions.
Extended date format modifiers are available on [glib v2.56](https://bugzilla.gnome.org/show_bug.cgi?id=749206).
eel-glib-extensions.h/c:
```C
GDate * eel_g_date_new_tm (struct tm *time_pieces);
char * eel_strdup_strftime (const char *format, struct tm *time_pieces);
gint64 eel_get_system_time (void);
```

Do not need to test the extensions in `eel_self_check_glib_extensions (void)`.
eel-glib-extensions.c:
```C
static void check_tm_to_g_date (time_t time)
static char * test_strftime (...)
```

Do not need to check if strftime implements extended date format modifiers on the system (available on [glibc v2.27](https://sourceware.org/bugzilla/show_bug.cgi?id=10871)).
configure.ac