### PR TITLE
libegg: reduce the scope of some variables

### DIFF
--- a/libegg/eggdesktopfile.c
+++ b/libegg/eggdesktopfile.c
@@ -480,10 +480,7 @@ gboolean
 egg_desktop_file_can_launch (EggDesktopFile *desktop_file,
                              const char     *desktop_environment)
 {
-    char *try_exec, *found_program;
-    char **only_show_in, **not_show_in;
     gboolean found;
-    int i;
 
     if (desktop_file->type != EGG_DESKTOP_FILE_TYPE_APPLICATION &&
             desktop_file->type != EGG_DESKTOP_FILE_TYPE_LINK)
@@ -491,12 +488,16 @@ egg_desktop_file_can_launch (EggDesktopFile *desktop_file,
 
     if (desktop_environment)
     {
+        char **only_show_in, **not_show_in;
+
         only_show_in = g_key_file_get_string_list (desktop_file->key_file,
                        EGG_DESKTOP_FILE_GROUP,
                        EGG_DESKTOP_FILE_KEY_ONLY_SHOW_IN,
                        NULL, NULL);
         if (only_show_in)
         {
+            int i;
+
             for (i = 0, found = FALSE; only_show_in[i] && !found; i++)
             {
                 if (!strcmp (only_show_in[i], desktop_environment))
@@ -515,6 +516,8 @@ egg_desktop_file_can_launch (EggDesktopFile *desktop_file,
                       NULL, NULL);
         if (not_show_in)
         {
+            int i;
+
             for (i = 0, found = FALSE; not_show_in[i] && !found; i++)
             {
                 if (!strcmp (not_show_in[i], desktop_environment))
@@ -530,12 +533,16 @@ egg_desktop_file_can_launch (EggDesktopFile *desktop_file,
 
     if (desktop_file->type == EGG_DESKTOP_FILE_TYPE_APPLICATION)
     {
+        char *try_exec;
+
         try_exec = g_key_file_get_string (desktop_file->key_file,
                                           EGG_DESKTOP_FILE_GROUP,
                                           EGG_DESKTOP_FILE_KEY_TRY_EXEC,
                                           NULL);
         if (try_exec)
         {
+            char *found_program;
+
             found_program = g_find_program_in_path (try_exec);
             g_free (try_exec);
 
@@ -605,8 +612,6 @@ append_quoted_word (GString    *str,
                     gboolean    in_single_quotes,
                     gboolean    in_double_quotes)
 {
-    const char *p;
-
     if (!in_single_quotes && !in_double_quotes)
         g_string_append_c (str, '\'');
     else if (!in_single_quotes && in_double_quotes)
@@ -616,6 +621,8 @@ append_quoted_word (GString    *str,
         g_string_append (str, s);
     else
     {
+        const char *p;
+
         for (p = s; *p != '\0'; p++)
         {
             if (*p == '\'')

--- a/libegg/eggsmclient-xsmp.c
+++ b/libegg/eggsmclient-xsmp.c
@@ -224,7 +224,7 @@ sm_client_xsmp_set_initial_properties (gpointer user_data)
     if (desktop_file)
     {
         GError *err = NULL;
-        char *cmdline, **argv;
+        char **argv;
         int argc;
 
         if (xsmp->restart_style == SmRestartIfRunning)
@@ -236,6 +236,8 @@ sm_client_xsmp_set_initial_properties (gpointer user_data)
 
         if (!xsmp->set_restart_command)
         {
+            char *cmdline;
+
             cmdline = egg_desktop_file_parse_exec (desktop_file, NULL, &err);
             if (cmdline && g_shell_parse_argv (cmdline, &argc, &argv, &err))
             {
@@ -770,7 +772,7 @@ save_state (EggSMClientXSMP *xsmp)
     char *state_file_path, *data;
     EggDesktopFile *desktop_file;
     GPtrArray *restart;
-    int offset, fd;
+    int offset;
 
     /* We set xsmp->state before emitting save_state, but our caller is
      * responsible for setting it back afterward.
@@ -805,11 +807,13 @@ save_state (EggSMClientXSMP *xsmp)
                                            G_KEY_FILE_KEEP_TRANSLATIONS, NULL))
         {
             guint g, k, i;
-            char **groups, **keys, *value, *exec;
+            char **groups, *value, *exec;
 
             groups = g_key_file_get_groups (state_file, NULL);
             for (g = 0; groups[g]; g++)
             {
+                char **keys;
+
                 keys = g_key_file_get_keys (state_file, groups[g], NULL, NULL);
                 for (k = 0; keys[k]; k++)
                 {
@@ -861,6 +865,8 @@ save_state (EggSMClientXSMP *xsmp)
     offset = 0;
     while (1)
     {
+        int fd;
+
         state_file_path = g_strdup_printf ("%s%csession-state%c%s-%ld.%s",
                                            g_get_user_config_dir (),
                                            G_DIR_SEPARATOR, G_DIR_SEPARATOR,

--- a/libegg/eggtreemultidnd.c
+++ b/libegg/eggtreemultidnd.c
@@ -302,7 +302,6 @@ egg_tree_multi_drag_motion_event (GtkWidget      *widget,
         GList *path_list = NULL;
         GtkTreeSelection *selection;
         GtkTreeModel *model;
-        GdkDragContext *context;
         TreeViewDragInfo *di;
 
         di = get_info (GTK_TREE_VIEW (widget));
@@ -317,6 +316,7 @@ egg_tree_multi_drag_motion_event (GtkWidget      *widget,
         model = gtk_tree_view_get_model (GTK_TREE_VIEW (widget));
         if (egg_tree_multi_drag_source_row_draggable (EGG_TREE_MULTI_DRAG_SOURCE (model), path_list))
         {
+            GdkDragContext *context;
 
             context = gtk_drag_begin_with_coordinates (widget,
                                                        gtk_drag_source_get_target_list (widget),


### PR DESCRIPTION
Fixes 'cppcheck' warnings:

```
[libegg/eggdesktopfile.c:483]: (style) The scope of the variable 'try_exec' can be reduced.
[libegg/eggdesktopfile.c:483]: (style) The scope of the variable 'found_program' can be reduced.
[libegg/eggdesktopfile.c:484]: (style) The scope of the variable 'only_show_in' can be reduced.
[libegg/eggdesktopfile.c:484]: (style) The scope of the variable 'not_show_in' can be reduced.
[libegg/eggdesktopfile.c:486]: (style) The scope of the variable 'i' can be reduced.
[libegg/eggdesktopfile.c:608]: (style) The scope of the variable 'p' can be reduced.

[libegg/eggsmclient-xsmp.c:227]: (style) The scope of the variable 'cmdline' can be reduced.
[libegg/eggsmclient-xsmp.c:773]: (style) The scope of the variable 'fd' can be reduced.
[libegg/eggsmclient-xsmp.c:808]: (style) The scope of the variable 'keys' can be reduced.

[libegg/eggtreemultidnd.c:305]: (style) The scope of the variable 'context' can be reduced.
```