### PR TITLE
eel-canvas: cppcheck: Local variable 'allocation' shadows outer variable

### DIFF
--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -3294,7 +3294,6 @@ eel_canvas_set_pixels_per_unit (EelCanvas *canvas, double n)
     window = NULL;
     if (gtk_widget_get_mapped (widget))
     {
-        GtkAllocation allocation;
         attributes.window_type = GDK_WINDOW_CHILD;
         gtk_widget_get_allocation (widget, &allocation);
         attributes.x = allocation.x;


### PR DESCRIPTION
Fixes `cppcheck` warning:

`[eel/eel-canvas.c:3261] -> [eel/eel-canvas.c:3297]: (style) Local variable allocation shadows outer variable`