### PR TITLE
caja-open-with-dialog: cppcheck: Redundant condition

### DIFF
--- a/libcaja-private/caja-open-with-dialog.c
+++ b/libcaja-private/caja-open-with-dialog.c
@@ -263,8 +263,7 @@ add_or_find_application (CajaOpenWithDialog *dialog)
     }
 
     should_set_default = (dialog->details->add_mode) ||
-                         (!dialog->details->add_mode &&
-                          gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (dialog->details->checkbox)));
+                          gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (dialog->details->checkbox));
     success = TRUE;
 
     if (should_set_default)


### PR DESCRIPTION
Fixes `cppcheck` warning:

`[libcaja-private/caja-open-with-dialog.c:265]: (style) Redundant condition: !dialog->details->add_mode. 'A || (!A && B)' is equivalent to 'A || B'`