### PR TITLE
desktop icon view: disconnect callback from correct GSettings instance

### DIFF
--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -287,7 +287,7 @@ fm_desktop_icon_view_dispose (GObject *object)
     g_signal_handlers_disconnect_by_func (caja_icon_view_preferences,
                                           default_zoom_level_changed,
                                           icon_view);
-    g_signal_handlers_disconnect_by_func (caja_preferences,
+    g_signal_handlers_disconnect_by_func (caja_desktop_preferences,
                                           font_changed_callback,
                                           icon_view);
 


### PR DESCRIPTION
Taken from https://github.com/linuxmint/nemo/commit/89090ac192638d75359876d917b6d3ce106196af. It's a fix for a random crash which can be probably triggered by changing the desktop font while the desktop icon view is being deleted... I only saw a report about it on Launchpad ([here](https://bugs.launchpad.net/bugs/1598262)). In other words, if nobody can reproduce the crash, just check that things work as before :slightly_smiling_face: 