### PR TITLE
libcaja-private: reduce the scope of some variables

### DIFF
--- a/libcaja-private/caja-autorun.c
+++ b/libcaja-private/caja-autorun.c
@@ -475,7 +475,6 @@ caja_autorun_prepare_combo_box (GtkWidget *combo_box,
     cairo_surface_t *surface;
     int icon_size, icon_scale;
     int set_active;
-    int n;
     int num_apps;
     gboolean pref_ask;
     gboolean pref_start_app;
@@ -593,6 +592,8 @@ caja_autorun_prepare_combo_box (GtkWidget *combo_box,
                             COLUMN_AUTORUN_X_CONTENT_TYPE, NULL,
                             COLUMN_AUTORUN_ITEM_TYPE, AUTORUN_SEP,
                             -1);
+
+        int n;
 
         for (l = app_info_list, n = include_ask ? 4 : 3; l != NULL; l = l->next, n++)
         {

--- a/libcaja-private/caja-bookmark.c
+++ b/libcaja-private/caja-bookmark.c
@@ -467,8 +467,7 @@ bookmark_file_changed_callback (CajaFile *file, CajaBookmark *bookmark)
 static void
 caja_bookmark_set_icon_to_default (CajaBookmark *bookmark)
 {
-    GIcon *icon, *emblemed_icon, *folder;
-    GEmblem *emblem;
+    GIcon *emblemed_icon, *folder;
 
     if (bookmark->details->icon)
     {
@@ -479,6 +478,9 @@ caja_bookmark_set_icon_to_default (CajaBookmark *bookmark)
 
     if (caja_bookmark_uri_known_not_to_exist (bookmark))
     {
+        GIcon *icon;
+        GEmblem *emblem;
+
         icon = g_themed_icon_new ("dialog-warning");
         emblem = g_emblem_new (icon);
 
@@ -644,13 +646,14 @@ bookmark_image_menu_item_new_from_surface (cairo_surface_t   *icon_surface,
 GtkWidget *
 caja_bookmark_menu_item_new (CajaBookmark *bookmark)
 {
-    GtkWidget *menu_item;
     cairo_surface_t *image_cairo;
 
     image_cairo = create_image_cairo_for_bookmark (bookmark);
 
     if (strlen (bookmark->details->name) > 0)
     {
+        GtkWidget *menu_item;
+
         menu_item = bookmark_image_menu_item_new_from_surface (image_cairo, bookmark->details->name);
 
         return menu_item;

--- a/libcaja-private/caja-clipboard-monitor.c
+++ b/libcaja-private/caja-clipboard-monitor.c
@@ -78,10 +78,10 @@ destroy_clipboard_monitor (void)
 CajaClipboardMonitor *
 caja_clipboard_monitor_get (void)
 {
-    GtkClipboard *clipboard;
-
     if (clipboard_monitor == NULL)
     {
+        GtkClipboard *clipboard;
+
         clipboard_monitor = CAJA_CLIPBOARD_MONITOR (g_object_new (CAJA_TYPE_CLIPBOARD_MONITOR, NULL));
         eel_debug_call_at_shutdown (destroy_clipboard_monitor);
 
@@ -227,7 +227,7 @@ convert_file_list_to_string (CajaClipboardInfo *info,
                              gsize *len)
 {
     GString *uris;
-    char *uri, *tmp;
+    char *tmp;
     GFile *f;
     guint i;
     GList *l;
@@ -243,6 +243,8 @@ convert_file_list_to_string (CajaClipboardInfo *info,
 
     for (i = 0, l = info->files; l != NULL; l = l->next, i++)
     {
+        char *uri;
+
         uri = caja_file_get_uri (l->data);
 
         if (format_for_text)
@@ -286,9 +288,7 @@ caja_get_clipboard_callback (GtkClipboard     *clipboard,
                              guint             info,
                              gpointer          user_data)
 {
-    char **uris;
     GList *l;
-    int i;
     CajaClipboardInfo *clipboard_info;
     GdkAtom target;
 
@@ -299,6 +299,9 @@ caja_get_clipboard_callback (GtkClipboard     *clipboard,
 
     if (gtk_targets_include_uri (&target, 1))
     {
+        char **uris;
+        int i;
+
         uris = g_malloc ((g_list_length (clipboard_info->files) + 1) * sizeof (char *));
         i = 0;
 

--- a/libcaja-private/caja-clipboard.c
+++ b/libcaja-private/caja-clipboard.c
@@ -162,7 +162,6 @@ received_clipboard_contents (GtkClipboard     *clipboard,
 static void
 set_paste_sensitive_if_clipboard_contains_data (GtkActionGroup *action_group)
 {
-    GtkAction *action;
     if (gdk_display_supports_selection_notification (gdk_display_get_default ()))
     {
         gtk_clipboard_request_contents (gtk_clipboard_get (GDK_SELECTION_CLIPBOARD),
@@ -172,6 +171,8 @@ set_paste_sensitive_if_clipboard_contains_data (GtkActionGroup *action_group)
     }
     else
     {
+        GtkAction *action;
+
         /* If selection notification isn't supported, always activate Paste */
         action = gtk_action_group_get_action (action_group,
                                               "Paste");
@@ -614,7 +615,6 @@ caja_clipboard_get_uri_list_from_selection_data (GtkSelectionData *selection_dat
         GdkAtom copied_files_atom)
 {
     GList *items;
-    char **lines;
 
     if (gtk_selection_data_get_data_type (selection_data) != copied_files_atom
             || gtk_selection_data_get_length (selection_data) <= 0)
@@ -623,6 +623,7 @@ caja_clipboard_get_uri_list_from_selection_data (GtkSelectionData *selection_dat
     }
     else
     {
+        char **lines;
         guchar *data;
         /* Not sure why it's legal to assume there's an extra byte
          * past the end of the selection data that it's safe to write

--- a/libcaja-private/caja-customization-data.c
+++ b/libcaja-private/caja-customization-data.c
@@ -124,8 +124,7 @@ caja_customization_data_new (const char *customization_name,
                              int maximum_icon_width)
 {
     CajaCustomizationData *data;
-    char *public_directory_path, *private_directory_path;
-    char *temp_str;
+    char *private_directory_path;
     gboolean public_result, private_result;
 
     data = g_new0 (CajaCustomizationData, 1);
@@ -134,6 +133,8 @@ caja_customization_data_new (const char *customization_name,
 
     if (show_public_customizations)
     {
+        char *public_directory_path;
+
         public_directory_path = get_global_customization_path (customization_name);
 
         public_result  = read_all_children (public_directory_path,
@@ -171,6 +172,8 @@ caja_customization_data_new (const char *customization_name,
     /* load the frame if necessary */
     if (strcmp (customization_name, "patterns") == 0)
     {
+        char *temp_str;
+
         temp_str = caja_pixmap_file ("chit_frame.png");
         if (temp_str != NULL)
         {
@@ -425,7 +428,7 @@ caja_customization_make_pattern_chit (GdkPixbuf *pattern_tile, GdkPixbuf *frame,
 static char*
 format_name_for_display (CajaCustomizationData *data, const char* name)
 {
-    char *formatted_str, *mapped_name;
+    char *formatted_str;
 
     if (!g_strcmp0(name, RESET_IMAGE_NAME))
     {
@@ -437,6 +440,8 @@ format_name_for_display (CajaCustomizationData *data, const char* name)
     formatted_str = eel_filename_strip_extension (name);
     if (data->name_map_hash != NULL)
     {
+        char *mapped_name;
+
         mapped_name = g_hash_table_lookup (data->name_map_hash, formatted_str);
         if (mapped_name)
         {
@@ -455,7 +460,6 @@ static void
 load_name_map_hash_table (CajaCustomizationData *data)
 {
     char *xml_path;
-    char *filename, *display_name;
 
     xmlDocPtr browser_data;
     xmlNodePtr category_node, current_node;
@@ -479,6 +483,8 @@ load_name_map_hash_table (CajaCustomizationData *data)
             /* loop through the entries, adding a mapping to the hash table */
             while (current_node != NULL)
             {
+                char *filename, *display_name;
+
                 display_name = eel_xml_get_property_translated (current_node, "display_name");
                 filename = xmlGetProp (current_node, "filename");
                 if (display_name && filename)

--- a/libcaja-private/caja-debug-log.c
+++ b/libcaja-private/caja-debug-log.c
@@ -396,8 +396,6 @@ caja_debug_log_enable_domains (const char **domains, int n_domains)
 void
 caja_debug_log_disable_domains (const char **domains, int n_domains)
 {
-    int i;
-
     g_assert (domains != NULL);
     g_assert (n_domains >= 0);
 
@@ -405,6 +403,8 @@ caja_debug_log_disable_domains (const char **domains, int n_domains)
 
     if (domains_hash)
     {
+        int i;
+
         for (i = 0; i < n_domains; i++)
         {
             char *domain;
@@ -464,7 +464,6 @@ make_key_file_from_configuration (void)
 {
     GKeyFile *key_file;
     struct domains_dump_closure closure;
-    int num_domains;
 
     key_file = g_key_file_new ();
 
@@ -472,6 +471,8 @@ make_key_file_from_configuration (void)
 
     if (domains_hash)
     {
+        int num_domains;
+
         num_domains = g_hash_table_size (domains_hash);
         if (num_domains != 0)
         {

--- a/libcaja-private/caja-desktop-icon-file.c
+++ b/libcaja-private/caja-desktop-icon-file.c
@@ -329,11 +329,12 @@ caja_desktop_icon_file_unmount (CajaFile                   *file,
                                 gpointer                        callback_data)
 {
     CajaDesktopIconFile *desktop_file;
-    GMount *mount;
 
     desktop_file = CAJA_DESKTOP_ICON_FILE (file);
     if (desktop_file)
     {
+        GMount *mount;
+
         mount = caja_desktop_link_get_mount (desktop_file->details->link);
         if (mount != NULL)
         {
@@ -351,11 +352,12 @@ caja_desktop_icon_file_eject (CajaFile                   *file,
                               gpointer                        callback_data)
 {
     CajaDesktopIconFile *desktop_file;
-    GMount *mount;
 
     desktop_file = CAJA_DESKTOP_ICON_FILE (file);
     if (desktop_file)
     {
+        GMount *mount;
+
         mount = caja_desktop_link_get_mount (desktop_file->details->link);
         if (mount != NULL)
         {

--- a/libcaja-private/caja-desktop-link-monitor.c
+++ b/libcaja-private/caja-desktop-link-monitor.c
@@ -95,11 +95,12 @@ volume_file_name_used (CajaDesktopLinkMonitor *monitor,
                        const char *name)
 {
     GList *l;
-    char *other_name;
     gboolean same;
 
     for (l = monitor->details->mount_links; l != NULL; l = l->next)
     {
+        char *other_name;
+
         other_name = caja_desktop_link_get_file_name (l->data);
         same = strcmp (name, other_name) == 0;
         g_free (other_name);
@@ -135,8 +136,8 @@ has_mount (CajaDesktopLinkMonitor *monitor,
            GMount                     *mount)
 {
     gboolean ret;
-    GMount *other_mount;
     GList *l;
+    GMount *other_mount = NULL;
 
     ret = FALSE;
 
@@ -159,14 +160,14 @@ static void
 create_mount_link (CajaDesktopLinkMonitor *monitor,
                    GMount *mount)
 {
-    CajaDesktopLink *link;
-
     if (has_mount (monitor, mount))
         return;
 
     if ((!g_mount_is_shadowed (mount)) &&
             g_settings_get_boolean (caja_desktop_preferences, CAJA_PREFERENCES_DESKTOP_VOLUMES_VISIBLE))
     {
+        CajaDesktopLink *link;
+
         link = caja_desktop_link_new_from_mount (mount);
         monitor->details->mount_links = g_list_prepend (monitor->details->mount_links, link);
     }
@@ -178,7 +179,7 @@ remove_mount_link (CajaDesktopLinkMonitor *monitor,
 {
     GList *l;
     CajaDesktopLink *link;
-    GMount *other_mount;
+    GMount *other_mount = NULL;
 
     link = NULL;
     for (l = monitor->details->mount_links; l != NULL; l = l->next)
@@ -363,7 +364,7 @@ caja_desktop_link_monitor_init (gpointer object, gpointer klass)
 {
     CajaDesktopLinkMonitor *monitor;
     GList *l, *mounts;
-    GMount *mount;
+    GMount *mount = NULL;
 
     monitor = CAJA_DESKTOP_LINK_MONITOR (object);
 

--- a/libcaja-private/caja-desktop-metadata.c
+++ b/libcaja-private/caja-desktop-metadata.c
@@ -235,8 +235,7 @@ caja_desktop_update_metadata_from_keyfile (CajaFile *file,
 {
     gchar **keys, **values;
     const gchar *actual_values[2];
-    const gchar *key, *value;
-    gchar *gio_key;
+    const gchar *value;
     gsize length, values_length;
     GKeyFile *keyfile;
     GFileInfo *info;
@@ -257,6 +256,9 @@ caja_desktop_update_metadata_from_keyfile (CajaFile *file,
     info = g_file_info_new ();
 
     for (idx = 0; idx < length; idx++) {
+        const gchar *key;
+        gchar *gio_key;
+
         key = keys[idx];
         values = g_key_file_get_string_list (keyfile,
                              name,

--- a/libcaja-private/caja-directory-async.c
+++ b/libcaja-private/caja-directory-async.c
@@ -623,10 +623,11 @@ static void
 new_files_cancel (CajaDirectory *directory)
 {
     GList *l;
-    NewFilesState *state;
 
     if (directory->details->new_files_in_progress != NULL)
     {
+        NewFilesState *state = NULL;
+
         for (l = directory->details->new_files_in_progress; l != NULL; l = l->next)
         {
             state = l->data;
@@ -688,10 +689,10 @@ static void
 remove_monitor_link (CajaDirectory *directory,
                      GList *link)
 {
-    Monitor *monitor;
-
     if (link != NULL)
     {
+        Monitor *monitor;
+
         monitor = link->data;
         request_counter_remove_request (directory->details->monitor_counters,
                                         monitor->request);
@@ -804,7 +805,6 @@ caja_directory_monitor_add_internal (CajaDirectory *directory,
                                      gpointer callback_data)
 {
     Monitor *monitor;
-    GList *file_list;
 
     g_assert (CAJA_IS_DIRECTORY (directory));
 
@@ -829,6 +829,8 @@ caja_directory_monitor_add_internal (CajaDirectory *directory,
 
     if (callback != NULL)
     {
+        GList *file_list;
+
         file_list = caja_directory_get_file_list (directory);
         (* callback) (directory, file_list, callback_data);
         caja_file_list_free (file_list);
@@ -1128,12 +1130,13 @@ directory_load_one (CajaDirectory *directory,
 static void
 directory_load_cancel (CajaDirectory *directory)
 {
-    CajaFile *file;
     DirectoryLoadState *state;
 
     state = directory->details->directory_load_in_progress;
     if (state != NULL)
     {
+        CajaFile *file;
+
         file = state->load_directory_file;
         file->details->loading_directory = FALSE;
         if (file->details->directory != directory)
@@ -1230,7 +1233,7 @@ caja_directory_remove_file_monitors (CajaDirectory *directory,
                                      CajaFile *file)
 {
     GList *result, **list, *node, *next;
-    Monitor *monitor;
+    Monitor *monitor = NULL;
 
     g_assert (CAJA_IS_DIRECTORY (directory));
     g_assert (CAJA_IS_FILE (file));
@@ -1267,7 +1270,7 @@ caja_directory_add_file_monitors (CajaDirectory *directory,
 {
     GList **list;
     GList *l;
-    Monitor *monitor;
+    Monitor *monitor = NULL;
 
     g_assert (CAJA_IS_DIRECTORY (directory));
     g_assert (CAJA_IS_FILE (file));
@@ -1618,8 +1621,8 @@ caja_directory_get_info_for_new_files (CajaDirectory *directory,
                                        GList *location_list)
 {
     NewFilesState *state;
-    GFile *location;
     GList *l;
+    GFile *location = NULL;
 
     if (location_list == NULL)
     {
@@ -1656,8 +1659,8 @@ caja_async_destroying_file (CajaFile *file)
     CajaDirectory *directory;
     gboolean changed;
     GList *node, *next;
-    ReadyCallback *callback;
-    Monitor *monitor;
+    ReadyCallback *callback = NULL;
+    Monitor *monitor = NULL;
 
     directory = file->details->directory;
     changed = FALSE;
@@ -2064,7 +2067,7 @@ call_ready_callbacks (CajaDirectory *directory)
 {
     gboolean found_any;
     GList *node, *next;
-    ReadyCallback *callback;
+    ReadyCallback *callback = NULL;
 
     found_any = FALSE;
 
@@ -2095,8 +2098,8 @@ caja_directory_has_active_request_for_file (CajaDirectory *directory,
         CajaFile *file)
 {
     GList *node;
-    ReadyCallback *callback;
-    Monitor *monitor;
+    ReadyCallback *callback = NULL;
+    Monitor *monitor = NULL;
 
     for (node = directory->details->call_when_ready_list;
             node != NULL; node = node->next)
@@ -2152,7 +2155,7 @@ static void
 mark_all_files_unconfirmed (CajaDirectory *directory)
 {
     GList *node;
-    CajaFile *file;
+    CajaFile *file = NULL;
 
     for (node = directory->details->file_list; node != NULL; node = node->next)
     {
@@ -2192,7 +2195,7 @@ more_files_callback (GObject *source_object,
     CajaDirectory *directory;
     GError *error;
     GList *files, *l;
-    GFileInfo *info;
+    GFileInfo *info = NULL;
 
     state = user_data;
 
@@ -2467,8 +2470,6 @@ is_needy (CajaFile *file,
 {
     CajaDirectory *directory;
     GList *node;
-    ReadyCallback *callback;
-    Monitor *monitor;
 
     if (!(* check_missing) (file))
     {
@@ -2478,6 +2479,8 @@ is_needy (CajaFile *file,
     directory = file->details->directory;
     if (directory->details->call_when_ready_counters[request_type_wanted] > 0)
     {
+        ReadyCallback *callback = NULL;
+
         for (node = directory->details->call_when_ready_list;
                 node != NULL; node = node->next)
         {
@@ -2500,6 +2503,8 @@ is_needy (CajaFile *file,
 
     if (directory->details->monitor_counters[request_type_wanted] > 0)
     {
+        Monitor *monitor = NULL;
+
         for (node = directory->details->monitor_list;
                 node != NULL; node = node->next)
         {
@@ -2519,10 +2524,10 @@ is_needy (CajaFile *file,
 static void
 directory_count_stop (CajaDirectory *directory)
 {
-    CajaFile *file;
-
     if (directory->details->count_in_progress != NULL)
     {
+        CajaFile *file;
+
         file = directory->details->count_in_progress->count_file;
         if (file != NULL)
         {
@@ -2546,7 +2551,7 @@ count_non_skipped_files (GList *list)
 {
     guint count;
     GList *node;
-    GFileInfo *info;
+    GFileInfo *info = NULL;
 
     count = 0;
     for (node = list; node != NULL; node = node->next)
@@ -2678,13 +2683,14 @@ count_children_callback (GObject *source_object,
 {
     DirectoryCountState *state;
     GFileEnumerator *enumerator;
-    CajaDirectory *directory;
     GError *error;
 
     state = user_data;
 
     if (g_cancellable_is_cancelled (state->cancellable))
     {
+        CajaDirectory *directory;
+
         /* Operation was cancelled. Bail out */
         directory = state->directory;
         directory->details->count_in_progress = NULL;
@@ -2831,9 +2837,7 @@ deep_count_one (DeepCountState *state,
                 GFileInfo *info)
 {
     CajaFile *file;
-    GFile *subdir;
     gboolean is_seen_inode;
-    const char *fs_id;
 
     if (should_skip_file (NULL, info))
     {
@@ -2850,6 +2854,8 @@ deep_count_one (DeepCountState *state,
 
     if (g_file_info_get_file_type (info) == G_FILE_TYPE_DIRECTORY)
     {
+        const char *fs_id;
+
         /* Count the directory. */
         file->details->deep_directory_count += 1;
 
@@ -2858,6 +2864,8 @@ deep_count_one (DeepCountState *state,
         fs_id = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_ID_FILESYSTEM);
         if (g_strcmp0 (fs_id, state->fs_id) == 0)
         {
+            GFile *subdir;
+
             /* only if it is on the same filesystem */
             subdir = g_file_get_child (state->deep_count_location, g_file_info_get_name (info));
             state->deep_count_subdirectories = g_list_prepend (state->deep_count_subdirectories, subdir);
@@ -2908,7 +2916,6 @@ deep_count_state_free (DeepCountState *state)
 static void
 deep_count_next_dir (DeepCountState *state)
 {
-    GFile *location;
     CajaFile *file;
     CajaDirectory *directory;
     gboolean done;
@@ -2923,6 +2930,8 @@ deep_count_next_dir (DeepCountState *state)
 
     if (state->deep_count_subdirectories != NULL)
     {
+        GFile *location;
+
         /* Work on a new directory. */
         location = state->deep_count_subdirectories->data;
         state->deep_count_subdirectories = g_list_remove
@@ -2957,7 +2966,7 @@ deep_count_more_files_callback (GObject *source_object,
     DeepCountState *state;
     CajaDirectory *directory;
     GList *files, *l;
-    GFileInfo *info;
+    GFileInfo *info = NULL;
 
     state = user_data;
 
@@ -3074,10 +3083,10 @@ deep_count_load (DeepCountState *state, GFile *location)
 static void
 deep_count_stop (CajaDirectory *directory)
 {
-    CajaFile *file;
-
     if (directory->details->deep_count_in_progress != NULL)
     {
+        CajaFile *file;
+
         file = directory->details->deep_count_file;
         if (file != NULL)
         {
@@ -3102,13 +3111,14 @@ deep_count_got_info (GObject *source_object,
                      gpointer user_data)
 {
      GFileInfo *info;
-     const char *id;
      GFile *file = (GFile *)source_object;
      DeepCountState *state = (DeepCountState *)user_data;
 
      info = g_file_query_info_finish (file, res, NULL);
      if (info != NULL)
      {
+         const char *id;
+
          id = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_ID_FILESYSTEM);
          state->fs_id = g_strdup (id);
          g_object_unref (info);
@@ -3182,10 +3192,10 @@ deep_count_start (CajaDirectory *directory,
 static void
 mime_list_stop (CajaDirectory *directory)
 {
-    CajaFile *file;
-
     if (directory->details->mime_list_in_progress != NULL)
     {
+        CajaFile *file;
+
         file = directory->details->mime_list_in_progress->mime_list_file;
         if (file != NULL)
         {
@@ -3287,7 +3297,7 @@ mime_list_callback (GObject *source_object,
     CajaDirectory *directory;
     GError *error;
     GList *files, *l;
-    GFileInfo *info;
+    GFileInfo *info = NULL;
 
     state = user_data;
     directory = state->directory;
@@ -3349,13 +3359,14 @@ list_mime_enum_callback (GObject *source_object,
 {
     MimeListState *state;
     GFileEnumerator *enumerator;
-    CajaDirectory *directory;
     GError *error;
 
     state = user_data;
 
     if (g_cancellable_is_cancelled (state->cancellable))
     {
+        CajaDirectory *directory;
+
         /* Operation was cancelled. Bail out */
         directory = state->directory;
         directory->details->mime_list_in_progress = NULL;
@@ -3464,10 +3475,10 @@ mime_list_start (CajaDirectory *directory,
 static void
 top_left_stop (CajaDirectory *directory)
 {
-    CajaFile *file;
-
     if (directory->details->top_left_read_state != NULL)
     {
+        CajaFile *file;
+
         file = directory->details->top_left_read_state->file;
         if (file != NULL)
         {
@@ -3732,10 +3743,10 @@ query_info_callback (GObject *source_object,
 static void
 file_info_stop (CajaDirectory *directory)
 {
-    CajaFile *file;
-
     if (directory->details->get_info_in_progress != NULL)
     {
+        CajaFile *file;
+
         file = directory->details->get_info_file;
         if (file != NULL)
         {
@@ -3843,7 +3854,6 @@ static gboolean
 is_link_trusted (CajaFile *file,
                  gboolean is_launcher)
 {
-    GFile *location;
     gboolean res;
 
     if (!is_launcher)
@@ -3860,6 +3870,8 @@ is_link_trusted (CajaFile *file,
 
     if (caja_file_is_local (file))
     {
+        GFile *location;
+
         location = caja_file_get_location (file);
         res = caja_is_in_system_dir (location);
 
@@ -3931,10 +3943,10 @@ should_read_link_info_sync (CajaFile *file)
 static void
 link_info_stop (CajaDirectory *directory)
 {
-    CajaFile *file;
-
     if (directory->details->link_info_read_state != NULL)
     {
+        CajaFile *file;
+
         file = directory->details->link_info_read_state->file;
 
         if (file != NULL)
@@ -3961,7 +3973,7 @@ link_info_got_data (CajaDirectory *directory,
                     goffset bytes_read,
                     char *file_contents)
 {
-    char *link_uri, *uri, *name, *icon;
+    char *uri, *name, *icon;
     gboolean is_launcher;
     gboolean is_foreign;
 
@@ -3976,6 +3988,8 @@ link_info_got_data (CajaDirectory *directory,
     /* Handle the case where we read the Caja link. */
     if (result)
     {
+        char *link_uri;
+
         link_uri = caja_file_get_uri (file);
         caja_link_get_link_info_given_file_contents (file_contents, bytes_read, link_uri,
                 &uri, &name, &icon, &is_launcher, &is_foreign);
@@ -4117,9 +4131,6 @@ thumbnail_done (CajaDirectory *directory,
                 GdkPixbuf *pixbuf,
                 gboolean tried_original)
 {
-    const char *thumb_mtime_str;
-    time_t thumb_mtime = 0;
-
     file->details->thumbnail_is_up_to_date = TRUE;
     file->details->thumbnail_tried_original  = tried_original;
     if (file->details->thumbnail)
@@ -4129,12 +4140,16 @@ thumbnail_done (CajaDirectory *directory,
     }
     if (pixbuf)
     {
+        time_t thumb_mtime = 0;
+
         if (tried_original)
         {
             thumb_mtime = file->details->mtime;
         }
         else
         {
+            const char *thumb_mtime_str;
+
             thumb_mtime_str = gdk_pixbuf_get_option (pixbuf, "tEXt::Thumb::MTime");
             if (thumb_mtime_str)
             {
@@ -4161,10 +4176,10 @@ thumbnail_done (CajaDirectory *directory,
 static void
 thumbnail_stop (CajaDirectory *directory)
 {
-    CajaFile *file;
-
     if (directory->details->thumbnail_state != NULL)
     {
+        CajaFile *file;
+
         file = directory->details->thumbnail_state->file;
 
         if (file != NULL)
@@ -4300,7 +4315,6 @@ thumbnail_read_callback (GObject *source_object,
     gboolean result;
     CajaDirectory *directory;
     GdkPixbuf *pixbuf;
-    GFile *location;
 
     state = user_data;
 
@@ -4327,6 +4341,8 @@ thumbnail_read_callback (GObject *source_object,
 
     if (pixbuf == NULL && state->trying_original)
     {
+        GFile *location;
+
         state->trying_original = FALSE;
 
         location = g_file_new_for_path (state->file->details->thumbnail_path);
@@ -4404,10 +4420,10 @@ thumbnail_start (CajaDirectory *directory,
 static void
 mount_stop (CajaDirectory *directory)
 {
-    CajaFile *file;
-
     if (directory->details->mount_state != NULL)
     {
+        CajaFile *file;
+
         file = directory->details->mount_state->file;
 
         if (file != NULL)
@@ -4468,7 +4484,6 @@ find_enclosing_mount_callback (GObject *source_object,
 {
     GMount *mount;
     MountState *state;
-    GFile *location, *root;
 
     state = user_data;
     if (state->directory == NULL)
@@ -4483,6 +4498,8 @@ find_enclosing_mount_callback (GObject *source_object,
 
     if (mount)
     {
+        GFile *location, *root;
+
         root = g_mount_get_root (mount);
         location = caja_file_get_location (state->file);
         if (!g_file_equal (location, root))
@@ -4621,10 +4638,10 @@ filesystem_info_cancel (CajaDirectory *directory)
 static void
 filesystem_info_stop (CajaDirectory *directory)
 {
-    CajaFile *file;
-
     if (directory->details->filesystem_info_state != NULL)
     {
+        CajaFile *file;
+
         file = directory->details->filesystem_info_state->file;
 
         if (file != NULL)
@@ -5294,10 +5311,11 @@ static void
 add_all_files_to_work_queue (CajaDirectory *directory)
 {
     GList *node;
-    CajaFile *file;
 
     for (node = directory->details->file_list; node != NULL; node = node->next)
     {
+        CajaFile *file;
+
         file = CAJA_FILE (node->data);
 
         caja_directory_add_file_to_work_queue (directory, file);

--- a/libcaja-private/caja-directory.c
+++ b/libcaja-private/caja-directory.c
@@ -237,7 +237,7 @@ void
 emit_change_signals_for_all_files_in_all_directories (void)
 {
     GList *dirs, *l;
-    CajaDirectory *directory;
+    CajaDirectory *directory = NULL;
 
     dirs = NULL;
     g_hash_table_foreach (directories,
@@ -361,11 +361,12 @@ CajaFile *
 caja_directory_get_corresponding_file (CajaDirectory *directory)
 {
     CajaFile *file;
-    char *uri;
 
     file = caja_directory_get_existing_corresponding_file (directory);
     if (file == NULL)
     {
+        char *uri;
+
         uri = caja_directory_get_uri (directory);
         file = caja_file_get_by_uri (uri);
         g_free (uri);
@@ -719,12 +720,13 @@ caja_directory_emit_load_error (CajaDirectory *directory,
 static CajaDirectory *
 get_parent_directory (GFile *location)
 {
-    CajaDirectory *directory;
     GFile *parent;
 
     parent = g_file_get_parent (location);
     if (parent)
     {
+        CajaDirectory *directory;
+
         directory = caja_directory_get_internal (parent, TRUE);
         g_object_unref (parent);
         return directory;
@@ -738,12 +740,13 @@ get_parent_directory (GFile *location)
 static CajaDirectory *
 get_parent_directory_if_exists (GFile *location)
 {
-    CajaDirectory *directory;
     GFile *parent;
 
     parent = g_file_get_parent (location);
     if (parent)
     {
+        CajaDirectory *directory;
+
         directory = caja_directory_get_internal (parent, FALSE);
         g_object_unref (parent);
         return directory;
@@ -778,7 +781,7 @@ static void
 call_files_changed_common (CajaDirectory *directory, GList *file_list)
 {
     GList *node;
-    CajaFile *file;
+    CajaFile *file = NULL;
 
     for (node = file_list; node != NULL; node = node->next)
     {
@@ -859,10 +862,11 @@ caja_directory_notify_files_added (GList *files)
 {
     GHashTable *added_lists;
     GList *p;
-    CajaDirectory *directory;
     GHashTable *parent_directories;
     CajaFile *file;
-    GFile *location, *parent;
+    GFile *parent;
+    CajaDirectory *directory = NULL;
+    GFile *location = NULL;
 
     /* Make a list of added files in each directory. */
     added_lists = g_hash_table_new (NULL, NULL);
@@ -948,8 +952,8 @@ caja_directory_notify_files_changed (GList *files)
 {
     GHashTable *changed_lists;
     GList *node;
-    GFile *location;
-    CajaFile *file;
+    GFile *location = NULL;
+    CajaFile *file = NULL;
 
     /* Make a list of changed files in each directory. */
     changed_lists = g_hash_table_new (NULL, NULL);
@@ -986,10 +990,10 @@ caja_directory_notify_files_removed (GList *files)
 {
     GHashTable *changed_lists;
     GList *p;
-    CajaDirectory *directory;
     GHashTable *parent_directories;
-    CajaFile *file;
-    GFile *location;
+    CajaDirectory *directory = NULL;
+    CajaFile *file = NULL;
+    GFile *location = NULL;
 
     /* Make a list of changed files in each directory. */
     changed_lists = g_hash_table_new (NULL, NULL);
@@ -1095,10 +1099,10 @@ caja_directory_moved_internal (GFile *old_location,
                                GFile *new_location)
 {
     CollectData collection;
-    CajaDirectory *directory;
     GList *node, *affected_files;
-    GFile *new_directory_location;
     char *relative_path;
+    CajaDirectory *directory = NULL;
+    GFile *new_directory_location = NULL;
 
     collection.container = old_location;
     collection.directories = NULL;
@@ -1161,9 +1165,9 @@ caja_directory_moved (const char *old_uri,
 {
     GList *list, *node;
     GHashTable *hash;
-    CajaFile *file;
     GFile *old_location;
     GFile *new_location;
+    CajaFile *file = NULL;
 
     hash = g_hash_table_new (NULL, NULL);
 
@@ -1199,7 +1203,8 @@ caja_directory_notify_files_moved (GList *file_pairs)
     GHashTable *added_lists, *changed_lists;
     char *name;
     CajaFileAttributes cancel_attributes;
-    GFile *to_location, *from_location;
+    GFile *to_location = NULL;
+    GFile *from_location = NULL;
 
     /* Make a list of added and changed files in each directory. */
     new_files_list = NULL;
@@ -1318,10 +1323,10 @@ void
 caja_directory_schedule_position_set (GList *position_setting_list)
 {
     GList *p;
-    const CajaFileChangesQueuePosition *item;
-    CajaFile *file;
     char str[64];
     time_t now;
+    const CajaFileChangesQueuePosition *item = NULL;
+    CajaFile *file = NULL;
 
     time (&now);
 

--- a/libcaja-private/caja-dnd.c
+++ b/libcaja-private/caja-dnd.c
@@ -125,9 +125,9 @@ caja_drag_destroy_selection_list (GList *list)
 GList *
 caja_drag_uri_list_from_selection_list (const GList *selection_list)
 {
-    CajaDragSelectionItem *selection_item;
     GList *uri_list;
     const GList *l;
+    CajaDragSelectionItem *selection_item = NULL;
 
     uri_list = NULL;
     for (l = selection_list; l != NULL; l = l->next)
@@ -369,13 +369,14 @@ static gboolean
 check_same_fs (CajaFile *file1,
                CajaFile *file2)
 {
-    char *id1, *id2;
     gboolean result;
 
     result = FALSE;
 
     if (file1 != NULL && file2 != NULL)
     {
+        char *id1, *id2;
+
         id1 = caja_file_get_filesystem_id (file1);
         id2 = caja_file_get_filesystem_id (file2);
 
@@ -637,7 +638,6 @@ static void
 add_one_compatible_uri (const char *uri, int x, int y, int w, int h, gpointer data)
 {
     GString *result;
-    char *local_path;
 
     result = (GString *) data;
 
@@ -654,6 +654,8 @@ add_one_compatible_uri (const char *uri, int x, int y, int w, int h, gpointer da
     }
     else
     {
+        char *local_path;
+
         local_path = g_filename_from_uri (uri, NULL, NULL);
 
         /* Check for characters that confuse the old
@@ -1039,10 +1041,11 @@ gboolean
 caja_drag_selection_includes_special_link (GList *selection_list)
 {
     GList *node;
-    char *uri;
 
     for (node = selection_list; node != NULL; node = node->next)
     {
+        char *uri;
+
         uri = ((CajaDragSelectionItem *) node->data)->uri;
 
         if (eel_uri_is_desktop (uri))
@@ -1226,7 +1229,6 @@ slot_proxy_handle_drop (GtkWidget                *widget,
     CajaWindowSlotInfo *target_slot;
     CajaView *target_view;
     char *target_uri;
-    GList *uri_list;
 
     if (!drag_info->have_data ||
             !drag_info->have_valid_data)
@@ -1268,6 +1270,8 @@ slot_proxy_handle_drop (GtkWidget                *widget,
     {
         if (drag_info->info == CAJA_ICON_DND_MATE_ICON_LIST)
         {
+            GList *uri_list;
+
             uri_list = caja_drag_uri_list_from_selection_list (drag_info->data.selection_list);
             g_assert (uri_list != NULL);
 

--- a/libcaja-private/caja-entry.c
+++ b/libcaja-private/caja-entry.c
@@ -96,7 +96,6 @@ caja_entry_key_press (GtkWidget *widget, GdkEventKey *event)
 {
     CajaEntry *entry;
     GtkEditable *editable;
-    int position;
     gboolean old_has, new_has;
     gboolean result;
 
@@ -119,6 +118,8 @@ caja_entry_key_press (GtkWidget *widget, GdkEventKey *event)
          */
         if (entry->details->special_tab_handling && gtk_editable_get_selection_bounds (editable, NULL, NULL))
         {
+            int position;
+
             position = strlen (gtk_entry_get_text (GTK_ENTRY (editable)));
             gtk_editable_select_region (editable, position, position);
             return TRUE;

--- a/libcaja-private/caja-file-changes-queue.c
+++ b/libcaja-private/caja-file-changes-queue.c
@@ -220,7 +220,7 @@ static void
 pairs_list_free (GList *pairs)
 {
     GList *p;
-    GFilePair *pair;
+    GFilePair *pair = NULL;
 
     /* deep delete the list of pairs */
 
@@ -240,7 +240,7 @@ static void
 position_set_list_free (GList *list)
 {
     GList *p;
-    CajaFileChangesQueuePosition *item;
+    CajaFileChangesQueuePosition *item = NULL;
 
     for (p = list; p != NULL; p = p->next)
     {

--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -526,11 +526,12 @@ diff_button_clicked_cb (GtkButton *w,
     
     GError *error;
     char *command;
-    char **argv;
 
     command = g_find_program_in_path ("meld");
     if (command)
     {
+        char **argv;
+
         argv = g_new (char *, 4);
         argv[0] = command;
         argv[1] = g_file_get_path (caja_file_get_location (details->source));

--- a/libcaja-private/caja-file-dnd.c
+++ b/libcaja-private/caja-file-dnd.c
@@ -35,10 +35,9 @@
 static gboolean
 caja_drag_can_accept_files (CajaFile *drop_target_item)
 {
-    CajaDirectory *directory;
-
     if (caja_file_is_directory (drop_target_item))
     {
+        CajaDirectory *directory;
         gboolean res;
 
         /* target is a directory, accept if editable */
@@ -154,7 +153,7 @@ void
 caja_drag_file_receive_dropped_keyword (CajaFile *file,
                                         const char *keyword)
 {
-    GList *keywords, *word;
+    GList *keywords;
 
     g_return_if_fail (CAJA_IS_FILE (file));
     g_return_if_fail (keyword != NULL);
@@ -166,6 +165,8 @@ caja_drag_file_receive_dropped_keyword (CajaFile *file,
     }
     else
     {
+        GList *word;
+
         keywords = caja_file_get_keywords (file);
         word = g_list_find_custom (keywords, keyword, (GCompareFunc) strcmp);
         if (word == NULL)

--- a/libcaja-private/caja-file-utilities.c
+++ b/libcaja-private/caja-file-utilities.c
@@ -55,7 +55,6 @@ static void desktop_dir_changed (void);
 char *
 caja_compute_title_for_location (GFile *location)
 {
-    CajaFile *file;
     char *title;
 
     /* TODO-gio: This doesn't really work all that great if the
@@ -64,6 +63,8 @@ caja_compute_title_for_location (GFile *location)
     title = NULL;
     if (location)
     {
+        CajaFile *file;
+
         file = caja_file_get (location);
         title = caja_file_get_description (file);
         if (title == NULL)
@@ -195,10 +196,8 @@ parse_xdg_dirs (const char *config_file)
     XdgDirEntry dir;
     char *data;
     char **lines;
-    char *p, *d;
-    int i;
-    char *type_start, *type_end;
-    char *value, *unescaped;
+    char *p;
+    char *unescaped;
     gboolean relative;
 
     array = g_array_new (TRUE, TRUE, sizeof (XdgDirEntry));
@@ -212,10 +211,16 @@ parse_xdg_dirs (const char *config_file)
 
     if (g_file_get_contents (config_file, &data, NULL, NULL))
     {
+        int i;
+
         lines = g_strsplit (data, "\n", 0);
         g_free (data);
         for (i = 0; lines[i] != NULL; i++)
         {
+            char *d;
+            char *type_start, *type_end;
+            char *value;
+
             p = lines[i];
             while (g_ascii_isspace (*p))
                 p++;
@@ -383,10 +388,10 @@ unschedule_user_dirs_changed (void)
 static void
 free_xdg_dir_cache (void)
 {
-    int i;
-
     if (cached_xdg_dirs != NULL)
     {
+        int i;
+
         for (i = 0; cached_xdg_dirs[i].type != NULL; i++)
         {
             if (cached_xdg_dirs[i].file != NULL)
@@ -422,8 +427,7 @@ destroy_xdg_dir_cache (void)
 static void
 update_xdg_dir_cache (void)
 {
-    GFile *file;
-    char *config_file, *uri;
+    char *uri;
     int i;
 
     free_xdg_dir_cache ();
@@ -451,6 +455,9 @@ update_xdg_dir_cache (void)
 
     if (cached_xdg_dirs_monitor == NULL)
     {
+        GFile *file;
+        char *config_file;
+
         config_file = g_build_filename (g_get_user_config_dir (),
                                         "user-dirs.dirs", NULL);
         file = g_file_new_for_path (config_file);
@@ -672,12 +679,13 @@ gboolean
 caja_is_home_directory_file (GFile *dir,
                              const char *filename)
 {
-    char *dirname;
     static GFile *home_dir_dir = NULL;
     static char *home_dir_filename = NULL;
 
     if (home_dir_dir == NULL)
     {
+        char *dirname;
+
         dirname = g_path_get_dirname (g_get_home_dir ());
         home_dir_dir = g_file_new_for_path (dirname);
         g_free (dirname);
@@ -763,7 +771,7 @@ caja_get_mounted_mount_for_root (GFile *location)
 	GVolumeMonitor *volume_monitor;
 	GList *mounts;
 	GList *l;
-	GMount *mount;
+	GMount *mount = NULL;
 	GMount *result = NULL;
 	GFile *root = NULL;
 	GFile *default_location = NULL;
@@ -917,8 +925,8 @@ caja_ensure_unique_file_name (const char *directory_uri,
 GFile *
 caja_find_existing_uri_in_hierarchy (GFile *location)
 {
-    GFileInfo *info;
-    GFile *tmp;
+    GFileInfo *info = NULL;
+    GFile *tmp = NULL;
 
     g_assert (location != NULL);
 
@@ -1131,8 +1139,10 @@ caja_trashed_files_get_original_directories (GList *files,
         GList **unhandled_files)
 {
     GHashTable *directories;
-    CajaFile *file, *original_file, *original_dir;
     GList *l, *m;
+    CajaFile *file = NULL;
+    CajaFile *original_file = NULL;
+    CajaFile *original_dir = NULL;
 
     directories = NULL;
 
@@ -1192,8 +1202,8 @@ caja_trashed_files_get_original_directories (GList *files,
 static GList *
 locations_from_file_list (GList *file_list)
 {
-    CajaFile *file;
     GList *l, *ret;
+    CajaFile *file = NULL;
 
     ret = NULL;
 
@@ -1210,17 +1220,17 @@ void
 caja_restore_files_from_trash (GList *files,
                                GtkWindow *parent_window)
 {
-    CajaFile *file, *original_dir;
     GHashTable *original_dirs_hash;
     GList *original_dirs, *unhandled_files;
-    GFile *original_dir_location;
-    GList *locations, *l;
-    char *message, *file_name;
+    GList *l;
+    CajaFile *file = NULL;
 
     original_dirs_hash = caja_trashed_files_get_original_directories (files, &unhandled_files);
 
     for (l = unhandled_files; l != NULL; l = l->next)
     {
+        char *message, *file_name;
+
         file = CAJA_FILE (l->data);
         file_name = caja_file_get_display_name (file);
         message = g_strdup_printf (_("Could not determine original location of \"%s\" "), file_name);
@@ -1234,6 +1244,10 @@ caja_restore_files_from_trash (GList *files,
 
     if (original_dirs_hash != NULL)
     {
+        CajaFile *original_dir = NULL;
+        GFile *original_dir_location = NULL;
+        GList *locations = NULL;
+
         original_dirs = g_hash_table_get_keys (original_dirs_hash);
         for (l = original_dirs; l != NULL; l = l->next)
         {

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -767,13 +767,14 @@ finalize (GObject *object)
 {
 	CajaDirectory *directory;
 	CajaFile *file;
-	char *uri;
 
 	file = CAJA_FILE (object);
 
 	g_assert (file->details->operations_in_progress == NULL);
 
 	if (file->details->is_thumbnailing) {
+		char *uri;
+
 		uri = caja_file_get_uri (file);
 		caja_thumbnail_remove_from_queue (uri);
 		g_free (uri);
@@ -1703,12 +1704,6 @@ rename_get_info_callback (GObject *source_object,
 			  gpointer callback_data)
 {
 	CajaFileOperation *op;
-	CajaDirectory *directory;
-	CajaFile *existing_file;
-	char *old_name;
-	char *old_uri;
-	char *new_uri;
-	const char *new_name;
 	GFileInfo *new_info;
 	GError *error;
 
@@ -1717,6 +1712,13 @@ rename_get_info_callback (GObject *source_object,
 	error = NULL;
 	new_info = g_file_query_info_finish (G_FILE (source_object), res, &error);
 	if (new_info != NULL) {
+		CajaDirectory *directory;
+		CajaFile *existing_file;
+		char *old_name;
+		char *old_uri;
+		char *new_uri;
+		const char *new_name;
+
 		directory = op->file->details->directory;
 
 		new_name = g_file_info_get_name (new_info);
@@ -1806,7 +1808,6 @@ caja_file_rename (CajaFile *file,
 		      gpointer callback_data)
 {
 	CajaFileOperation *op;
-	char *uri;
 	char *old_name;
 	char *new_file_name;
 	gboolean success, name_changed;
@@ -1905,6 +1906,8 @@ caja_file_rename (CajaFile *file,
 	}
 
 	if (is_renameable_desktop_file) {
+		char *uri;
+
 		/* Don't actually change the name if the new name is the same.
 		 * This helps for the vfolder method where this can happen and
 		 * we want to minimize actual changes
@@ -1974,7 +1977,7 @@ gboolean
 caja_file_rename_in_progress (CajaFile *file)
 {
 	GList *node;
-	CajaFileOperation *op;
+	CajaFileOperation *op = NULL;
 
 	for (node = file->details->operations_in_progress; node != NULL; node = node->next) {
 		op = node->data;
@@ -1991,7 +1994,7 @@ caja_file_cancel (CajaFile *file,
 		      gpointer callback_data)
 {
 	GList *node, *next;
-	CajaFileOperation *op;
+	CajaFileOperation *op = NULL;
 
 	for (node = file->details->operations_in_progress; node != NULL; node = next) {
 		next = node->next;
@@ -2062,12 +2065,13 @@ update_link (CajaFile *link_file, CajaFile *target_file)
 static GList *
 get_link_files (CajaFile *target_file)
 {
-	char *uri;
 	GList **link_files;
 
 	if (symbolic_links == NULL) {
 		link_files = NULL;
 	} else {
+		char *uri;
+
 		uri = caja_file_get_uri (target_file);
 		link_files = g_hash_table_lookup (symbolic_links, uri);
 		g_free (uri);
@@ -2095,7 +2099,6 @@ update_info_internal (CajaFile *file,
 		      GFileInfo *info,
 		      gboolean update_name)
 {
-	GList *node;
 	gboolean changed;
 	gboolean is_symlink, is_hidden, is_backup, is_mountpoint;
 	gboolean has_permissions;
@@ -2112,11 +2115,9 @@ update_info_internal (CajaFile *file,
 	time_t trash_time;
 	GTimeVal g_trash_time;
 	const char * time_string;
-	const char *symlink_name, *mime_type, *selinux_context, *name, *thumbnail_path;
+	const char *symlink_name, *mime_type, *selinux_context, *thumbnail_path;
 	GFileType file_type;
 	GIcon *icon;
-	char *old_activation_uri;
-	const char *activation_uri;
 	const char *description;
 	const char *filesystem_id;
 	const char *trash_orig_path;
@@ -2159,6 +2160,8 @@ update_info_internal (CajaFile *file,
 	file->details->type = file_type;
 
 	if (!file->details->got_custom_activation_uri) {
+		const char *activation_uri;
+
 		activation_uri = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_STANDARD_TARGET_URI);
 		if (activation_uri == NULL) {
 			if (file->details->activation_uri) {
@@ -2167,6 +2170,8 @@ update_info_internal (CajaFile *file,
 				changed = TRUE;
 			}
 		} else {
+			char *old_activation_uri;
+
 			old_activation_uri = file->details->activation_uri;
 			file->details->activation_uri = g_strdup (activation_uri);
 
@@ -2503,9 +2508,13 @@ update_info_internal (CajaFile *file,
 		caja_file_update_metadata_from_info (file, info);
 
 	if (update_name) {
+		const char *name;
+
 		name = g_file_info_get_name (info);
 		if (file->details->name == NULL ||
 		    strcmp (file->details->name, name) != 0) {
+			GList *node;
+
 			changed = TRUE;
 
 			node = caja_directory_begin_file_name_change
@@ -3052,7 +3061,6 @@ static int
 compare_by_emblems (CajaFile *file_1, CajaFile *file_2)
 {
 	const char *keyword_cache_1, *keyword_cache_2;
-	size_t length;
 	int compare_result;
 
 	fill_emblem_cache_if_needed (file_1);
@@ -3063,6 +3071,8 @@ compare_by_emblems (CajaFile *file_1, CajaFile *file_2)
 	keyword_cache_1 = file_1->details->compare_by_emblem_cache->emblem_keywords;
 	keyword_cache_2 = file_2->details->compare_by_emblem_cache->emblem_keywords;
 	for (; *keyword_cache_1 != '\0' && *keyword_cache_2 != '\0';) {
+		size_t length;
+
 		compare_result = g_utf8_collate (keyword_cache_1, keyword_cache_2);
 		if (compare_result != 0) {
 			return compare_result;
@@ -3228,7 +3238,6 @@ is_valid_extension_segment (const char *segment, int segment_index)
 {
 	gboolean result;
 	gboolean has_letters;
-	char c;
 	int char_offset;
 	switch (segment_index) {
 		case 0:
@@ -3239,6 +3248,8 @@ is_valid_extension_segment (const char *segment, int segment_index)
 			has_letters = FALSE;
 			char_offset = 0;
 			while (TRUE) {
+				char c;
+
 				c = *(segment + char_offset);
 				if (c == '\0') {
 					result = has_letters;
@@ -3333,18 +3344,21 @@ compare_by_extension_segments (CajaFile *file_1, CajaFile *file_2)
 static gchar *
 caja_file_get_extension_as_string (CajaFile *file)
 {
-	char *name;
 	int rem_chars;
-	int segment_index;
 	char *segment;
-	char *right_segment;
-	char *result;
+
 	if (!caja_file_is_directory (file)) {
+		char *name;
+
 		name = caja_file_get_display_name (file);
 		rem_chars = strlen (name);
 		segment = prev_extension_segment (name + rem_chars, &rem_chars);
 
 		if (rem_chars > 0 && is_valid_extension_segment (segment, 0)) {
+			int segment_index;
+			char *right_segment;
+			char *result;
+
 			segment_index = 1;
 			do {
 				right_segment = segment;
@@ -3770,10 +3784,8 @@ GList *
 caja_file_get_metadata_list (CajaFile *file,
 				 const char *key)
 {
-	GList *res;
 	guint id;
 	char **value;
-	int i;
 
 	g_return_val_if_fail (key != NULL, NULL);
 	g_return_val_if_fail (key[0] != '\0', NULL);
@@ -3791,6 +3803,9 @@ caja_file_get_metadata_list (CajaFile *file,
 	value = g_hash_table_lookup (file->details->metadata, GUINT_TO_POINTER (id));
 
 	if (value) {
+		GList *res;
+		int i;
+
 		res = NULL;
 		for (i = 0; value[i] != NULL; i++) {
 			res = g_list_prepend (res, g_strdup (value[i]));
@@ -4029,9 +4044,6 @@ caja_file_peek_display_name_collation_key (CajaFile *file)
 static const char *
 caja_file_peek_display_name (CajaFile *file)
 {
-	const char *name;
-	char *escaped_name;
-
 	/*
 	stefano-k: Imported 15_nautilus_file_peek_crash.patch from debian nautilus
 	Date: Thu, 27 Jan 2011 10:22:10 +0000
@@ -4048,6 +4060,8 @@ caja_file_peek_display_name (CajaFile *file)
 	/* Default to display name based on filename if its not set yet */
 
 	if (file->details->display_name == NULL) {
+		const char *name;
+
 		name = file->details->name;
 		if (g_utf8_validate (name, -1, NULL)) {
 			caja_file_set_display_name (file,
@@ -4055,6 +4069,8 @@ caja_file_peek_display_name (CajaFile *file)
 							NULL,
 							FALSE);
 		} else {
+			char *escaped_name;
+
 			escaped_name = g_uri_escape_string (name, G_URI_RESERVED_CHARS_ALLOWED_IN_PATH, TRUE);
 			caja_file_set_display_name (file,
 							escaped_name,
@@ -4191,11 +4207,12 @@ caja_file_get_drop_target_uri (CajaFile *file)
 {
 	char *uri, *target_uri;
 	GFile *location;
-	CajaDesktopLink *link;
 
 	g_return_val_if_fail (CAJA_IS_FILE (file), NULL);
 
 	if (CAJA_IS_DESKTOP_ICON_FILE (file)) {
+		CajaDesktopLink *link;
+
 		link = caja_desktop_icon_file_get_link (CAJA_DESKTOP_ICON_FILE (file));
 
 		if (link != NULL) {
@@ -4245,12 +4262,13 @@ get_custom_icon_metadata_uri (CajaFile *file)
 {
 	char *custom_icon_uri;
 	char *uri;
-	char *dir_uri;
 
 	uri = caja_file_get_metadata (file, CAJA_METADATA_KEY_CUSTOM_ICON, NULL);
 	if (uri != NULL &&
 	    caja_file_is_directory (file) &&
 	    is_uri_relative (uri)) {
+		char *dir_uri;
+
 		dir_uri = caja_file_get_uri (file);
 		custom_icon_uri = g_build_filename (dir_uri, uri, NULL);
 		g_free (dir_uri);
@@ -4377,12 +4395,7 @@ caja_file_get_gicon (CajaFile *file,
 			 CajaFileIconFlags flags)
 {
 	const char * const * names;
-	const char *name;
-	GPtrArray *prepend_array;
-	GMount *mount;
 	GIcon *icon, *mount_icon = NULL, *emblemed_icon;
-	GEmblem *emblem;
-	int i;
 	gboolean is_folder = FALSE, is_preview = FALSE, is_inode_directory = FALSE;
 
 	if (file == NULL) {
@@ -4400,6 +4413,8 @@ caja_file_get_gicon (CajaFile *file,
 		/* fetch the mount icon here, we'll use it later */
 		if (flags & CAJA_FILE_ICON_FLAGS_USE_MOUNT_ICON ||
 		    flags & CAJA_FILE_ICON_FLAGS_USE_MOUNT_ICON_AS_EMBLEM) {
+			GMount *mount;
+
 			mount = caja_file_get_mount (file);
 
 			if (mount != NULL) {
@@ -4416,10 +4431,15 @@ caja_file_get_gicon (CajaFile *file,
 		     ((flags & CAJA_FILE_ICON_FLAGS_IGNORE_VISITING) == 0 &&
 		      caja_file_has_open_window (file))) &&
 		    G_IS_THEMED_ICON (file->details->icon)) {
+			GPtrArray *prepend_array;
+			int i;
+
 			names = g_themed_icon_get_names (G_THEMED_ICON (file->details->icon));
 			prepend_array = g_ptr_array_new ();
 
 			for (i = 0; names[i] != NULL; i++) {
+				const char *name;
+
 				name = names[i];
 
 				if (strcmp (name, "folder") == 0) {
@@ -4477,6 +4497,7 @@ caja_file_get_gicon (CajaFile *file,
 			icon = mount_icon;
 		} else if ((flags & CAJA_FILE_ICON_FLAGS_USE_MOUNT_ICON_AS_EMBLEM) &&
 			     mount_icon != NULL && !g_icon_equal (mount_icon, icon)) {
+			GEmblem *emblem;
 
 			emblem = g_emblem_new (mount_icon);
 			emblemed_icon = g_emblemed_icon_new (icon, emblem);
@@ -4521,8 +4542,7 @@ caja_file_get_icon (CajaFile *file,
 {
 	CajaIconInfo *icon;
 	GIcon *gicon;
-	GdkPixbuf *raw_pixbuf, *scaled_pixbuf;
-	int modified_size;
+	GdkPixbuf *scaled_pixbuf;
 
 	if (file == NULL) {
 		return NULL;
@@ -4551,6 +4571,7 @@ caja_file_get_icon (CajaFile *file,
 
 	if (flags & CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS &&
 	    caja_file_should_show_thumbnail (file)) {
+		int modified_size;
 
 		if (flags & CAJA_FILE_ICON_FLAGS_FORCE_THUMBNAIL_SIZE) {
 			modified_size = size * scale;
@@ -4561,6 +4582,7 @@ caja_file_get_icon (CajaFile *file,
 		if (file->details->thumbnail) {
 			int w, h, s;
 			double thumb_scale;
+			GdkPixbuf *raw_pixbuf;
 
 			raw_pixbuf = g_object_ref (file->details->thumbnail);
 
@@ -4808,7 +4830,6 @@ caja_file_fit_date_as_string (CajaFile *file,
 	time_t file_time_raw;
 	struct tm *file_time;
 	const char **formats;
-	const char *width_template;
 	const char *format;
 	char *date_string;
 	char *result;
@@ -4865,6 +4886,8 @@ caja_file_fit_date_as_string (CajaFile *file,
 	format = NULL;
 
 	for (i = 0; ; i += 2) {
+		const char *width_template;
+
 		width_template = (formats [i] ? _(formats [i]) : NULL);
 		if (width_template == NULL) {
 			/* no more formats left */
@@ -4930,11 +4953,11 @@ caja_file_fit_modified_date_as_string (CajaFile *file,
 static char *
 caja_file_get_trash_original_file_parent_as_string (CajaFile *file)
 {
-	CajaFile *orig_file, *parent;
-	GFile *location;
-	char *filename;
-
 	if (file->details->trash_orig_path != NULL) {
+		CajaFile *orig_file, *parent;
+		GFile *location;
+		char *filename;
+
 		orig_file = caja_file_get_trash_original_file (file);
 		parent = caja_file_get_parent (orig_file);
 		location = caja_file_get_location (parent);
@@ -5420,9 +5443,10 @@ caja_file_set_permissions (CajaFile *file,
 			       gpointer callback_data)
 {
 	GFileInfo *info;
-	GError *error;
 
 	if (!caja_file_can_set_permissions (file)) {
+		GError *error;
+
 		/* Claim that something changed even if the permission change failed.
 		 * This makes it easier for some clients who see the "reverting"
 		 * to the old permissions as "changing back".
@@ -5785,7 +5809,7 @@ GList *
 caja_get_user_names (void)
 {
 	GList *list;
-	char *real_name, *name;
+	char *name;
 	struct passwd *user;
 
 	list = NULL;
@@ -5793,6 +5817,8 @@ caja_get_user_names (void)
 	setpwent ();
 
 	while ((user = getpwent ()) != NULL) {
+		char *real_name;
+
 		real_name = get_real_name (user->pw_name, user->pw_gecos);
 		if (real_name != NULL) {
 			name = g_strconcat (user->pw_name, "\n", real_name, NULL);
@@ -5892,9 +5918,9 @@ static GList *
 caja_get_group_names_for_user (void)
 {
 	GList *list;
-	struct group *group;
 	int count, i;
 	gid_t gid_list[NGROUPS_MAX + 1];
+	struct group *group = NULL;
 
 
 	list = NULL;
@@ -6741,9 +6767,9 @@ get_description (CajaFile *file)
 static char *
 update_description_for_link (CajaFile *file, char *string)
 {
-	char *res;
-
 	if (caja_file_is_symbolic_link (file)) {
+		char *res;
+
 		g_assert (!caja_file_is_broken_symbolic_link (file));
 		if (string == NULL) {
 			return g_strdup (_("link"));
@@ -6938,9 +6964,9 @@ caja_file_get_emblem_pixbufs (CajaFile *file,
 {
 	GList *icons, *l;
 	GList *pixbufs;
-	GIcon *icon;
 	GdkPixbuf *pixbuf;
-	CajaIconInfo *icon_info;
+	GIcon *icon = NULL;
+	CajaIconInfo *icon_info = NULL;
 
 	icons = caja_file_get_emblem_icons (file, exclude);
 	pixbufs = NULL;
@@ -6974,9 +7000,10 @@ static GList *
 sort_keyword_list_and_remove_duplicates (GList *keywords)
 {
 	GList *p;
-	GList *duplicate_link;
 
 	if (keywords != NULL) {
+		GList *duplicate_link = NULL;
+
 		keywords = eel_g_str_list_alphabetize (keywords);
 
 		p = keywords;
@@ -7136,7 +7163,6 @@ get_fs_free_cb (GObject *source_object,
 		gpointer user_data)
 {
 	CajaDirectory *directory;
-	CajaFile *file;
 	guint64 free_space;
 	GFileInfo *info;
 
@@ -7153,6 +7179,8 @@ get_fs_free_cb (GObject *source_object,
 	}
 
 	if (directory->details->free_space != free_space) {
+		CajaFile *file;
+
 		directory->details->free_space = free_space;
 		file = caja_directory_get_existing_corresponding_file (directory);
 		if (file) {
@@ -7174,7 +7202,6 @@ char *
 caja_file_get_volume_free_space (CajaFile *file)
 {
 	CajaDirectory *directory;
-	GFile *location;
 	char *res;
 	time_t now;
 
@@ -7184,6 +7211,8 @@ caja_file_get_volume_free_space (CajaFile *file)
 	/* Update first time and then every 2 seconds */
 	if (directory->details->free_space_read == 0 ||
 	    (now - directory->details->free_space_read) > 2)  {
+		GFile *location;
+
 		directory->details->free_space_read = now;
 		location = caja_file_get_location (file);
 		g_file_query_filesystem_info_async (location,
@@ -7269,9 +7298,6 @@ caja_file_get_symbolic_link_target_path (CajaFile *file)
 char *
 caja_file_get_symbolic_link_target_uri (CajaFile *file)
 {
-	GFile *location, *parent, *target;
-	char *target_uri;
-
 	if (!caja_file_is_symbolic_link (file)) {
 		g_warning ("File has symlink target, but  is not marked as symlink");
 	}
@@ -7279,6 +7305,9 @@ caja_file_get_symbolic_link_target_uri (CajaFile *file)
 	if (file->details->symlink_name == NULL) {
 		return NULL;
 	} else {
+		GFile *location, *parent, *target;
+		char *target_uri;
+
 		target = NULL;
 
 		location = caja_file_get_location (file);
@@ -7473,7 +7502,6 @@ caja_file_is_binary (CajaFile *file)
 	}
 	
 	gboolean is_binary = FALSE;
-	int c;
 	int i = 0;
 	FILE *fp;
 	
@@ -7489,6 +7517,8 @@ caja_file_is_binary (CajaFile *file)
 	}
 	
 	while (!feof (fp)) {
+		int c;
+
 		if (i > 4096) {
 			break;
 		}
@@ -7596,12 +7626,13 @@ caja_file_get_filesystem_id (CajaFile *file)
 CajaFile *
 caja_file_get_trash_original_file (CajaFile *file)
 {
-	GFile *location;
 	CajaFile *original_file;
 
 	original_file = NULL;
 
 	if (file->details->trash_orig_path != NULL) {
+		GFile *location;
+
 		location = g_file_new_for_path (file->details->trash_orig_path);
 		original_file = caja_file_get (location);
 		g_object_unref (location);
@@ -8302,7 +8333,7 @@ caja_file_list_call_when_ready (GList *file_list,
 {
 	GList *l;
 	FileListReadyData *data;
-	CajaFile *file;
+	CajaFile *file = NULL;
 
 	g_return_if_fail (file_list != NULL);
 
@@ -8332,7 +8363,6 @@ void
 caja_file_list_cancel_call_when_ready (CajaFileListHandle *handle)
 {
 	GList *l;
-	CajaFile *file;
 	FileListReadyData *data;
 
 	g_return_if_fail (handle != NULL);
@@ -8341,6 +8371,8 @@ caja_file_list_cancel_call_when_ready (CajaFileListHandle *handle)
 
 	l = g_list_find (ready_data_list, data);
 	if (l != NULL) {
+		CajaFile *file = NULL;
+
 		for (l = data->remaining_files; l != NULL; l = l->next) {
 			file = CAJA_FILE (l->data);
 

--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -503,11 +503,12 @@ get_scaled_icon_size (CajaIconCanvasItem *item,
 		      gint *width,
 		      gint *height)
 {
-    EelCanvas *canvas;
     GdkPixbuf *pixbuf = NULL;
     gint scale = 1;
 
     if (item != NULL) {
+        EelCanvas *canvas;
+
         canvas = EEL_CANVAS_ITEM (item)->canvas;
         scale = gtk_widget_get_scale_factor (GTK_WIDGET (canvas));
         pixbuf = item->details->pixbuf;
@@ -980,9 +981,7 @@ layout_get_size_for_layout (PangoLayout *layout,
                             int          height_for_entire_text,
                             int         *height_for_layout)
 {
-    PangoLayoutIter *iter;
     PangoRectangle logical_rect;
-    int i;
 
     /* only use the first max_layout_line_count lines for the gridded auto layout */
     if (pango_layout_get_line_count (layout) <= max_layout_line_count)
@@ -991,6 +990,9 @@ layout_get_size_for_layout (PangoLayout *layout,
     }
     else
     {
+        PangoLayoutIter *iter;
+        int i;
+
         *height_for_layout = 0;
         iter = pango_layout_get_iter (layout);
         /* VOODOO-TODO, determine number of lines based on the icon size for text besides icon.
@@ -1457,13 +1459,14 @@ static GdkPixbuf *
 get_knob_pixbuf (void)
 {
     GdkPixbuf *knob_pixbuf;
-    char *knob_filename;
 
     knob_pixbuf = gtk_icon_theme_load_icon (gtk_icon_theme_get_default (),
                                             "stock-caja-knob",
                                             8, 0, NULL);
     if (!knob_pixbuf)
     {
+        char *knob_filename;
+
         knob_filename = caja_pixmap_file ("knob.png");
         knob_pixbuf = gdk_pixbuf_new_from_file (knob_filename, NULL);
         g_free (knob_filename);
@@ -1695,10 +1698,7 @@ static cairo_surface_t *
 real_map_surface (CajaIconCanvasItem *icon_item)
 {
     EelCanvas *canvas;
-    char *audio_filename;
-    GdkPixbuf *temp_pixbuf, *old_pixbuf, *audio_pixbuf;
-    int emblem_size;
-    GtkStyleContext *style;
+    GdkPixbuf *temp_pixbuf, *old_pixbuf;
     GdkRGBA color;
     GdkRGBA *c;
     cairo_surface_t *surface;
@@ -1726,6 +1726,10 @@ real_map_surface (CajaIconCanvasItem *icon_item)
         /* audio is the only kind of previewing right now, so this code isn't as general as it could be */
         if (icon_item->details->is_active)
         {
+            char *audio_filename;
+            GdkPixbuf *audio_pixbuf;
+            int emblem_size;
+
             emblem_size = caja_icon_get_emblem_size_for_icon_size (gdk_pixbuf_get_width (temp_pixbuf));
             /* Load the audio symbol. */
             audio_filename = caja_pixmap_file ("audio.svg");
@@ -1764,6 +1768,8 @@ real_map_surface (CajaIconCanvasItem *icon_item)
     if (icon_item->details->is_highlighted_for_selection
             || icon_item->details->is_highlighted_for_drop)
     {
+        GtkStyleContext *style;
+
         style = gtk_widget_get_style_context (GTK_WIDGET (canvas));
 
         if (gtk_widget_has_focus (GTK_WIDGET (canvas))) {
@@ -1828,8 +1834,6 @@ draw_embedded_text (CajaIconCanvasItem *item,
                     int x, int y)
 {
     PangoLayout *layout;
-    PangoContext *context;
-    PangoFontDescription *desc;
     GtkWidget *widget;
     GtkStyleContext *style_context;
 
@@ -1848,6 +1852,9 @@ draw_embedded_text (CajaIconCanvasItem *item,
     }
     else
     {
+        PangoContext *context;
+        PangoFontDescription *desc;
+
         context = gtk_widget_get_pango_context (widget);
         layout = pango_layout_new (context);
         pango_layout_set_text (layout, item->details->embedded_text, -1);
@@ -1961,9 +1968,7 @@ create_label_layout (CajaIconCanvasItem *item,
     PangoFontDescription *desc;
     CajaIconContainer *container;
     EelCanvasItem *canvas_item;
-    GString *str;
     char *zeroified_text;
-    const char *p;
 
     canvas_item = EEL_CANVAS_ITEM (item);
 
@@ -1975,6 +1980,9 @@ create_label_layout (CajaIconCanvasItem *item,
 
     if (text != NULL)
     {
+        GString *str;
+        const char *p;
+
         str = g_string_new (NULL);
 
         for (p = text; *p != '\0'; p++)
@@ -2063,7 +2071,6 @@ static int
 caja_icon_canvas_item_event (EelCanvasItem *item, GdkEvent *event)
 {
     CajaIconCanvasItem *icon_item;
-    GdkCursor *cursor;
     GdkWindow *cursor_window;
 
     icon_item = CAJA_ICON_CANVAS_ITEM (item);
@@ -2083,6 +2090,8 @@ caja_icon_canvas_item_event (EelCanvasItem *item, GdkEvent *event)
             /* show a hand cursor */
             if (in_single_click_mode ())
             {
+                GdkCursor *cursor;
+
                 cursor = gdk_cursor_new_for_display (gdk_display_get_default(),
                                                      GDK_HAND2);
                 gdk_window_set_cursor (cursor_window, cursor);
@@ -2392,7 +2401,6 @@ caja_icon_canvas_item_ensure_bounds_up_to_date (CajaIconCanvasItem *icon_item)
     EelIRect text_rect, text_rect_for_layout, text_rect_for_entire_text;
     EelIRect total_rect, total_rect_for_layout, total_rect_for_entire_text;
     EelCanvasItem *item;
-    double pixels_per_unit;
     gint width, height;
     EmblemLayout emblem_layout;
     GdkPixbuf *emblem_pixbuf;
@@ -2403,6 +2411,8 @@ caja_icon_canvas_item_ensure_bounds_up_to_date (CajaIconCanvasItem *icon_item)
 
     if (!details->bounds_cached)
     {
+        double pixels_per_unit;
+
         measure_label_text (icon_item);
 
         pixels_per_unit = EEL_CANVAS_ITEM (item)->canvas->pixels_per_unit;
@@ -3064,8 +3074,8 @@ caja_icon_canvas_item_accessible_get_index_in_parent (AtkObject *accessible)
     CajaIconCanvasItem *item;
     CajaIconContainer *container;
     GList *l;
-    CajaIcon *icon;
     int i;
+    CajaIcon *icon = NULL;
 
     item = CAJA_ICON_CANVAS_ITEM (atk_gobject_accessible_get_object (ATK_GOBJECT_ACCESSIBLE (accessible)));
     if (!item)
@@ -3098,8 +3108,6 @@ static const gchar* caja_icon_canvas_item_accessible_get_image_description(AtkIm
 {
     CajaIconCanvasItemAccessiblePrivate* priv;
     CajaIconCanvasItem* item;
-    CajaIcon* icon;
-    CajaIconContainer* container;
     char* description;
 
     priv = GET_PRIV (image);
@@ -3110,6 +3118,9 @@ static const gchar* caja_icon_canvas_item_accessible_get_image_description(AtkIm
     }
     else
     {
+        CajaIcon* icon;
+        CajaIconContainer* container;
+
         item = CAJA_ICON_CANVAS_ITEM (atk_gobject_accessible_get_object (ATK_GOBJECT_ACCESSIBLE (image)));
 
         if (item == NULL)

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -319,15 +319,8 @@ icon_set_position (CajaIcon *icon,
                    double x, double y)
 {
     CajaIconContainer *container;
-    double pixels_per_unit;
-    int container_left, container_top, container_right, container_bottom;
     int x1, x2, y1, y2;
-    int container_x, container_y, container_width, container_height;
     EelDRect icon_bounds;
-    int item_width, item_height;
-    int height_above, width_left;
-    int min_x, max_x, min_y, max_y;
-    int scale;
 
     if (icon->x == x && icon->y == y)
     {
@@ -343,6 +336,14 @@ icon_set_position (CajaIcon *icon,
 
     if (caja_icon_container_get_is_fixed_size (container))
     {
+        double pixels_per_unit;
+        int container_left, container_top, container_right, container_bottom;
+        int container_x, container_y, container_width, container_height;
+        int item_width, item_height;
+        int height_above, width_left;
+        int min_x, max_x, min_y, max_y;
+        int scale;
+
         /*  FIXME: This should be:
 
         container_x = GTK_WIDGET (container)->allocation.x;
@@ -704,8 +705,8 @@ icon_get_row_and_column_bounds (CajaIconContainer *container,
                                 gboolean safety_pad)
 {
     GList *p;
-    CajaIcon *one_icon;
     EelIRect one_bounds;
+    CajaIcon *one_icon = NULL;
 
     item_get_canvas_bounds (EEL_CANVAS_ITEM (icon->item), bounds, safety_pad);
 
@@ -1262,11 +1263,11 @@ lay_down_one_line (CajaIconContainer *container,
                    gboolean whole_text)
 {
     GList *p;
-    CajaIcon *icon;
     double x, y_offset;
     IconPositions *position;
     int i;
     gboolean is_rtl;
+    CajaIcon *icon = NULL;
 
     is_rtl = caja_icon_container_is_layout_rtl (container);
 
@@ -1310,11 +1311,11 @@ lay_down_one_column (CajaIconContainer *container,
                      GArray *positions)
 {
     GList *p;
-    CajaIcon *icon;
     double y;
-    IconPositions *position;
     int i;
     gboolean is_rtl;
+    IconPositions *position = NULL;
+    CajaIcon *icon = NULL;
 
     is_rtl = caja_icon_container_is_layout_rtl (container);
 
@@ -1346,21 +1347,19 @@ lay_down_icons_horizontal (CajaIconContainer *container,
     GList *p, *line_start;
     CajaIcon *icon;
     double canvas_width, y;
-    GArray *positions;
-    IconPositions *position;
     EelDRect bounds;
     EelDRect icon_bounds;
     EelDRect text_bounds;
     double max_height_above, max_height_below;
-    double height_above, height_below;
     double line_width;
     gboolean gridded_layout;
     double grid_width;
     double max_text_width, max_icon_width;
     int icon_width;
     int i;
-    int num_columns;
     GtkAllocation allocation;
+    GArray *positions;
+    IconPositions *position = NULL;
 
     g_assert (CAJA_IS_ICON_CONTAINER (container));
 
@@ -1394,6 +1393,8 @@ lay_down_icons_horizontal (CajaIconContainer *container,
     }
     else
     {
+        int num_columns;
+
         num_columns = floor(canvas_width / STANDARD_ICON_GRID_WIDTH);
         num_columns = fmax(num_columns, 1);
         /* Minimum of one column */
@@ -1412,6 +1413,8 @@ lay_down_icons_horizontal (CajaIconContainer *container,
     max_height_below = 0;
     for (p = icons; p != NULL; p = p->next)
     {
+        double height_above, height_below;
+
         icon = p->data;
 
         /* Assume it's only one level hierarchy to avoid costly affine calculations */
@@ -1539,11 +1542,11 @@ get_max_icon_dimensions (GList *icon_start,
                          double *max_text_height,
                          double *max_bounds_height)
 {
-    CajaIcon *icon;
     EelDRect icon_bounds;
     EelDRect text_bounds;
     GList *p;
     double y1, y2;
+    CajaIcon *icon = NULL;
 
     *max_icon_width = *max_text_width = 0.0;
     *max_icon_height = *max_text_height = 0.0;
@@ -1576,7 +1579,6 @@ lay_down_icons_vertical (CajaIconContainer *container,
                          double start_y)
 {
     GList *p, *line_start;
-    CajaIcon *icon;
     double x, canvas_height;
     GArray *positions;
     IconPositions *position;
@@ -1596,8 +1598,9 @@ lay_down_icons_vertical (CajaIconContainer *container,
 
     double max_text_width, max_icon_width;
     double max_text_height, max_icon_height;
-    int height;
     int i;
+
+    CajaIcon *icon = NULL;
 
     g_assert (CAJA_IS_ICON_CONTAINER (container));
     g_assert (container->details->label_position == CAJA_ICON_LABEL_POSITION_BESIDE);
@@ -1637,6 +1640,8 @@ lay_down_icons_vertical (CajaIconContainer *container,
 
     for (p = icons; p != NULL; p = p->next)
     {
+        int height;
+
         icon = p->data;
 
         /* If this icon doesn't fit, it's time to lay out the column that's queued up. */
@@ -2088,8 +2093,7 @@ static void
 caja_icon_container_set_rtl_positions (CajaIconContainer *container)
 {
     GList *l;
-    CajaIcon *icon;
-    double x;
+    CajaIcon *icon = NULL;
 
     if (!container->details->icons)
     {
@@ -2098,6 +2102,8 @@ caja_icon_container_set_rtl_positions (CajaIconContainer *container)
 
     for (l = container->details->icons; l != NULL; l = l->next)
     {
+        double x;
+
         icon = l->data;
         x = get_mirror_x_position (container, icon, icon->saved_ltr_x);
         icon_set_position (icon, x, icon->y);
@@ -2110,7 +2116,7 @@ lay_down_icons_vertical_desktop (CajaIconContainer *container, GList *icons)
     GList *p, *placed_icons, *unplaced_icons;
     int total, new_length, placed;
     CajaIcon *icon;
-    int height, max_width, column_width, icon_width, icon_height;
+    int height;
     int x, y, x1, x2, y1, y2;
     EelDRect icon_rect;
     GtkAllocation allocation;
@@ -2193,6 +2199,7 @@ lay_down_icons_vertical_desktop (CajaIconContainer *container, GList *icons)
 
         while (icons != NULL)
         {
+            int max_width, column_width, icon_height;
             int center_x;
             int baseline;
             int icon_height_for_bound_check;
@@ -2207,6 +2214,8 @@ lay_down_icons_vertical_desktop (CajaIconContainer *container, GList *icons)
             /* Calculate max width for column */
             for (p = icons; p != NULL; p = p->next)
             {
+                int icon_width;
+
                 icon = p->data;
 
                 icon_get_bounding_box (icon, &x1, &y1, &x2, &y2,
@@ -2404,12 +2413,12 @@ static void
 reload_icon_positions (CajaIconContainer *container)
 {
     GList *p, *no_position_icons;
-    CajaIcon *icon;
     gboolean have_stored_position;
     CajaIconPosition position;
     EelDRect bounds;
     double bottom;
     EelCanvasItem *item;
+    CajaIcon *icon = NULL;
 
     g_assert (!container->details->auto_layout);
 
@@ -2474,7 +2483,7 @@ static void
 invalidate_label_sizes (CajaIconContainer *container)
 {
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     for (p = container->details->icons; p != NULL; p = p->next)
     {
@@ -2489,7 +2498,7 @@ static void
 invalidate_labels (CajaIconContainer *container)
 {
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     for (p = container->details->icons; p != NULL; p = p->next)
     {
@@ -2507,7 +2516,7 @@ select_range (CajaIconContainer *container,
 {
     gboolean selection_changed;
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
     CajaIcon *unmatched_icon;
     gboolean select;
 
@@ -2560,7 +2569,7 @@ select_one_unselect_others (CajaIconContainer *container,
 {
     gboolean selection_changed;
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     selection_changed = FALSE;
 
@@ -2667,9 +2676,9 @@ rubberband_select (CajaIconContainer *container,
 {
     GList *p;
     gboolean selection_changed, is_in, canvas_rect_calculated;
-    CajaIcon *icon;
     EelIRect canvas_rect;
     EelCanvas *canvas;
+    CajaIcon *icon = NULL;
 
     selection_changed = FALSE;
     canvas_rect_calculated = FALSE;
@@ -6609,7 +6618,7 @@ static void
 update_selected (CajaIconContainer *container)
 {
     GList *node;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     for (node = container->details->icons; node != NULL; node = node->next)
     {
@@ -6657,7 +6666,6 @@ get_text_ellipsis_limit_for_zoom (char **strs,
                                   const char *zoom_level,
                                   int *limit)
 {
-    char **p;
     char *str;
     gboolean success;
 
@@ -6677,6 +6685,8 @@ get_text_ellipsis_limit_for_zoom (char **strs,
 
     if (strs != NULL)
     {
+        char **p;
+
         for (p = strs; *p != NULL; p++)
         {
             if (sscanf (*p, str, limit))
@@ -6998,8 +7008,8 @@ void
 caja_icon_container_clear (CajaIconContainer *container)
 {
     CajaIconContainerDetails *details;
-    CajaIcon *icon;
     GList *p;
+    CajaIcon *icon = NULL;
 
     g_return_if_fail (CAJA_IS_ICON_CONTAINER (container));
 
@@ -7146,10 +7156,10 @@ caja_icon_container_scroll_to_icon (CajaIconContainer  *container,
                                     CajaIconData       *data)
 {
     GList *l;
-    CajaIcon *icon;
     GtkAdjustment *hadj, *vadj;
     EelIRect bounds;
     GtkAllocation allocation;
+    CajaIcon *icon = NULL;
 
     hadj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (container));
     vadj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (container));
@@ -7467,9 +7477,9 @@ caja_icon_container_update_visible_icons (CajaIconContainer *container)
     double min_x, max_x;
     double x0, y0, x1, y1;
     GList *node;
-    CajaIcon *icon;
     gboolean visible;
     GtkAllocation allocation;
+    CajaIcon *icon = NULL;
 
     hadj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (container));
     vadj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (container));
@@ -8035,7 +8045,7 @@ void
 caja_icon_container_request_update_all (CajaIconContainer *container)
 {
     GList *node;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     g_return_if_fail (CAJA_IS_ICON_CONTAINER (container));
 
@@ -8205,7 +8215,7 @@ caja_icon_container_select_all (CajaIconContainer *container)
 {
     gboolean selection_changed;
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     g_return_if_fail (CAJA_IS_ICON_CONTAINER (container));
 
@@ -8240,7 +8250,7 @@ caja_icon_container_set_selection (CajaIconContainer *container,
     gboolean selection_changed;
     GHashTable *hash;
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     g_return_if_fail (CAJA_IS_ICON_CONTAINER (container));
 
@@ -8282,7 +8292,7 @@ caja_icon_container_select_list_unselect_others (CajaIconContainer *container,
     gboolean selection_changed;
     GHashTable *hash;
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     g_return_if_fail (CAJA_IS_ICON_CONTAINER (container));
 
@@ -8375,8 +8385,8 @@ static CajaIcon *
 get_nth_selected_icon (CajaIconContainer *container, int index)
 {
     GList *p;
-    CajaIcon *icon;
     int selection_count;
+    CajaIcon *icon = NULL;
 
     g_assert (index > 0);
 
@@ -8412,7 +8422,7 @@ static gboolean
 all_selected (CajaIconContainer *container)
 {
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     for (p = container->details->icons; p != NULL; p = p->next)
     {
@@ -8508,7 +8518,7 @@ gboolean
 caja_icon_container_is_stretched (CajaIconContainer *container)
 {
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     for (p = container->details->icons; p != NULL; p = p->next)
     {
@@ -8531,7 +8541,7 @@ void
 caja_icon_container_unstretch (CajaIconContainer *container)
 {
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     for (p = container->details->icons; p != NULL; p = p->next)
     {
@@ -8936,7 +8946,6 @@ caja_icon_container_start_renaming_selected_item (CajaIconContainer *container,
     CajaIcon *icon;
     EelDRect icon_rect;
     EelDRect text_rect;
-    PangoContext *context;
     PangoFontDescription *desc;
     const char *editable_text;
     int x, y, width;
@@ -9015,6 +9024,8 @@ caja_icon_container_start_renaming_selected_item (CajaIconContainer *container,
     }
     else
     {
+        PangoContext *context;
+
         context = gtk_widget_get_pango_context (GTK_WIDGET (container));
         desc = pango_font_description_copy (pango_context_get_font_description (context));
         pango_font_description_set_size (desc,
@@ -9093,8 +9104,6 @@ static void
 end_renaming_mode (CajaIconContainer *container, gboolean commit)
 {
     CajaIcon *icon;
-    const char *changed_text;
-    AtkObject *accessible_icon;
 
     set_pending_icon_to_rename (container, NULL);
 
@@ -9119,10 +9128,14 @@ end_renaming_mode (CajaIconContainer *container, gboolean commit)
 
     if (commit)
     {
+        const char *changed_text;
+
         /* Verify that text has been modified before signalling change. */
         changed_text = eel_editable_label_get_text (EEL_EDITABLE_LABEL (container->details->rename_widget));
         if (strcmp (container->details->original_text, changed_text) != 0)
         {
+            AtkObject *accessible_icon;
+
             g_signal_emit (container,
                            signals[ICON_TEXT_CHANGED], 0,
                            icon->data,
@@ -9165,9 +9178,9 @@ gboolean
 caja_icon_container_has_stored_icon_positions (CajaIconContainer *container)
 {
     GList *p;
-    CajaIcon *icon;
     gboolean have_stored_position;
     CajaIconPosition position;
+    CajaIcon *icon = NULL;
 
     for (p = container->details->icons; p != NULL; p = p->next)
     {
@@ -9403,8 +9416,8 @@ caja_icon_container_set_highlighted_for_clipboard (CajaIconContainer *container,
         GList                 *clipboard_icon_data)
 {
     GList *l;
-    CajaIcon *icon;
     gboolean highlighted_for_clipboard;
+    CajaIcon *icon = NULL;
 
     g_return_if_fail (CAJA_IS_ICON_CONTAINER (container));
 
@@ -9554,7 +9567,7 @@ caja_icon_container_accessible_update_selection (AtkObject *accessible)
     CajaIconContainer *container;
     CajaIconContainerAccessiblePrivate *priv;
     GList *l;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     container = CAJA_ICON_CONTAINER (gtk_accessible_get_widget (GTK_ACCESSIBLE (accessible)));
 
@@ -9592,9 +9605,6 @@ caja_icon_container_accessible_icon_added_cb (CajaIconContainer *container,
         gpointer data)
 {
     CajaIcon *icon;
-    AtkObject *atk_parent;
-    AtkObject *atk_child;
-    int index;
 
     // We don't want to emit children_changed signals during any type of load.
     if (container->details->is_loading || container->details->is_populating_container)
@@ -9603,6 +9613,10 @@ caja_icon_container_accessible_icon_added_cb (CajaIconContainer *container,
     icon = g_hash_table_lookup (container->details->icon_set, icon_data);
     if (icon)
     {
+        AtkObject *atk_parent;
+        AtkObject *atk_child;
+        int index;
+
         atk_parent = ATK_OBJECT (data);
         atk_child = atk_gobject_accessible_for_object
                     (G_OBJECT (icon->item));
@@ -9619,13 +9633,14 @@ caja_icon_container_accessible_icon_removed_cb (CajaIconContainer *container,
         gpointer data)
 {
     CajaIcon *icon;
-    AtkObject *atk_parent;
-    AtkObject *atk_child;
-    int index;
 
     icon = g_hash_table_lookup (container->details->icon_set, icon_data);
     if (icon)
     {
+        AtkObject *atk_parent;
+        AtkObject *atk_child;
+        int index;
+
         atk_parent = ATK_OBJECT (data);
         atk_child = atk_gobject_accessible_for_object
                     (G_OBJECT (icon->item));
@@ -9650,7 +9665,6 @@ caja_icon_container_accessible_add_selection (AtkSelection *accessible,
 {
     GtkWidget *widget;
     CajaIconContainer *container;
-    GList *selection;
     CajaIcon *icon;
 
     widget = gtk_accessible_get_widget (GTK_ACCESSIBLE (accessible));
@@ -9664,6 +9678,8 @@ caja_icon_container_accessible_add_selection (AtkSelection *accessible,
     icon = g_list_nth_data (container->details->icons, i);
     if (icon)
     {
+        GList *selection;
+
         selection = caja_icon_container_get_selection (container);
         selection = g_list_prepend (selection,
                                     icon->data);
@@ -9699,7 +9715,6 @@ static AtkObject *
 caja_icon_container_accessible_ref_selection (AtkSelection *accessible,
         int i)
 {
-    AtkObject *atk_object;
     CajaIconContainerAccessiblePrivate *priv;
     CajaIcon *icon;
 
@@ -9709,6 +9724,8 @@ caja_icon_container_accessible_ref_selection (AtkSelection *accessible,
     icon = g_list_nth_data (priv->selection, i);
     if (icon)
     {
+        AtkObject *atk_object;
+
         atk_object = atk_gobject_accessible_for_object (G_OBJECT (icon->item));
         if (atk_object)
         {
@@ -9763,7 +9780,6 @@ caja_icon_container_accessible_remove_selection (AtkSelection *accessible,
 {
     CajaIconContainer *container;
     CajaIconContainerAccessiblePrivate *priv;
-    GList *selection;
     CajaIcon *icon;
     GtkWidget *widget;
 
@@ -9781,6 +9797,8 @@ caja_icon_container_accessible_remove_selection (AtkSelection *accessible,
     icon = g_list_nth_data (priv->selection, i);
     if (icon)
     {
+        GList *selection;
+
         selection = caja_icon_container_get_selection (container);
         selection = g_list_remove (selection, icon->data);
         caja_icon_container_set_selection (container, selection);
@@ -9912,7 +9930,6 @@ static void
 caja_icon_container_accessible_initialize (AtkObject *accessible,
         gpointer data)
 {
-    CajaIconContainer *container;
     CajaIconContainerAccessiblePrivate *priv;
 
     if (ATK_OBJECT_CLASS (accessible_parent_class)->initialize)
@@ -9927,6 +9944,8 @@ caja_icon_container_accessible_initialize (AtkObject *accessible,
 
     if (GTK_IS_ACCESSIBLE (accessible))
     {
+        CajaIconContainer *container;
+
         caja_icon_container_accessible_update_selection
         (ATK_OBJECT (accessible));
 
@@ -10115,9 +10134,9 @@ caja_icon_container_begin_loading (CajaIconContainer *container)
 static void
 store_layout_timestamps_now (CajaIconContainer *container)
 {
-    CajaIcon *icon;
     GList *p;
     gboolean dummy;
+    CajaIcon *icon = NULL;
 
     container->details->layout_timestamp = time (NULL);
     g_signal_emit (container,

--- a/libcaja-private/caja-icon-dnd.c
+++ b/libcaja-private/caja-icon-dnd.c
@@ -282,7 +282,7 @@ caja_icon_container_each_selected_icon (CajaIconContainer *container,
                                         gboolean (*each_function) (CajaIcon *, gpointer), gpointer data)
 {
     GList *p;
-    CajaIcon *icon;
+    CajaIcon *icon = NULL;
 
     for (p = container->details->icons; p != NULL; p = p->next)
     {
@@ -424,7 +424,6 @@ get_direct_save_filename (GdkDragContext *context)
 static void
 set_direct_save_uri (GtkWidget *widget, GdkDragContext *context, CajaDragInfo *drag_info, int x, int y)
 {
-    GFile *base, *child;
     char *filename, *drop_target;
     gchar *uri;
 
@@ -445,6 +444,8 @@ set_direct_save_uri (GtkWidget *widget, GdkDragContext *context, CajaDragInfo *d
 
     if (filename != NULL && drop_target != NULL)
     {
+        GFile *base, *child;
+
         /* Resolve relative path */
         base = g_file_new_for_uri (drop_target);
         child = g_file_get_child (base, filename);
@@ -949,12 +950,12 @@ handle_local_move (CajaIconContainer *container,
                    double world_x, double world_y)
 {
     GList *moved_icons, *p;
-    CajaDragSelectionItem *item;
-    CajaIcon *icon;
     CajaFile *file;
     char screen_string[32];
     GdkScreen *screen;
     time_t now;
+    CajaDragSelectionItem *item = NULL;
+    CajaIcon *icon = NULL;
 
     if (container->details->auto_layout)
     {
@@ -1022,7 +1023,6 @@ handle_nonlocal_move (CajaIconContainer *container,
     GList *source_uris, *p;
     GArray *source_item_locations;
     gboolean free_target_uri, is_rtl;
-    int index, item_x;
     GtkAllocation allocation;
 
     if (container->details->dnd_info->drag_info.selection_list == NULL)
@@ -1043,6 +1043,8 @@ handle_nonlocal_move (CajaIconContainer *container,
     source_item_locations = g_array_new (FALSE, TRUE, sizeof (GdkPoint));
     if (!icon_hit)
     {
+        int index;
+
         /* Drop onto a container. Pass along the item points to allow placing
          * the items in their same relative positions in the new container.
          */
@@ -1052,6 +1054,8 @@ handle_nonlocal_move (CajaIconContainer *container,
         for (index = 0, p = container->details->dnd_info->drag_info.selection_list;
                 p != NULL; index++, p = p->next)
         {
+            int item_x;
+
             item_x = ((CajaDragSelectionItem *)p->data)->icon_x;
             if (is_rtl)
                 item_x = -item_x - ((CajaDragSelectionItem *)p->data)->icon_width;
@@ -1101,9 +1105,6 @@ caja_icon_container_find_drop_target (CajaIconContainer *container,
 {
     CajaIcon *drop_target_icon;
     double world_x, world_y;
-    CajaFile *file;
-    char *icon_uri;
-    char *container_uri;
 
     if (icon_hit)
     {
@@ -1127,9 +1128,13 @@ caja_icon_container_find_drop_target (CajaIconContainer *container,
     drop_target_icon = caja_icon_container_item_at (container, world_x, world_y);
     if (drop_target_icon != NULL)
     {
+        char *icon_uri;
+
         icon_uri = caja_icon_container_get_icon_uri (container, drop_target_icon);
         if (icon_uri != NULL)
         {
+            CajaFile *file;
+
             file = caja_file_get_by_uri (icon_uri);
 
             if (!caja_drag_can_accept_info (file,
@@ -1149,6 +1154,8 @@ caja_icon_container_find_drop_target (CajaIconContainer *container,
 
     if (drop_target_icon == NULL)
     {
+        char *container_uri;
+
         if (icon_hit)
         {
             *icon_hit = FALSE;
@@ -1225,7 +1232,6 @@ caja_icon_container_receive_dropped_icons (CajaIconContainer *container,
     double world_x, world_y;
     gboolean icon_hit;
     GdkDragAction action, real_action;
-    CajaDragSelectionItem *selected_item;
 
     drop_target = NULL;
 
@@ -1259,6 +1265,8 @@ caja_icon_container_receive_dropped_icons (CajaIconContainer *container,
 
     if (real_action == (GdkDragAction) CAJA_DND_ACTION_SET_AS_BACKGROUND)
     {
+        CajaDragSelectionItem *selected_item;
+
         selected_item = container->details->dnd_info->drag_info.selection_list->data;
         eel_background_set_dropped_image (eel_get_widget_background (GTK_WIDGET (container)),
                                           real_action, selected_item->uri);
@@ -1406,9 +1414,7 @@ caja_icon_dnd_update_drop_target (CajaIconContainer *container,
                                   int x, int y)
 {
     CajaIcon *icon;
-    CajaFile *file;
     double world_x, world_y;
-    char *uri;
 
     g_assert (CAJA_IS_ICON_CONTAINER (container));
 
@@ -1426,6 +1432,9 @@ caja_icon_dnd_update_drop_target (CajaIconContainer *container,
     /* Find if target icon accepts our drop. */
     if (icon != NULL && (container->details->dnd_info->drag_info.data_type != CAJA_ICON_DND_KEYWORD))
     {
+        CajaFile *file;
+        char *uri;
+
         uri = caja_icon_container_get_icon_uri (container, icon);
         file = caja_file_get_by_uri (uri);
         g_free (uri);
@@ -1751,10 +1760,6 @@ drag_data_received_callback (GtkWidget *widget,
                              gpointer user_data)
 {
     CajaDragInfo *drag_info;
-    EelBackground *background;
-    char *tmp;
-    const char *tmp_raw;
-    int length;
     gboolean success;
 
     drag_info = &(CAJA_ICON_CONTAINER (widget)->details->dnd_info->drag_info);
@@ -1801,6 +1806,10 @@ drag_data_received_callback (GtkWidget *widget,
      */
     if (drag_info->drop_occured)
     {
+        EelBackground *background;
+        char *tmp;
+        const char *tmp_raw;
+        int length;
 
         success = FALSE;
         switch (info)

--- a/libcaja-private/caja-icon-info.c
+++ b/libcaja-private/caja-icon-info.c
@@ -148,7 +148,7 @@ caja_icon_info_new_for_icon_info (GtkIconInfo *icon_info,
     GdkPoint *points;
     gint n_points;
     const char *filename;
-    char *basename, *p;
+    char *basename;
 
     icon = g_object_new (CAJA_TYPE_ICON_INFO, NULL);
 
@@ -168,6 +168,8 @@ caja_icon_info_new_for_icon_info (GtkIconInfo *icon_info,
     filename = gtk_icon_info_get_filename (icon_info);
     if (filename != NULL)
     {
+        char *p;
+
         basename = g_path_get_basename (filename);
         p = strrchr (basename, '.');
         if (p)

--- a/libcaja-private/caja-keep-last-vertical-box.c
+++ b/libcaja-private/caja-keep-last-vertical-box.c
@@ -89,7 +89,6 @@ static void
 caja_keep_last_vertical_box_size_allocate (GtkWidget *widget,
         GtkAllocation *allocation)
 {
-    GtkWidget *last_child, *child;
     GList *children, *l;
     GtkAllocation last_child_allocation, child_allocation, tiny_allocation;
 
@@ -103,6 +102,8 @@ caja_keep_last_vertical_box_size_allocate (GtkWidget *widget,
 
     if (l != NULL)
     {
+        GtkWidget *last_child;
+
         last_child = l->data;
         l = l->prev;
 
@@ -114,6 +115,7 @@ caja_keep_last_vertical_box_size_allocate (GtkWidget *widget,
         if (last_child_allocation.y + last_child_allocation.height >
                 allocation->y + allocation->height)
         {
+            GtkWidget *child = NULL;
 
             while (l != NULL)
             {

--- a/libcaja-private/caja-link.c
+++ b/libcaja-private/caja-link.c
@@ -200,7 +200,7 @@ caja_link_local_create (const char     *directory_uri,
                         gboolean        unique_filename)
 {
     char *real_directory_uri;
-    char *uri, *contents;
+    char *contents;
     GFile *file;
     GList dummy_list;
     CajaFileChangesQueuePosition item;
@@ -227,6 +227,8 @@ caja_link_local_create (const char     *directory_uri,
 
     if (unique_filename)
     {
+        char *uri;
+
         uri = caja_ensure_unique_file_name (real_directory_uri,
                                             base_name, ".desktop");
         if (uri == NULL)
@@ -481,7 +483,7 @@ caja_link_get_link_name_from_desktop (GKeyFile *key_file)
 static char *
 caja_link_get_link_icon_from_desktop (GKeyFile *key_file)
 {
-    char *icon_uri, *icon, *p, *type;
+    char *icon_uri, *icon, *type;
 
     icon_uri = g_key_file_get_string (key_file, MAIN_GROUP, "X-Caja-Icon", NULL);
     if (icon_uri != NULL)
@@ -494,6 +496,8 @@ caja_link_get_link_icon_from_desktop (GKeyFile *key_file)
     {
         if (!g_path_is_absolute (icon))
         {
+            char *p;
+
             /* Strip out any extension on non-filename icons. Old desktop files may have this */
             p = strchr (icon, '.');
             /* Only strip known icon extensions */

--- a/libcaja-private/caja-metadata.c
+++ b/libcaja-private/caja-metadata.c
@@ -66,10 +66,11 @@ guint
 caja_metadata_get_id (const char *metadata)
 {
     static GHashTable *hash;
-    int i;
 
     if (hash == NULL)
     {
+        int i;
+
         hash = g_hash_table_new (g_str_hash, g_str_equal);
         for (i = 0; used_metadata_names[i] != NULL; i++)
             g_hash_table_insert (hash,

--- a/libcaja-private/caja-mime-actions.c
+++ b/libcaja-private/caja-mime-actions.c
@@ -134,7 +134,7 @@ static GList *
 get_file_list_for_launch_locations (GList *locations)
 {
     GList *files, *l;
-    LaunchLocation *location;
+    LaunchLocation *location = NULL;
 
     files = NULL;
     for (l = locations; l != NULL; l = l->next)
@@ -183,8 +183,8 @@ static LaunchLocation *
 find_launch_location_for_file (GList *list,
                                CajaFile *file)
 {
-    LaunchLocation *location;
     GList *l;
+    LaunchLocation *location = NULL;
 
     for (l = list; l != NULL; l = l->next)
     {
@@ -240,12 +240,13 @@ static GList*
 filter_caja_handler (GList *apps)
 {
     GList *l, *next;
-    GAppInfo *application;
-    const char *id;
+    GAppInfo *application = NULL;
 
     l = apps;
     while (l != NULL)
     {
+        const char *id;
+
         application = (GAppInfo *) l->data;
         next = l->next;
 
@@ -268,7 +269,7 @@ static GList*
 filter_non_uri_apps (GList *apps)
 {
     GList *l, *next;
-    GAppInfo *app;
+    GAppInfo *app = NULL;
 
     for (l = apps; l != NULL; l = next)
     {
@@ -337,7 +338,6 @@ caja_mime_get_default_application_for_file (CajaFile *file)
 {
     GAppInfo *app;
     char *mime_type;
-    char *uri_scheme;
 
     if (!caja_mime_actions_check_if_required_attributes_ready (file))
     {
@@ -350,6 +350,8 @@ caja_mime_get_default_application_for_file (CajaFile *file)
 
     if (app == NULL)
     {
+        char *uri_scheme;
+
         uri_scheme = caja_file_get_uri_scheme (file);
         if (uri_scheme != NULL)
         {
@@ -447,7 +449,6 @@ caja_mime_get_applications_for_file (CajaFile *file)
     char *mime_type;
     char *uri_scheme;
     GList *result;
-    GAppInfo *uri_handler;
 
     if (!caja_mime_actions_check_if_required_attributes_ready (file))
     {
@@ -459,6 +460,8 @@ caja_mime_get_applications_for_file (CajaFile *file)
     uri_scheme = caja_file_get_uri_scheme (file);
     if (uri_scheme != NULL)
     {
+        GAppInfo *uri_handler;
+
         uri_handler = g_app_info_get_default_for_uri_scheme (uri_scheme);
         if (uri_handler)
         {
@@ -486,7 +489,6 @@ caja_mime_has_any_applications_for_file (CajaFile *file)
     char *mime_type;
     gboolean result;
     char *uri_scheme;
-    GAppInfo *uri_handler;
 
     mime_type = caja_file_get_mime_type (file);
 
@@ -495,6 +497,8 @@ caja_mime_has_any_applications_for_file (CajaFile *file)
     uri_scheme = caja_file_get_uri_scheme (file);
     if (uri_scheme != NULL)
     {
+        GAppInfo *uri_handler;
+
         uri_handler = g_app_info_get_default_for_uri_scheme (uri_scheme);
         if (uri_handler)
         {
@@ -529,8 +533,8 @@ GAppInfo *
 caja_mime_get_default_application_for_files (GList *files)
 {
     GList *l, *sorted_files;
-    CajaFile *file;
     GAppInfo *app, *one_app;
+    CajaFile *file = NULL;
 
     g_assert (files != NULL);
 
@@ -588,8 +592,8 @@ intersect_application_lists (GList *a,
 {
     GList *l, *m;
     GList *ret;
-    GAppInfo *a_app, *b_app;
-    int cmp;
+    GAppInfo *a_app = NULL;
+    GAppInfo *b_app = NULL;
 
     ret = NULL;
 
@@ -598,6 +602,8 @@ intersect_application_lists (GList *a,
 
     while (l != NULL && m != NULL)
     {
+        int cmp;
+
         a_app = (GAppInfo *) l->data;
         b_app = (GAppInfo *) m->data;
 
@@ -634,8 +640,8 @@ GList *
 caja_mime_get_applications_for_files (GList *files)
 {
     GList *l, *sorted_files;
-    CajaFile *file;
     GList *one_ret, *ret;
+    CajaFile *file = NULL;
 
     g_assert (files != NULL);
 
@@ -979,10 +985,10 @@ make_activation_parameters (GList *uris,
                             GList **unhandled_uris)
 {
     GList *ret, *l, *app_uris;
-    CajaFile *file;
-    GAppInfo *app, *old_app;
     GHashTable *app_table;
-    char *uri;
+    GAppInfo *old_app;
+    GAppInfo *app = NULL;
+    CajaFile *file = NULL;
 
     ret = NULL;
     *unhandled_uris = NULL;
@@ -995,6 +1001,8 @@ make_activation_parameters (GList *uris,
 
     for (l = uris; l != NULL; l = l->next)
     {
+        char *uri;
+
         uri = l->data;
         file = caja_file_get_by_uri (uri);
 
@@ -1246,11 +1254,12 @@ get_application_no_mime_type_handler_message (CajaFile *file, char *uri)
     char *uri_for_display;
     char *nice_uri;
     char *error_message;
-    GFile *location;
 
     /* For local files, we want to use filename if possible */
     if (caja_file_is_local (file))
     {
+        GFile *location;
+
         location = caja_file_get_location (file);
         nice_uri = g_file_get_parse_name (location);
         g_object_unref (location);
@@ -1478,13 +1487,13 @@ application_unhandled_file_install (GtkDialog *dialog,
                                     gint response_id,
                                     ActivateParametersInstall *parameters_install)
 {
-    char *mime_type;
-
     gtk_widget_destroy (GTK_WIDGET (dialog));
     parameters_install->dialog = NULL;
 
     if (response_id == GTK_RESPONSE_YES)
     {
+        char *mime_type;
+
         mime_type = caja_file_get_mime_type (parameters_install->file);
         search_for_application_mime_type (parameters_install, mime_type);
         g_free (mime_type);
@@ -1686,8 +1695,6 @@ activate_desktop_file (ActivateParameters *parameters,
                        CajaFile *file)
 {
     ActivateParametersDesktop *parameters_desktop;
-    char *primary, *secondary, *display_name;
-    GtkWidget *dialog;
     GdkScreen *screen;
     char *uri;
 
@@ -1695,6 +1702,9 @@ activate_desktop_file (ActivateParameters *parameters,
 
     if (!caja_file_is_trusted_link (file))
     {
+        char *primary, *secondary, *display_name;
+        GtkWidget *dialog;
+
         /* copy the parts of parameters we are interested in as the orignal will be freed */
         parameters_desktop = g_new0 (ActivateParametersDesktop, 1);
         if (parameters->parent_window)
@@ -1767,7 +1777,6 @@ activate_files (ActivateParameters *parameters)
     GList *open_in_app_uris;
     GList *open_in_app_parameters;
     GList *unhandled_open_in_app_uris;
-    ApplicationLaunchParameters *one_parameters;
     GList *open_in_view_files;
     GList *l;
     int count;
@@ -1777,6 +1786,7 @@ activate_files (ActivateParameters *parameters)
     ActivationAction action;
     GdkScreen *screen;
     LaunchLocation *location;
+    ApplicationLaunchParameters *one_parameters = NULL;
 
     screen = gtk_widget_get_screen (GTK_WIDGET (parameters->parent_window));
 
@@ -2014,7 +2024,6 @@ activation_mount_not_mounted_callback (GObject *source_object,
     ActivateParameters *parameters = user_data;
     GError *error;
     CajaFile *file;
-    LaunchLocation *loc;
 
     file = parameters->not_mounted->data;
 
@@ -2033,6 +2042,8 @@ activation_mount_not_mounted_callback (GObject *source_object,
         if (error->domain != G_IO_ERROR ||
                 error->code != G_IO_ERROR_ALREADY_MOUNTED)
         {
+            LaunchLocation *loc;
+
             loc = find_launch_location_for_file (parameters->locations,
                                                  file);
             if (loc)
@@ -2056,14 +2067,15 @@ activation_mount_not_mounted_callback (GObject *source_object,
 static void
 activation_mount_not_mounted (ActivateParameters *parameters)
 {
-    CajaFile *file;
-    GFile *location;
-    LaunchLocation *loc;
-    GMountOperation *mount_op;
+    LaunchLocation *loc = NULL;
     GList *l, *next, *files;
 
     if (parameters->not_mounted != NULL)
     {
+        CajaFile *file;
+        GFile *location;
+        GMountOperation *mount_op;
+
         file = parameters->not_mounted->data;
         mount_op = gtk_mount_operation_new (parameters->parent_window);
         g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_FOR_SESSION);
@@ -2110,8 +2122,8 @@ activate_callback (GList *files, gpointer callback_data)
 {
     ActivateParameters *parameters = callback_data;
     GList *l, *next;
-    CajaFile *file;
     LaunchLocation *location;
+    CajaFile *file = NULL;
 
     parameters->files_handle = NULL;
 
@@ -2161,8 +2173,8 @@ activate_activation_uris_ready_callback (GList *files_ignore,
 {
     ActivateParameters *parameters = callback_data;
     GList *l, *next, *files;
-    CajaFile *file;
     LaunchLocation *location;
+    CajaFile *file = NULL;
 
     parameters->files_handle = NULL;
 
@@ -2239,8 +2251,8 @@ static void
 activation_get_activation_uris (ActivateParameters *parameters)
 {
     GList *l, *files;
-    CajaFile *file;
     LaunchLocation *location;
+    CajaFile *file = NULL;
 
     /* link target info might be stale, re-read it */
     for (l = parameters->locations; l != NULL; l = l->next)
@@ -2287,7 +2299,6 @@ activation_mountable_mounted (CajaFile  *file,
                               gpointer       callback_data)
 {
     ActivateParameters *parameters = callback_data;
-    CajaFile *target_file;
     LaunchLocation *location;
 
     /* Remove from list of files that have to be mounted */
@@ -2297,6 +2308,8 @@ activation_mountable_mounted (CajaFile  *file,
 
     if (error == NULL)
     {
+        CajaFile *target_file;
+
         /* Replace file with the result of the mount */
         target_file = caja_file_get (result_location);
 
@@ -2351,11 +2364,11 @@ activation_mountable_mounted (CajaFile  *file,
 static void
 activation_mount_mountables (ActivateParameters *parameters)
 {
-    CajaFile *file;
-    GMountOperation *mount_op;
-
     if (parameters->mountables != NULL)
     {
+        CajaFile *file;
+        GMountOperation *mount_op;
+
         file = parameters->mountables->data;
         mount_op = gtk_mount_operation_new (parameters->parent_window);
         g_mount_operation_set_password_save (mount_op, G_PASSWORD_SAVE_FOR_SESSION);
@@ -2438,11 +2451,11 @@ activation_mountable_started (CajaFile  *file,
 static void
 activation_start_mountables (ActivateParameters *parameters)
 {
-    CajaFile *file;
-    GMountOperation *start_op;
-
     if (parameters->start_mountables != NULL)
     {
+        CajaFile *file;
+        GMountOperation *start_op;
+
         file = parameters->start_mountables->data;
         start_op = gtk_mount_operation_new (parameters->parent_window);
         g_signal_connect (start_op, "notify::is-showing",
@@ -2479,11 +2492,10 @@ caja_mime_activate_files (GtkWindow *parent_window,
                           gboolean user_confirmation)
 {
     ActivateParameters *parameters;
-    char *file_name;
     int file_count;
     GList *l, *next;
-    CajaFile *file;
     LaunchLocation *location;
+    CajaFile *file = NULL;
 
     if (files == NULL)
     {
@@ -2512,6 +2524,8 @@ caja_mime_activate_files (GtkWindow *parent_window,
     file_count = g_list_length (files);
     if (file_count == 1)
     {
+        char *file_name;
+
         file_name = caja_file_get_display_name (files->data);
         parameters->timed_wait_prompt = g_strdup_printf (_("Opening \"%s\"."), file_name);
         g_free (file_name);

--- a/libcaja-private/caja-mime-application-chooser.c
+++ b/libcaja-private/caja-mime-application-chooser.c
@@ -134,7 +134,6 @@ default_toggled_cb (GtkCellRendererToggle *renderer,
         gboolean is_default;
         gboolean success;
         GAppInfo *info;
-        char *message;
 
         gtk_tree_model_get (GTK_TREE_MODEL (chooser->details->model),
                             &iter,
@@ -160,6 +159,8 @@ default_toggled_cb (GtkCellRendererToggle *renderer,
 
             if (!success)
             {
+                char *message;
+
                 message = g_strdup_printf (_("Could not set application as the default: %s"), error->message);
                 eel_show_error_dialog (_("Could not set as default application"),
                                        message,

--- a/libcaja-private/caja-monitor.c
+++ b/libcaja-private/caja-monitor.c
@@ -45,10 +45,11 @@ caja_monitor_active (void)
     static gboolean tried_monitor = FALSE;
     static gboolean monitor_success;
     GFileMonitor *dir_monitor;
-    GFile *file;
 
     if (tried_monitor == FALSE)
     {
+        GFile *file;
+
         file = g_file_new_for_path (g_get_home_dir ());
         dir_monitor = g_file_monitor_directory (file, G_FILE_MONITOR_NONE, NULL, NULL);
         g_object_unref (file);

--- a/libcaja-private/caja-open-with-dialog.c
+++ b/libcaja-private/caja-open-with-dialog.c
@@ -221,12 +221,9 @@ static GAppInfo *
 add_or_find_application (CajaOpenWithDialog *dialog)
 {
     GAppInfo *app;
-    char *app_name;
-    const char *commandline;
     GError *error;
     gboolean success, should_set_default;
     char *message;
-    GList *applications;
 
     error = NULL;
     app = NULL;
@@ -236,6 +233,9 @@ add_or_find_application (CajaOpenWithDialog *dialog)
     }
     else
     {
+        char *app_name;
+        const char *commandline;
+
         commandline = gtk_entry_get_text (GTK_ENTRY (dialog->details->entry));
         app_name = get_app_name (commandline, &error);
         if (app_name != NULL)
@@ -284,6 +284,8 @@ add_or_find_application (CajaOpenWithDialog *dialog)
     }
     else
     {
+        GList *applications;
+
         applications = g_app_info_get_all_for_type (dialog->details->content_type);
         if (dialog->details->content_type && applications != NULL)
         {
@@ -327,13 +329,13 @@ response_cb (CajaOpenWithDialog *dialog,
              int response_id,
              gpointer data)
 {
-    GAppInfo *application;
-
     switch (response_id)
     {
     case RESPONSE_OPEN:
         if (check_application (dialog))
         {
+            GAppInfo *application;
+
             application = add_or_find_application (dialog);
 
             if (application)
@@ -500,7 +502,6 @@ static cairo_surface_t *
 get_surface_for_icon (GIcon *icon)
 {
     cairo_surface_t  *surface;
-    char *filename;
     gint icon_scale;
 
     surface = NULL;
@@ -508,6 +509,8 @@ get_surface_for_icon (GIcon *icon)
 
     if (G_IS_FILE_ICON (icon))
     {
+        char *filename;
+
         filename = g_file_get_path (g_file_icon_get_file (G_FILE_ICON (icon)));
         if (filename)
         {
@@ -524,13 +527,14 @@ get_surface_for_icon (GIcon *icon)
     else if (G_IS_THEMED_ICON (icon))
     {
         const char * const *names;
-        char *icon_no_extension;
-        char *p;
 
         names = g_themed_icon_get_names (G_THEMED_ICON (icon));
 
         if (names != NULL && names[0] != NULL)
         {
+            char *icon_no_extension;
+            char *p;
+
             icon_no_extension = g_strdup (names[0]);
             p = strrchr (icon_no_extension, '.');
             if (p &&
@@ -556,11 +560,11 @@ get_surface_for_icon (GIcon *icon)
 static gboolean
 caja_open_with_dialog_add_icon_idle (CajaOpenWithDialog *dialog)
 {
-    GtkTreeIter      iter;
-    GtkTreePath     *path;
     cairo_surface_t *surface;
     GIcon           *icon;
     gboolean         long_operation;
+    GtkTreeIter      iter;
+    GtkTreePath     *path = NULL;
 
     long_operation = FALSE;
     do
@@ -616,14 +620,14 @@ caja_open_with_search_equal_func (GtkTreeModel *model,
                                   GtkTreeIter *iter,
                                   gpointer user_data)
 {
-    char *normalized_key;
-    char *name, *normalized_name;
-    char *path, *normalized_path;
-    char *basename, *normalized_basename;
+    char *name;
+    char *path;
     gboolean ret;
 
     if (key != NULL)
     {
+        char *normalized_key;
+
         normalized_key = g_utf8_casefold (key, -1);
         g_assert (normalized_key != NULL);
 
@@ -636,6 +640,8 @@ caja_open_with_search_equal_func (GtkTreeModel *model,
 
         if (name != NULL)
         {
+            char *normalized_name;
+
             normalized_name = g_utf8_casefold (name, -1);
             g_assert (normalized_name != NULL);
 
@@ -649,6 +655,9 @@ caja_open_with_search_equal_func (GtkTreeModel *model,
 
         if (ret && path != NULL)
         {
+            char *normalized_path;
+            char *basename, *normalized_basename;
+
             normalized_path = g_utf8_casefold (path, -1);
             g_assert (normalized_path != NULL);
 
@@ -1028,7 +1037,6 @@ set_uri_and_type (CajaOpenWithDialog *dialog,
     char *label;
     char *emname;
     char *name, *extension;
-    char *description;
     char *checkbox_text;
 
     name = NULL;
@@ -1087,6 +1095,8 @@ set_uri_and_type (CajaOpenWithDialog *dialog,
     }
     else
     {
+        char *description;
+
         dialog->details->content_type = g_strdup (mime_type);
         description = g_content_type_get_description (mime_type);
 

--- a/libcaja-private/caja-progress-info.c
+++ b/libcaja-private/caja-progress-info.c
@@ -307,7 +307,7 @@ progress_widget_data_free (ProgressWidgetData *data)
 static void
 update_data (ProgressWidgetData *data)
 {
-    char *status, *details, *curstat, *t;
+    char *status, *details, *curstat;
     char *markup;
 
     status = caja_progress_info_get_status (data->info);
@@ -330,6 +330,8 @@ update_data (ProgressWidgetData *data)
     }
 
     if (curstat != NULL) {
+        char *t;
+
         t = status;
         status = g_strconcat (status, " \xE2\x80\x94 ", curstat, NULL);
         g_free (t);
@@ -376,9 +378,9 @@ get_running_operations ()
 static void
 foreach_get_queued_widget (GtkWidget * widget, GtkWidget ** out)
 {
-    ProgressWidgetData *data;
-
     if (*out == NULL) {
+        ProgressWidgetData *data;
+
         data = (ProgressWidgetData*) g_object_get_data (
                 G_OBJECT(widget), "data");
 
@@ -463,10 +465,10 @@ widget_reposition_as_queued (GtkWidget * widget)
 static void
 widget_reposition_as_paused (GtkWidget * widget)
 {
-    ProgressWidgetData *data;
-    GList *children, *child;
-    gboolean abort = FALSE;
     int i;
+    GList *children, *child;
+    ProgressWidgetData *data = NULL;
+    gboolean abort = FALSE;
     GtkWidget * container = get_widgets_container();
 
     children = gtk_container_get_children (GTK_CONTAINER(container));
@@ -495,8 +497,8 @@ widget_reposition_as_paused (GtkWidget * widget)
 static void
 widget_reposition_as_running (GtkWidget * widget)
 {
-    ProgressWidgetData *data;
     GList *children, *child;
+    ProgressWidgetData *data = NULL;
     gboolean abort = FALSE;
     int i, mypos = -1;
     GtkWidget * container = get_widgets_container();
@@ -561,13 +563,14 @@ widget_state_transit_to (ProgressWidgetData *data,
 static void
 update_queue ()
 {
-    GtkWidget *next;
-    ProgressWidgetData *data;
-
     if (get_running_operations () == 0) {
+        GtkWidget *next;
+
         next = get_first_queued_widget ();
 
         if (next != NULL) {
+            ProgressWidgetData *data;
+
             data = (ProgressWidgetData*) g_object_get_data (
                     G_OBJECT(next), "data");
             widget_state_transit_to (data, STATE_RUNNING);
@@ -596,13 +599,14 @@ update_status_icon_and_window (void)
 {
     char *tooltip;
     gboolean toshow;
-    GIcon *icon;
     GNotification *notification;
     gboolean show_notifications = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_SHOW_NOTIFICATIONS);
     static gboolean window_shown = FALSE;
 
     if (show_notifications)
     {
+        GIcon *icon;
+
         notification = g_notification_new ("caja");
         icon = g_themed_icon_new ("system-file-manager");
         g_notification_set_icon (notification, icon);

--- a/libcaja-private/caja-query.c
+++ b/libcaja-private/caja-query.c
@@ -198,7 +198,6 @@ encode_home_uri (const char *uri)
 static char *
 decode_home_uri (const char *uri)
 {
-    char *home_uri;
     char *decoded_uri;
 
     if (g_str_has_prefix (uri, "file:"))
@@ -207,6 +206,8 @@ decode_home_uri (const char *uri)
     }
     else
     {
+        char *home_uri;
+
         home_uri = caja_get_home_directory_uri ();
 
         decoded_uri = g_strconcat (home_uri, "/", uri, NULL);
@@ -380,9 +381,6 @@ caja_query_to_xml (CajaQuery *query)
 {
     GString *xml;
     char *text;
-    char *uri;
-    char *mimetype;
-    char *tag;
     GList *l;
 
     xml = g_string_new ("");
@@ -396,6 +394,8 @@ caja_query_to_xml (CajaQuery *query)
 
     if (query->details->location_uri)
     {
+        char *uri;
+
         uri = encode_home_uri (query->details->location_uri);
         g_string_append_printf (xml, "   <location>%s</location>\n", uri);
         g_free (uri);
@@ -406,6 +406,8 @@ caja_query_to_xml (CajaQuery *query)
         g_string_append (xml, "   <mimetypes>\n");
         for (l = query->details->mime_types; l != NULL; l = l->next)
         {
+            char *mimetype;
+
             mimetype = g_markup_escape_text (l->data, -1);
             g_string_append_printf (xml, "      <mimetype>%s</mimetype>\n", mimetype);
             g_free (mimetype);
@@ -418,7 +420,9 @@ caja_query_to_xml (CajaQuery *query)
         g_string_append (xml, "   <tags>\n");
         for (l = query->details->tags; l != NULL; l = l->next)
         {
-          tag = g_markup_escape_text (l->data, -1);
+            char *tag;
+
+            tag = g_markup_escape_text (l->data, -1);
             g_string_append_printf (xml, "      <tag>%s</tag>\n", tag);
             g_free (tag);
         }

--- a/libcaja-private/caja-search-directory-file.c
+++ b/libcaja-private/caja-search-directory-file.c
@@ -100,10 +100,10 @@ search_directory_file_get_item_count (CajaFile *file,
                                       guint *count,
                                       gboolean *count_unreadable)
 {
-    GList *file_list;
-
     if (count)
     {
+        GList *file_list;
+
         file_list = caja_directory_get_file_list (file->details->directory);
 
         *count = g_list_length (file_list);
@@ -122,10 +122,10 @@ search_directory_file_get_deep_counts (CajaFile *file,
                                        goffset *total_size,
                                        goffset *total_size_on_disk)
 {
-    CajaFile *dir_file;
     GList *file_list, *l;
     guint dirs, files;
     GFileType type;
+    CajaFile *dir_file = NULL;
 
     file_list = caja_directory_get_file_list (file->details->directory);
 
@@ -182,8 +182,6 @@ void
 caja_search_directory_file_update_display_name (CajaSearchDirectoryFile *search_file)
 {
     CajaFile *file;
-    CajaSearchDirectory *search_dir;
-    CajaQuery *query;
     char *display_name;
     gboolean changed;
 
@@ -192,6 +190,9 @@ caja_search_directory_file_update_display_name (CajaSearchDirectoryFile *search_
     file = CAJA_FILE (search_file);
     if (file->details->directory)
     {
+        CajaSearchDirectory *search_dir;
+        CajaQuery *query;
+
         search_dir = CAJA_SEARCH_DIRECTORY (file->details->directory);
         query = caja_search_directory_get_query (search_dir);
 

--- a/libcaja-private/caja-search-directory.c
+++ b/libcaja-private/caja-search-directory.c
@@ -112,8 +112,8 @@ static void
 reset_file_list (CajaSearchDirectory *search)
 {
     GList *list, *monitor_list;
-    CajaFile *file;
     SearchMonitor *monitor;
+    CajaFile *file = NULL;
 
     /* Remove file connections */
     for (list = search->details->files; list != NULL; list = list->next)
@@ -189,7 +189,7 @@ search_monitor_add (CajaDirectory *directory,
     GList *list;
     SearchMonitor *monitor;
     CajaSearchDirectory *search;
-    CajaFile *file;
+    CajaFile *file = NULL;
 
     search = CAJA_SEARCH_DIRECTORY (directory);
 
@@ -220,7 +220,7 @@ static void
 search_monitor_remove_file_monitors (SearchMonitor *monitor, CajaSearchDirectory *search)
 {
     GList *list;
-    CajaFile *file;
+    CajaFile *file = NULL;
 
     for (list = search->details->files; list != NULL; list = list->next)
     {
@@ -243,8 +243,8 @@ search_monitor_remove (CajaDirectory *directory,
                        gconstpointer client)
 {
     CajaSearchDirectory *search;
-    SearchMonitor *monitor;
     GList *list;
+    SearchMonitor *monitor = NULL;
 
     search = CAJA_SEARCH_DIRECTORY (directory);
 
@@ -322,7 +322,7 @@ static void
 search_callback_add_file_callbacks (SearchCallback *callback)
 {
     GList *file_list_copy, *list;
-    CajaFile *file;
+    CajaFile *file = NULL;
 
     file_list_copy = g_list_copy (callback->file_list);
 
@@ -341,8 +341,8 @@ search_callback_add_file_callbacks (SearchCallback *callback)
 static SearchCallback *
 search_callback_find (CajaSearchDirectory *search, CajaDirectoryCallback callback, gpointer callback_data)
 {
-    SearchCallback *search_callback;
     GList *list;
+    SearchCallback *search_callback = NULL;
 
     for (list = search->details->callback_list; list != NULL; list = list->next)
     {
@@ -361,8 +361,8 @@ search_callback_find (CajaSearchDirectory *search, CajaDirectoryCallback callbac
 static SearchCallback *
 search_callback_find_pending (CajaSearchDirectory *search, CajaDirectoryCallback callback, gpointer callback_data)
 {
-    SearchCallback *search_callback;
     GList *list;
+    SearchCallback *search_callback = NULL;
 
     for (list = search->details->pending_callback_list; list != NULL; list = list->next)
     {
@@ -501,7 +501,6 @@ search_engine_hits_added (CajaSearchEngine *engine, GList *hits,
     GList *hit_list;
     GList *file_list;
     CajaFile *file;
-    char *uri;
     SearchMonitor *monitor;
     GList *monitor_list;
 
@@ -509,6 +508,8 @@ search_engine_hits_added (CajaSearchEngine *engine, GList *hits,
 
     for (hit_list = hits; hit_list != NULL; hit_list = hit_list->next)
     {
+        char *uri;
+
         uri = hit_list->data;
 
         if (g_str_has_suffix (uri, CAJA_SAVED_SEARCH_EXTENSION))
@@ -549,13 +550,14 @@ search_engine_hits_subtracted (CajaSearchEngine *engine, GList *hits,
     GList *monitor_list;
     SearchMonitor *monitor;
     GList *file_list;
-    char *uri;
     CajaFile *file;
 
     file_list = NULL;
 
     for (hit_list = hits; hit_list != NULL; hit_list = hit_list->next)
     {
+        char *uri;
+
         uri = hit_list->data;
         file = caja_file_get_by_uri (uri);
 
@@ -852,7 +854,6 @@ CajaSearchDirectory *
 caja_search_directory_new_from_saved_search (const char *uri)
 {
     CajaSearchDirectory *search;
-    CajaQuery *query;
     char *file;
 
     search = CAJA_SEARCH_DIRECTORY (g_object_new (CAJA_TYPE_SEARCH_DIRECTORY, NULL));
@@ -862,6 +863,8 @@ caja_search_directory_new_from_saved_search (const char *uri)
     file = g_filename_from_uri (uri, NULL, NULL);
     if (file != NULL)
     {
+        CajaQuery *query;
+
         query = caja_query_load (file);
         if (query != NULL)
         {

--- a/libcaja-private/caja-search-engine-beagle.c
+++ b/libcaja-private/caja-search-engine-beagle.c
@@ -214,7 +214,6 @@ beagle_hits_added (BeagleQuery *query,
 {
     GSList *hits, *list;
     GList *hit_uris;
-    const char *uri;
 
     hit_uris = NULL;
 
@@ -222,6 +221,8 @@ beagle_hits_added (BeagleQuery *query,
 
     for (list = hits; list != NULL; list = list->next)
     {
+        const char *uri;
+
         BeagleHit *hit = BEAGLE_HIT (list->data);
 
         uri = beagle_hit_get_uri (hit);
@@ -290,7 +291,7 @@ caja_search_engine_beagle_start (CajaSearchEngine *engine)
     CajaSearchEngineBeagle *beagle;
     GError *error;
     GList *mimetypes, *l;
-    char *text, *mimetype;
+    char *text;
 
     error = NULL;
     beagle = CAJA_SEARCH_ENGINE_BEAGLE (engine);
@@ -325,6 +326,8 @@ caja_search_engine_beagle_start (CajaSearchEngine *engine)
     for (l = mimetypes; l != NULL; l = l->next)
     {
         char* temp;
+        char *mimetype;
+
         mimetype = l->data;
         temp = g_strconcat (" mimetype:", mimetype, NULL);
         beagle_query_add_text (beagle->details->current_query,temp);

--- a/libcaja-private/caja-search-engine-simple.c
+++ b/libcaja-private/caja-search-engine-simple.c
@@ -197,12 +197,12 @@ search_thread_add_hits_idle (gpointer user_data)
 static void
 send_batch (SearchThreadData *data)
 {
-    SearchHits *hits;
-
     data->n_processed_files = 0;
 
     if (data->uri_hits)
     {
+        SearchHits *hits;
+
         hits = g_new (SearchHits, 1);
         hits->uris = data->uri_hits;
         hits->thread_data = data;
@@ -505,7 +505,6 @@ search_thread_func (gpointer user_data)
     SearchThreadData *data;
     GFile *dir;
     GFileInfo *info;
-    const char *id;
 
     data = user_data;
 
@@ -514,6 +513,8 @@ search_thread_func (gpointer user_data)
     info = g_file_query_info (dir, G_FILE_ATTRIBUTE_ID_FILE, 0, data->cancellable, NULL);
     if (info)
     {
+        const char *id;
+
         id = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_ID_FILE);
         if (id)
         {

--- a/libcaja-private/caja-search-engine-tracker.c
+++ b/libcaja-private/caja-search-engine-tracker.c
@@ -246,8 +246,6 @@ static void
 search_callback (gpointer results, GError *error, gpointer user_data)
 {
     CajaSearchEngineTracker *tracker;
-    char **results_p;
-    GPtrArray *OUT_result;
     GList *hit_uris;
     gint i;
     char *uri;
@@ -271,6 +269,8 @@ search_callback (gpointer results, GError *error, gpointer user_data)
 
     if (tracker->details->version == TRACKER_0_8)
     {
+        GPtrArray *OUT_result;
+
         /* new tracker 0.8 API */
         OUT_result = (GPtrArray*) results;
 
@@ -289,6 +289,8 @@ search_callback (gpointer results, GError *error, gpointer user_data)
     }
     else
     {
+        char **results_p;
+
         /* old tracker 0.6 API */
         for (results_p = results; *results_p; results_p++)
         {

--- a/libcaja-private/caja-thumbnails.c
+++ b/libcaja-private/caja-thumbnails.c
@@ -190,8 +190,6 @@ thumbnail_thread_starter_cb (gpointer data)
 void
 caja_thumbnail_remove_from_queue (const char *file_uri)
 {
-    GList *node;
-
 #ifdef DEBUG_THUMBNAILS
     g_message ("(Remove from queue) Locking mutex\n");
 #endif
@@ -203,6 +201,8 @@ caja_thumbnail_remove_from_queue (const char *file_uri)
 
     if (thumbnails_to_make_hash)
     {
+        GList *node;
+
         node = g_hash_table_lookup (thumbnails_to_make_hash, file_uri);
 
         if (node && node->data != currently_thumbnailing)
@@ -226,8 +226,6 @@ caja_thumbnail_remove_from_queue (const char *file_uri)
 void
 caja_thumbnail_prioritize (const char *file_uri)
 {
-    GList *node;
-
 #ifdef DEBUG_THUMBNAILS
     g_message ("(Prioritize) Locking mutex\n");
 #endif
@@ -239,6 +237,8 @@ caja_thumbnail_prioritize (const char *file_uri)
 
     if (thumbnails_to_make_hash)
     {
+        GList *node;
+
         node = g_hash_table_lookup (thumbnails_to_make_hash, file_uri);
 
         if (node && node->data != currently_thumbnailing)
@@ -296,8 +296,6 @@ get_types_table (void)
 {
     static GHashTable *image_mime_types = NULL;
     GSList *format_list, *l;
-    char **types;
-    int i;
 
     if (image_mime_types == NULL)
     {
@@ -308,6 +306,9 @@ get_types_table (void)
         format_list = gdk_pixbuf_get_formats ();
         for (l = format_list; l; l = l->next)
         {
+            char **types;
+            int i;
+
             types = gdk_pixbuf_format_get_mime_types (l->data);
 
             for (i = 0; types[i] != NULL; i++)
@@ -387,8 +388,7 @@ caja_create_thumbnail (CajaFile *file)
 {
     time_t file_mtime = 0;
     CajaThumbnailInfo *info;
-    CajaThumbnailInfo *existing_info;
-    GList *existing, *node;
+    GList *existing;
 
     caja_file_set_is_thumbnailing (file, TRUE);
 
@@ -431,6 +431,8 @@ caja_create_thumbnail (CajaFile *file)
     existing = g_hash_table_lookup (thumbnails_to_make_hash, info->image_uri);
     if (existing == NULL)
     {
+        GList *node;
+
         /* Add the thumbnail to the list. */
 #ifdef DEBUG_THUMBNAILS
         g_message ("(Main Thread) Adding thumbnail: %s\n",
@@ -453,6 +455,8 @@ caja_create_thumbnail (CajaFile *file)
     }
     else
     {
+        CajaThumbnailInfo *existing_info;
+
 #ifdef DEBUG_THUMBNAILS
         g_message ("(Main Thread) Updating non-current mtime: %s\n",
                    info->image_uri);

--- a/libcaja-private/caja-trash-monitor.c
+++ b/libcaja-private/caja-trash-monitor.c
@@ -100,10 +100,7 @@ update_info_cb (GObject *source_object,
 {
     CajaTrashMonitor *trash_monitor;
     GFileInfo *info;
-    GIcon *icon;
-    const char * const *names;
     gboolean empty;
-    int i;
 
     trash_monitor = CAJA_TRASH_MONITOR (user_data);
 
@@ -112,6 +109,8 @@ update_info_cb (GObject *source_object,
 
     if (info != NULL)
     {
+        GIcon *icon;
+
         icon = g_file_info_get_icon (info);
 
         if (icon)
@@ -121,6 +120,9 @@ update_info_cb (GObject *source_object,
             empty = TRUE;
             if (G_IS_THEMED_ICON (icon))
             {
+                const char * const *names;
+                int i;
+
                 names = g_themed_icon_get_names (G_THEMED_ICON (icon));
                 for (i = 0; names[i] != NULL; i++)
                 {

--- a/libcaja-private/caja-tree-view-drag-dest.c
+++ b/libcaja-private/caja-tree-view-drag-dest.c
@@ -335,7 +335,6 @@ static CajaFile *
 file_for_path (CajaTreeViewDragDest *dest, GtkTreePath *path)
 {
     CajaFile *file;
-    char *uri;
 
     if (path)
     {
@@ -343,6 +342,8 @@ file_for_path (CajaTreeViewDragDest *dest, GtkTreePath *path)
     }
     else
     {
+        char *uri;
+
         uri = get_root_uri (dest);
 
         file = NULL;
@@ -506,7 +507,6 @@ drag_motion_callback (GtkWidget *widget,
     CajaTreeViewDragDest *dest;
     GtkTreePath *path;
     GtkTreePath *drop_path, *old_drop_path;
-    GtkTreeModel *model;
     GtkTreeIter drop_iter;
     GtkTreeViewDropPosition pos;
     GdkWindow *bin_window;
@@ -549,6 +549,8 @@ drag_motion_callback (GtkWidget *widget,
 
     if (action)
     {
+        GtkTreeModel *model;
+
         set_drag_dest_row (dest, drop_path);
         model = gtk_tree_view_get_model (GTK_TREE_VIEW (widget));
         if (drop_path == NULL || (old_drop_path != NULL &&
@@ -907,8 +909,6 @@ drag_data_received_callback (GtkWidget *widget,
                              gpointer data)
 {
     CajaTreeViewDragDest *dest;
-    const char *tmp;
-    int length;
     gboolean success, finished;
 
     dest = CAJA_TREE_VIEW_DRAG_DEST (data);
@@ -949,11 +949,16 @@ drag_data_received_callback (GtkWidget *widget,
             success = TRUE;
             break;
         case CAJA_ICON_DND_RAW:
+        {
+            const char *tmp;
+            int length;
+
             length = gtk_selection_data_get_length (selection_data);
             tmp = gtk_selection_data_get_data (selection_data);
             receive_dropped_raw (dest, tmp, length, context, x, y);
             success = TRUE;
             break;
+        }
         case CAJA_ICON_DND_KEYWORD:
             receive_dropped_keyword (dest, context, x, y);
             success = TRUE;
@@ -1015,9 +1020,8 @@ set_direct_save_uri (CajaTreeViewDragDest *dest,
                      GdkDragContext *context,
                      int x, int y)
 {
-    GFile *base, *child;
     char *drop_uri;
-    char *filename, *uri;
+    char *uri;
 
     g_assert (dest->details->direct_save_uri == NULL);
 
@@ -1026,9 +1030,13 @@ set_direct_save_uri (CajaTreeViewDragDest *dest,
     drop_uri = get_drop_target_uri_at_pos (dest, x, y);
     if (drop_uri != NULL)
     {
+        char *filename;
+
         filename = get_direct_save_filename (context);
         if (filename != NULL)
         {
+            GFile *base, *child;
+
             /* Resolve relative path */
             base = g_file_new_for_uri (drop_uri);
             child = g_file_get_child (base, filename);

--- a/libcaja-private/caja-ui-utilities.c
+++ b/libcaja-private/caja-ui-utilities.c
@@ -93,7 +93,6 @@ caja_ui_string_get (const char *filename)
 {
     static GHashTable *ui_cache = NULL;
     char *ui;
-    char *path;
 
     if (ui_cache == NULL)
     {
@@ -104,6 +103,8 @@ caja_ui_string_get (const char *filename)
     ui = g_hash_table_lookup (ui_cache, filename);
     if (ui == NULL)
     {
+        char *path;
+
         path = caja_ui_file (filename);
         if (path == NULL || !g_file_get_contents (path, &ui, NULL, NULL))
         {
@@ -171,7 +172,6 @@ caja_action_from_menu_item (CajaMenuItem *item,
     char *name, *label, *tip, *icon_name;
     gboolean sensitive, priority;
     GtkAction *action;
-    cairo_surface_t *surface;
 
     g_object_get (G_OBJECT (item),
                   "name", &name, "label", &label,
@@ -187,6 +187,8 @@ caja_action_from_menu_item (CajaMenuItem *item,
 
     if (icon_name != NULL)
     {
+        cairo_surface_t *surface;
+
         surface = get_action_icon (icon_name,
                                    caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU),
                                    parent_widget);
@@ -220,7 +222,6 @@ caja_toolbar_action_from_menu_item (CajaMenuItem *item, GtkWidget *parent_widget
     char *name, *label, *tip, *icon_name;
     gboolean sensitive, priority;
     GtkAction *action;
-    cairo_surface_t *surface;
 
     g_object_get (G_OBJECT (item),
                   "name", &name, "label", &label,
@@ -236,6 +237,8 @@ caja_toolbar_action_from_menu_item (CajaMenuItem *item, GtkWidget *parent_widget
 
     if (icon_name != NULL)
     {
+        cairo_surface_t *surface;
+
         surface = get_action_icon (icon_name,
                                    caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_LARGE_TOOLBAR),
                                    parent_widget);
@@ -271,11 +274,12 @@ caja_toolbar_action_from_menu_item (CajaMenuItem *item, GtkWidget *parent_widget
 static GdkPixbuf *
 caja_get_thumbnail_frame (void)
 {
-    char *image_path;
     static GdkPixbuf *thumbnail_frame = NULL;
 
     if (thumbnail_frame == NULL)
     {
+        char *image_path;
+
         image_path = caja_pixmap_file ("thumbnail_frame.png");
         if (image_path != NULL)
         {

--- a/libcaja-private/caja-view-factory.c
+++ b/libcaja-private/caja-view-factory.c
@@ -40,7 +40,7 @@ const CajaViewInfo *
 caja_view_factory_lookup (const char *id)
 {
     GList *l;
-    CajaViewInfo *view_info;
+    CajaViewInfo *view_info = NULL;
 
     g_return_val_if_fail (id != NULL, NULL);
 
@@ -106,7 +106,7 @@ caja_view_factory_get_views_for_uri (const char *uri,
                                      const char *mime_type)
 {
     GList *l, *res;
-    const CajaViewInfo *view_info;
+    const CajaViewInfo *view_info = NULL;
 
     res = NULL;
 


### PR DESCRIPTION
Fixes all the `cppcheck` scope variables warnings into the `libcaja-private` folder