### PR TITLE
Silent gtk action

### DIFF
--- a/libcaja-private/caja-clipboard.c
+++ b/libcaja-private/caja-clipboard.c
@@ -147,6 +147,7 @@ received_clipboard_contents (GtkClipboard     *clipboard,
 
     action_group = data;
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     action = gtk_action_group_get_action (action_group,
                                           "Paste");
     if (action != NULL)
@@ -154,6 +155,7 @@ received_clipboard_contents (GtkClipboard     *clipboard,
         gtk_action_set_sensitive (action,
                                   gtk_selection_data_targets_include_text (selection_data));
     }
+    G_GNUC_END_IGNORE_DEPRECATIONS
 
     g_object_unref (action_group);
 }
@@ -174,9 +176,11 @@ set_paste_sensitive_if_clipboard_contains_data (GtkActionGroup *action_group)
         GtkAction *action;
 
         /* If selection notification isn't supported, always activate Paste */
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         action = gtk_action_group_get_action (action_group,
                                               "Paste");
         gtk_action_set_sensitive (action, TRUE);
+        G_GNUC_END_IGNORE_DEPRECATIONS
     }
 }
 
@@ -185,12 +189,14 @@ set_clipboard_menu_items_sensitive (GtkActionGroup *action_group)
 {
     GtkAction *action;
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     action = gtk_action_group_get_action (action_group,
                                           "Cut");
     gtk_action_set_sensitive (action, TRUE);
     action = gtk_action_group_get_action (action_group,
                                           "Copy");
     gtk_action_set_sensitive (action, TRUE);
+    G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 static void
@@ -198,12 +204,14 @@ set_clipboard_menu_items_insensitive (GtkActionGroup *action_group)
 {
     GtkAction *action;
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     action = gtk_action_group_get_action (action_group,
                                           "Cut");
     gtk_action_set_sensitive (action, FALSE);
     action = gtk_action_group_get_action (action_group,
                                           "Copy");
     gtk_action_set_sensitive (action, FALSE);
+    G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 static gboolean
@@ -485,11 +493,13 @@ initialize_clipboard_component_with_callback_data (GtkEditable *target,
     GtkActionGroup *action_group;
     TargetCallbackData *target_data;
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     action_group = gtk_action_group_new ("ClipboardActions");
     gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
     gtk_action_group_add_actions (action_group,
                                   clipboard_entries, G_N_ELEMENTS (clipboard_entries),
                                   target);
+    G_GNUC_END_IGNORE_DEPRECATIONS
 
     /* Do the actual connection of the UI to the container at
      * focus time, and disconnect at both focus and destroy

--- a/libcaja-private/caja-ui-utilities.c
+++ b/libcaja-private/caja-ui-utilities.c
@@ -61,8 +61,10 @@ caja_ui_prepare_merge_ui (GtkUIManager *ui_manager,
                           GtkActionGroup **action_group)
 {
     *merge_id = gtk_ui_manager_new_merge_id (ui_manager);
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     *action_group = gtk_action_group_new (name);
     gtk_action_group_set_translation_domain (*action_group, GETTEXT_PACKAGE);
+    G_GNUC_END_IGNORE_DEPRECATIONS
     gtk_ui_manager_insert_action_group (ui_manager, *action_group, 0);
     g_object_unref (*action_group); /* owned by ui manager */
 }
@@ -137,7 +139,9 @@ extension_action_sensitive_callback (CajaMenuItem *item,
                   "sensitive", &value,
                   NULL);
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     gtk_action_set_sensitive (GTK_ACTION (user_data), value);
+    G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 static cairo_surface_t *
@@ -180,10 +184,12 @@ caja_action_from_menu_item (CajaMenuItem *item,
                   "priority", &priority,
                   NULL);
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     action = gtk_action_new (name,
                              label,
                              tip,
                              icon_name);
+    G_GNUC_END_IGNORE_DEPRECATIONS
 
     if (icon_name != NULL)
     {
@@ -200,7 +206,9 @@ caja_action_from_menu_item (CajaMenuItem *item,
         }
     }
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     gtk_action_set_sensitive (action, sensitive);
+    G_GNUC_END_IGNORE_DEPRECATIONS
     g_object_set (action, "is-important", priority, NULL);
 
     g_signal_connect_data (action, "activate",
@@ -230,10 +238,12 @@ caja_toolbar_action_from_menu_item (CajaMenuItem *item, GtkWidget *parent_widget
                   "priority", &priority,
                   NULL);
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     action = gtk_action_new (name,
                              label,
                              tip,
                              icon_name);
+    G_GNUC_END_IGNORE_DEPRECATIONS
 
     if (icon_name != NULL)
     {
@@ -250,7 +260,9 @@ caja_toolbar_action_from_menu_item (CajaMenuItem *item, GtkWidget *parent_widget
         }
     }
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     gtk_action_set_sensitive (action, sensitive);
+    G_GNUC_END_IGNORE_DEPRECATIONS
     g_object_set (action, "is-important", priority, NULL);
 
     g_signal_connect_data (action, "activate",

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -726,23 +726,29 @@ real_update_menus (FMDirectoryView *view)
 
     /* New Launcher */
     disable_command_line = g_settings_get_boolean (mate_lockdown_preferences, CAJA_PREFERENCES_LOCKDOWN_COMMAND_LINE);
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     action = gtk_action_group_get_action (desktop_view->priv->desktop_action_group,
                                           FM_ACTION_NEW_LAUNCHER_DESKTOP);
     gtk_action_set_visible (action,
                             !disable_command_line);
+    G_GNUC_END_IGNORE_DEPRECATIONS
 
     /* Empty Trash */
     include_empty_trash = trash_link_is_selection (view);
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     action = gtk_action_group_get_action (desktop_view->priv->desktop_action_group,
                                           FM_ACTION_EMPTY_TRASH_CONDITIONAL);
     gtk_action_set_visible (action,
                             include_empty_trash);
+    G_GNUC_END_IGNORE_DEPRECATIONS
     if (include_empty_trash)
     {
         label = g_strdup (_("E_mpty Trash"));
         g_object_set (action , "label", label, NULL);
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         gtk_action_set_sensitive (action,
                                   !caja_trash_monitor_is_empty ());
+        G_GNUC_END_IGNORE_DEPRECATIONS
         g_free (label);
     }
 }
@@ -792,12 +798,15 @@ real_merge_menus (FMDirectoryView *view)
 
     ui_manager = fm_directory_view_get_ui_manager (view);
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     action_group = gtk_action_group_new ("DesktopViewActions");
     gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
     desktop_view->priv->desktop_action_group = action_group;
     gtk_action_group_add_actions (action_group,
                                   desktop_view_entries, G_N_ELEMENTS (desktop_view_entries),
                                   view);
+    G_GNUC_END_IGNORE_DEPRECATIONS
+
 
     gtk_ui_manager_insert_action_group (ui_manager, action_group, 0);
     g_object_unref (action_group); /* owned by ui manager */

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -995,6 +995,7 @@ trash_or_delete_selected_files (FMDirectoryView *view)
 static gboolean
 real_trash (FMDirectoryView *view)
 {
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	GtkAction *action;
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
@@ -1003,6 +1004,7 @@ real_trash (FMDirectoryView *view)
 	    gtk_action_get_visible (action)) {
 		trash_or_delete_selected_files (view);
 		return TRUE;
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	}
 	return FALSE;
 }
@@ -1066,6 +1068,7 @@ action_restore_from_trash_callback (GtkAction *action,
 static gboolean
 real_delete (FMDirectoryView *view)
 {
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	GtkAction *action;
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
@@ -1074,6 +1077,7 @@ real_delete (FMDirectoryView *view)
 	    gtk_action_get_visible (action)) {
 		delete_selected_files (view);
 		return TRUE;
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	}
 	return FALSE;
 }
@@ -4436,10 +4440,12 @@ add_submenu (GtkUIManager *ui_manager,
 		escaped_label = eel_str_double_underscores (label);
 
 		if (add_action) {
+			G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 			action = gtk_action_new (action_name,
 						 escaped_label,
 						 NULL,
 						 NULL);
+			G_GNUC_END_IGNORE_DEPRECATIONS
 			if (surface != NULL) {
 				g_object_set_data_full (G_OBJECT (action), "menu-icon",
 							cairo_surface_reference (surface),
@@ -4448,8 +4454,10 @@ add_submenu (GtkUIManager *ui_manager,
 
 			g_object_set (action, "hide-if-empty", FALSE, NULL);
 
+			G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 			gtk_action_group_add_action (action_group,
 						     action);
+			G_GNUC_END_IGNORE_DEPRECATIONS
 			g_object_unref (action);
 		}
 
@@ -4502,10 +4510,12 @@ add_application_to_open_with_menu (FMDirectoryView *view,
 
 	action_name = g_strdup_printf ("open_with_%d", index);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_new (action_name,
 				 label,
 				 tip,
 				 NULL);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	app_icon = g_app_info_get_icon (application);
 	if (app_icon != NULL) {
@@ -4514,7 +4524,9 @@ add_application_to_open_with_menu (FMDirectoryView *view,
 		app_icon = g_themed_icon_new ("application-x-executable");
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_set_gicon (action, app_icon);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_unref (app_icon);
 
 	g_signal_connect_data (action, "activate",
@@ -4522,8 +4534,10 @@ add_application_to_open_with_menu (FMDirectoryView *view,
 			       launch_parameters,
 			       (GClosureNotify)application_launch_parameters_free, 0);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_group_add_action (view->details->open_with_action_group,
 				     action);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_unref (action);
 
 	gtk_ui_manager_add_ui (caja_window_info_get_ui_manager (view->details->window),
@@ -4587,19 +4601,23 @@ add_parent_folder_to_open_menu (FMDirectoryView *view,
 	tip = g_strdup (_("Open parent location for the selected item"));
 	action_name = g_strdup ("open_location");
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_new (action_name,
 				 label,
 				 tip,
 				 NULL);
 
 	gtk_action_set_icon_name (action, "folder");
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	g_signal_connect_data (action, "activate",
 			       G_CALLBACK (open_parent_folder_callback),
 			       uri, (GClosureNotify)g_free, 0);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_group_add_action (view->details->open_with_action_group,
 				     action);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_unref (action);
 
 	gtk_ui_manager_add_ui (caja_window_info_get_ui_manager (view->details->window),
@@ -4789,6 +4807,7 @@ reset_open_with_menu (FMDirectoryView *view, GList *selection)
 	open_with_chooser_visible = other_applications_visible &&
 				    g_list_length (selection) == 1;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	if (submenu_visible) {
 		action = gtk_action_group_get_action (view->details->dir_action_group,
 						      FM_ACTION_OTHER_APPLICATION1);
@@ -4804,6 +4823,7 @@ reset_open_with_menu (FMDirectoryView *view, GList *selection)
 						      FM_ACTION_OTHER_APPLICATION2);
 		gtk_action_set_visible (action, open_with_chooser_visible);
 	}
+	G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 static GList *
@@ -4975,10 +4995,12 @@ add_extension_action_for_files (FMDirectoryView *view,
 		      "priority", &priority,
 		      NULL);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_new (name,
 				 label,
 				 tip,
 				 icon);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	if (icon != NULL) {
 		surface = get_menu_icon (icon, GTK_WIDGET (view));
@@ -4989,7 +5011,9 @@ add_extension_action_for_files (FMDirectoryView *view,
 		}
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_set_sensitive (action, sensitive);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_set (action, "is-important", priority, NULL);
 
 	data = g_new0 (ExtensionActionCallbackData, 1);
@@ -5003,8 +5027,10 @@ add_extension_action_for_files (FMDirectoryView *view,
 			       data,
 			       (GClosureNotify)extension_action_callback_data_free, 0);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_group_add_action (view->details->extensions_menu_action_group,
 				     GTK_ACTION (action));
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_unref (action);
 
 	g_free (name);
@@ -5039,6 +5065,7 @@ add_extension_menu_items (FMDirectoryView *view,
 		action = add_extension_action_for_files (view, item, files);
 
 		path = g_build_path ("/", FM_DIRECTORY_VIEW_POPUP_PATH_EXTENSION_ACTIONS, subdirectory, NULL);
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 		gtk_ui_manager_add_ui (ui_manager,
 				       view->details->extensions_menu_merge_id,
 				       path,
@@ -5056,6 +5083,7 @@ add_extension_menu_items (FMDirectoryView *view,
 				       gtk_action_get_name (action),
 				       (menu != NULL) ? GTK_UI_MANAGER_MENU : GTK_UI_MANAGER_MENUITEM,
 				       FALSE);
+		G_GNUC_END_IGNORE_DEPRECATIONS
 		g_free (path);
 
 		/* recursively fill the menu */
@@ -5065,7 +5093,9 @@ add_extension_menu_items (FMDirectoryView *view,
 
 			children = caja_menu_get_items (menu);
 
+			G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 			subdir = g_build_path ("/", subdirectory, gtk_action_get_name (action), NULL);
+			G_GNUC_END_IGNORE_DEPRECATIONS
 			add_extension_menu_items (view,
 						  files,
 						  children,
@@ -5443,10 +5473,12 @@ add_script_to_scripts_menus (FMDirectoryView *directory_view,
 	action_name = escape_action_name (uri, "script_");
 	escaped_label = eel_str_double_underscores (name);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_new (action_name,
 				 escaped_label,
 				 tip,
 				 NULL);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	surface = get_menu_icon_for_file (file, GTK_WIDGET (directory_view));
 	if (surface != NULL) {
@@ -5460,8 +5492,10 @@ add_script_to_scripts_menus (FMDirectoryView *directory_view,
 			       launch_parameters,
 			       (GClosureNotify)script_launch_parameters_free, 0);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_group_add_action_with_accel (directory_view->details->scripts_action_group,
 						action, NULL);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_unref (action);
 
 	ui_manager = caja_window_info_get_ui_manager (directory_view->details->window);
@@ -5654,8 +5688,10 @@ update_scripts_menu (FMDirectoryView *view)
 	}
 	caja_directory_list_free (sorted_copy);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group, FM_ACTION_SCRIPTS);
 	gtk_action_set_visible (action, any_scripts);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 static void
@@ -5694,10 +5730,12 @@ add_template_to_templates_menus (FMDirectoryView *directory_view,
 
 	parameters = create_template_parameters_new (file, directory_view);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_new (action_name,
 				 escaped_label,
 				 tip,
 				 NULL);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	surface = get_menu_icon_for_file (file, GTK_WIDGET (directory_view));
 	if (surface != NULL) {
@@ -5711,8 +5749,10 @@ add_template_to_templates_menus (FMDirectoryView *directory_view,
 			       parameters,
 			       (GClosureNotify)create_templates_parameters_free, 0);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_group_add_action (directory_view->details->templates_action_group,
 				     action);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_unref (action);
 
 	ui_manager = caja_window_info_get_ui_manager (directory_view->details->window);
@@ -5919,8 +5959,10 @@ update_templates_menu (FMDirectoryView *view)
 	}
 	caja_directory_list_free (sorted_copy);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group, FM_ACTION_NO_TEMPLATES);
 	gtk_action_set_visible (action, !any_templates);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	g_free (templates_directory_uri);
 }
@@ -7634,9 +7676,11 @@ connect_proxy (FMDirectoryView *view,
 	cairo_surface_t *surface;
 	GtkWidget *image;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	if (strcmp (gtk_action_get_name (action), FM_ACTION_NEW_EMPTY_FILE) == 0 &&
 	    GTK_IS_IMAGE_MENU_ITEM (proxy)) {
 		surface = get_menu_icon ("text-x-generic", GTK_WIDGET (view));
+	G_GNUC_END_IGNORE_DEPRECATIONS
 		if (surface != NULL) {
 			image = gtk_image_new_from_surface (surface);
 			gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (proxy), image);
@@ -7693,15 +7737,18 @@ real_merge_menus (FMDirectoryView *view)
 
 	ui_manager = caja_window_info_get_ui_manager (view->details->window);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action_group = gtk_action_group_new ("DirViewActions");
 	gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
 	view->details->dir_action_group = action_group;
 	gtk_action_group_add_actions (action_group,
 				      directory_view_entries, G_N_ELEMENTS (directory_view_entries),
 				      view);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	/* Translators: %s is a directory */
 	tooltip = g_strdup_printf(_("Run or manage scripts from %s"), "~/.config/caja/scripts");
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	/* Create a script action here specially because its tooltip is dynamic */
 	action = gtk_action_new ("Scripts", _("_Scripts"), tooltip, NULL);
 	gtk_action_group_add_action (action_group, action);
@@ -7710,6 +7757,7 @@ real_merge_menus (FMDirectoryView *view)
 
 	action = gtk_action_group_get_action (action_group, FM_ACTION_NO_TEMPLATES);
 	gtk_action_set_sensitive (action, FALSE);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	g_signal_connect_object (action_group, "connect-proxy",
 				 G_CALLBACK (connect_proxy), G_OBJECT (view),
@@ -7798,6 +7846,7 @@ clipboard_targets_received (GtkClipboard     *clipboard,
 	selection = fm_directory_view_get_selection (view);
 	count = g_list_length (selection);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_PASTE);
 	gtk_action_set_sensitive (action,
@@ -7811,14 +7860,17 @@ clipboard_targets_received (GtkClipboard     *clipboard,
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_PASTE_FILES_INTO);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_set_data (G_OBJECT (action),
 			   "can-paste-according-to-clipboard",
 			   GINT_TO_POINTER (can_paste));
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_set_sensitive (action,
 				  GPOINTER_TO_INT (g_object_get_data (G_OBJECT (action),
 						   "can-paste-according-to-clipboard")) &&
 				  GPOINTER_TO_INT (g_object_get_data (G_OBJECT (action),
 						   "can-paste-according-to-destination")));
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	caja_file_list_free (selection);
 
@@ -8093,7 +8145,9 @@ update_restore_from_trash_action (GtkAction *action,
 	}
 
 	if (original_file != NULL || original_dirs != NULL) {
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 		gtk_action_set_visible (action, TRUE);
+		G_GNUC_END_IGNORE_DEPRECATIONS
 
 		if (original_file != NULL) {
 			original_location = caja_file_get_location (original_file);
@@ -8148,7 +8202,9 @@ update_restore_from_trash_action (GtkAction *action,
 			g_object_unref (original_location);
 		}
 	} else {
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 		gtk_action_set_visible (action, FALSE);
+		G_GNUC_END_IGNORE_DEPRECATIONS
 	}
 
 	caja_file_unref (original_file);
@@ -8233,6 +8289,7 @@ real_update_menus_volumes (FMDirectoryView *view,
 		show_poll &= show_poll_one;
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_CONNECT_TO_SERVER_LINK);
 	gtk_action_set_visible (action, show_connect);
@@ -8314,6 +8371,7 @@ real_update_menus_volumes (FMDirectoryView *view,
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_POLL);
 	gtk_action_set_visible (action, show_poll);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	show_self_mount = show_self_unmount = show_self_eject =
 		show_self_format = show_self_start = show_self_stop = show_self_poll = FALSE;
@@ -8329,6 +8387,7 @@ real_update_menus_volumes (FMDirectoryView *view,
 			       &show_self_poll,
 			       &self_start_stop_type);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_SELF_MOUNT_VOLUME);
 	gtk_action_set_visible (action, show_self_mount);
@@ -8406,6 +8465,7 @@ real_update_menus_volumes (FMDirectoryView *view,
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_SELF_POLL);
 	gtk_action_set_visible (action, show_self_poll);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 }
 
@@ -8439,6 +8499,7 @@ real_update_location_menu_volumes (FMDirectoryView *view)
 				  &show_poll,
 				  &start_stop_type);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_MOUNT_VOLUME);
 	gtk_action_set_visible (action, show_mount);
@@ -8516,6 +8577,7 @@ real_update_location_menu_volumes (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_POLL);
 	gtk_action_set_visible (action, show_poll);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 /* TODO: we should split out this routine into two functions:
@@ -8541,6 +8603,7 @@ real_update_paste_menu (FMDirectoryView *view,
 	can_paste_files_into = (selection_count == 1 &&
 	                        can_paste_into_file (CAJA_FILE (selection->data)));
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_PASTE);
 	gtk_action_set_sensitive (action, !is_read_only);
@@ -8549,6 +8612,7 @@ real_update_paste_menu (FMDirectoryView *view,
 					      FM_ACTION_PASTE_FILES_INTO);
 	gtk_action_set_visible (action, can_paste_files_into);
 	gtk_action_set_sensitive (action, !selection_is_read_only);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	/* Ask the clipboard */
 	g_object_ref (view); /* Need to keep the object alive until we get the reply */
@@ -8588,6 +8652,7 @@ real_update_location_menu (FMDirectoryView *view)
 		label = g_strdup (ngettext ("_Browse Folder",
 					    "_Browse Folders", 1));
 	}
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_OPEN_ALTERNATE);
 	g_object_set (action,
@@ -8597,6 +8662,7 @@ real_update_location_menu (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_OPEN_IN_NEW_TAB);
 	gtk_action_set_visible (action, show_open_in_new_tab);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	if (show_open_in_new_tab) {
 		if (g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_ALWAYS_USE_BROWSER)) {
@@ -8609,9 +8675,11 @@ real_update_location_menu (FMDirectoryView *view)
 			      NULL);
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_OPEN_FOLDER_WINDOW);
 	gtk_action_set_visible (action, show_open_folder_window);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	file = view->details->location_popup_directory_as_file;
 	g_assert (CAJA_IS_FILE (file));
@@ -8628,20 +8696,24 @@ real_update_location_menu (FMDirectoryView *view)
 		!is_special_link &&
 		!is_desktop_or_home_dir;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_CUT);
 	gtk_action_set_sensitive (action, can_delete_file);
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_PASTE_FILES_INTO);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_set_data (G_OBJECT (action),
 			   "can-paste-according-to-destination",
 			   GINT_TO_POINTER (can_paste_into_file (file)));
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_set_sensitive (action,
 				  GPOINTER_TO_INT (g_object_get_data (G_OBJECT (action),
 						   "can-paste-according-to-clipboard")) &&
 				  GPOINTER_TO_INT (g_object_get_data (G_OBJECT (action),
 						   "can-paste-according-to-destination")));
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	show_delete = TRUE;
 
@@ -8660,6 +8732,7 @@ real_update_location_menu (FMDirectoryView *view)
 		show_separate_delete_command = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_ENABLE_DELETE);
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_TRASH);
 	g_object_set (action,
@@ -8685,6 +8758,7 @@ real_update_location_menu (FMDirectoryView *view)
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_RESTORE_FROM_TRASH);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	l.prev = NULL;
 	l.next = NULL;
 	l.data = file;
@@ -8793,6 +8867,7 @@ real_update_menus (FMDirectoryView *view)
 
 	vfolder_directory = we_are_in_vfolder_desktop_dir (view);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_RENAME);
 	gtk_action_set_sensitive (action,
@@ -8806,6 +8881,7 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_OPEN);
 	gtk_action_set_sensitive (action, selection_count != 0);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	can_open = show_app = selection_count != 0;
 
@@ -8879,10 +8955,12 @@ real_update_menus (FMDirectoryView *view)
 		app_icon = g_themed_icon_new ("document-open");
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_set_gicon (action, app_icon);
 	g_object_unref (app_icon);
 
 	gtk_action_set_visible (action, can_open);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	g_free (label_with_underscore);
 
@@ -8918,6 +8996,7 @@ real_update_menus (FMDirectoryView *view)
 							    selection_count));
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_OPEN_ALTERNATE);
 	g_object_set (action, "label",
@@ -8927,6 +9006,7 @@ real_update_menus (FMDirectoryView *view)
 
 	gtk_action_set_sensitive (action,  selection_count != 0);
 	gtk_action_set_visible (action, show_open_alternate);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	/* Open in New Tab action */
 	if (caja_window_info_get_window_type (view->details->window) == CAJA_WINDOW_NAVIGATION) {
@@ -8950,6 +9030,7 @@ real_update_menus (FMDirectoryView *view)
 									 selection_count);
 			}
 		}
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 		action = gtk_action_group_get_action (view->details->dir_action_group,
 						      FM_ACTION_OPEN_IN_NEW_TAB);
 		gtk_action_set_sensitive (action, selection_count != 0);
@@ -8962,10 +9043,12 @@ real_update_menus (FMDirectoryView *view)
 		action = gtk_action_group_get_action (view->details->dir_action_group,
 						      FM_ACTION_OPEN_IN_NEW_TAB);
 		gtk_action_set_visible (action, FALSE);
+		G_GNUC_END_IGNORE_DEPRECATIONS
 	}
 
 	/* next pane actions, only in navigation mode */
 	if (caja_window_info_get_window_type (view->details->window) != CAJA_WINDOW_NAVIGATION) {
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 		action = gtk_action_group_get_action (view->details->dir_action_group,
 						      FM_ACTION_COPY_TO_NEXT_PANE);
 		gtk_action_set_visible (action, FALSE);
@@ -8977,6 +9060,7 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_OPEN_FOLDER_WINDOW);
 	gtk_action_set_visible (action, show_open_folder_window);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	/* Broken into its own function just for convenience */
 	reset_open_with_menu (view, selection);
@@ -8992,6 +9076,7 @@ real_update_menus (FMDirectoryView *view)
 		show_separate_delete_command = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_ENABLE_DELETE);
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_TRASH);
 	g_object_set (action,
@@ -9017,8 +9102,10 @@ real_update_menus (FMDirectoryView *view)
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_RESTORE_FROM_TRASH);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	update_restore_from_trash_action (action, selection, FALSE);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_DUPLICATE);
 	gtk_action_set_sensitive (action, can_duplicate_files);
@@ -9026,6 +9113,7 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_CREATE_LINK);
 	gtk_action_set_sensitive (action, can_link_files);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	g_object_set (action, "label",
 		      ngettext ("Ma_ke Link",
 			      	"Ma_ke Links",
@@ -9035,6 +9123,7 @@ real_update_menus (FMDirectoryView *view)
 	show_properties = (!FM_IS_DESKTOP_ICON_VIEW (view) || selection_count > 0) &&
 			   fm_directory_view_supports_properties (view);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_PROPERTIES);
 
@@ -9060,6 +9149,7 @@ real_update_menus (FMDirectoryView *view)
 		      NULL);
 	gtk_action_set_sensitive (action, !caja_trash_monitor_is_empty ());
 	gtk_action_set_visible (action, should_show_empty_trash (view));
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	show_save_search = FALSE;
 	save_search_sensitive = FALSE;
@@ -9076,6 +9166,7 @@ real_update_menus (FMDirectoryView *view)
 			show_save_search_as = TRUE;
 		}
 	}
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_SAVE_SEARCH);
 	gtk_action_set_visible (action, show_save_search);
@@ -9104,14 +9195,17 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_COPY);
 	gtk_action_set_sensitive (action, can_copy_files);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	real_update_paste_menu (view, selection, selection_count);
 
 	disable_command_line = g_settings_get_boolean (mate_lockdown_preferences, CAJA_PREFERENCES_LOCKDOWN_COMMAND_LINE);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_NEW_LAUNCHER);
 	gtk_action_set_visible (action, vfolder_directory && !disable_command_line);
 	gtk_action_set_sensitive (action, can_create_files);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	real_update_menus_volumes (view, selection, selection_count);
 
@@ -9123,9 +9217,11 @@ real_update_menus (FMDirectoryView *view)
 		update_scripts_menu (view);
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_NEW_DOCUMENTS);
 	gtk_action_set_sensitive (action, can_create_files);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 
 	if (can_create_files && view->details->templates_invalid) {
 		update_templates_menu (view);
@@ -9133,6 +9229,7 @@ real_update_menus (FMDirectoryView *view)
 
 	next_pane_is_writable = has_writable_extra_pane (view);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	/* next pane: works if file is copyable, and next pane is writable */
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_COPY_TO_NEXT_PANE);
@@ -9164,6 +9261,7 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      "MoveToMenu");
 	gtk_action_set_sensitive (action, can_delete_files);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 /**
@@ -11189,9 +11287,11 @@ undo_update_menu (FMDirectoryView *view)
 	gchar* label;
 	gchar* tooltip;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	/* Update undo entry */
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_UNDO);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	available = view->details->undo_active;
 	if (available) {
 		label = view->details->undo_action_label;
@@ -11205,11 +11305,13 @@ undo_update_menu (FMDirectoryView *view)
 		      "label", label,
 		      "tooltip", tooltip,
 		      NULL);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_set_sensitive (action, available);
 
-    /* Update redo entry */
-    action = gtk_action_group_get_action (view->details->dir_action_group,
-					      FM_ACTION_REDO);
+	/* Update redo entry */
+	action = gtk_action_group_get_action (view->details->dir_action_group,
+                                          FM_ACTION_REDO);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 	available = view->details->redo_active;
 	if (available) {
 		label = view->details->redo_action_label;
@@ -11223,5 +11325,7 @@ undo_update_menu (FMDirectoryView *view)
 		      "label", label,
 		      "tooltip", tooltip,
 		      NULL);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 	gtk_action_set_sensitive (action, available);
+	G_GNUC_END_IGNORE_DEPRECATIONS
 }


### PR DESCRIPTION
This suppress noise from Gtk_Action and GtkUIManager in build logs and make them readable.
Gtk_Action and GtkUIManager can't be replace without loosing our icons.
So this have to be stay until we switch to GTK4, if we really do that.
Please review.