### PR TITLE
src: reduce the scope of some variables

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -136,12 +136,13 @@ static void
 automount_all_volumes (CajaApplication *application)
 {
     GList *volumes, *l;
-    GMount *mount;
-    GVolume *volume;
 
     if (g_settings_get_boolean (caja_media_preferences, CAJA_PREFERENCES_MEDIA_AUTOMOUNT))
     {
         /* automount all mountable volumes at start-up */
+
+        GVolume *volume = NULL;
+        GMount *mount = NULL;
 
         volumes = g_volume_monitor_get_volumes (application->priv->volume_monitor);
 
@@ -690,7 +691,6 @@ static void
 caja_application_create_desktop_windows (CajaApplication *application)
 {
     GdkDisplay *display;
-    CajaDesktopWindow *window;
     GtkWidget *selection_widget;
 
     g_return_if_fail (caja_application_desktop_windows == NULL);
@@ -698,8 +698,11 @@ caja_application_create_desktop_windows (CajaApplication *application)
     display = gdk_display_get_default ();
 
     selection_widget = get_desktop_manager_selection (display);
+
     if (selection_widget != NULL)
     {
+        CajaDesktopWindow *window;
+
         window = caja_desktop_window_new (application, gdk_display_get_default_screen (display));
 
         g_signal_connect (selection_widget, "selection_clear_event",
@@ -777,7 +780,7 @@ caja_application_get_existing_spatial_window (GFile *location)
 {
     GList *l;
     CajaWindowSlot *slot;
-    GFile *window_location;
+    GFile *window_location = NULL;
 
     for (l = caja_application_get_spatial_window_list ();
             l != NULL; l = l->next) {
@@ -1147,13 +1150,15 @@ drive_eject_cb (GObject *source_object,
                 gpointer user_data)
 {
     GError *error;
-    char *primary;
-    char *name;
     error = NULL;
+
     if (!g_drive_eject_with_operation_finish (G_DRIVE (source_object), res, &error))
     {
         if (error->code != G_IO_ERROR_FAILED_HANDLED)
         {
+            char *primary;
+            char *name;
+
             name = g_drive_get_name (G_DRIVE (source_object));
             primary = g_strdup_printf (_("Unable to eject %s"), name);
             g_free (name);
@@ -1429,9 +1434,10 @@ caja_application_get_session_data (CajaApplication *self)
     for (l = window_list; l != NULL; l = l->next) {
         xmlNodePtr win_node, slot_node;
         CajaWindow *window;
-        CajaWindowSlot *slot, *active_slot;
         GList *slots, *m;
         char *tmp;
+        CajaWindowSlot *active_slot;
+        CajaWindowSlot *slot = NULL;
 
         window = l->data;
 
@@ -1621,10 +1627,9 @@ caja_application_load_session (CajaApplication *application)
 
             {
                 CajaWindow *window;
-                xmlChar *type, *location_uri, *slot_uri;
+                xmlChar *type, *location_uri;
                 xmlNodePtr slot_node;
                 GFile *location;
-                int i;
 
                 type = xmlGetProp (node, "type");
                 if (type == NULL)
@@ -1646,6 +1651,8 @@ caja_application_load_session (CajaApplication *application)
                 if (g_strcmp0 (type, "navigation") == 0)
                 {
                     xmlChar *geometry;
+                    int i;
+
                     window = caja_application_create_navigation_window (application, gdk_screen_get_default ());
                     geometry = xmlGetProp (node, "geometry");
                     if (geometry != NULL)
@@ -1690,6 +1697,8 @@ caja_application_load_session (CajaApplication *application)
                     {
                         if (g_strcmp0 (slot_node->name, "slot") == 0)
                         {
+                            xmlChar *slot_uri;
+
                             slot_uri = xmlGetProp (slot_node, "location");
                             if (slot_uri != NULL)
                             {
@@ -1965,8 +1974,8 @@ caja_application_local_command_line (GApplication *application,
 
     /* Convert args to GFiles */
     if (remaining != NULL) {
-        GFile *file;
         GPtrArray *file_array;
+        GFile *file = NULL;
 
         file_array = g_ptr_array_new ();
 
@@ -2135,7 +2144,6 @@ static void
 caja_application_startup (GApplication *app)
 {
     CajaApplication *self = CAJA_APPLICATION (app);
-    GApplication *instance;
     gboolean exit_with_last_window;
     exit_with_last_window = TRUE;
 
@@ -2224,6 +2232,8 @@ caja_application_startup (GApplication *app)
 
     if (running_in_mate () && !running_as_root())
     {
+        GApplication *instance;
+
         exit_with_last_window = g_settings_get_boolean (caja_preferences,   
                                 CAJA_PREFERENCES_EXIT_WITH_LAST_WINDOW);
         /*Keep this inside the running as mate/not as root block */

--- a/src/caja-bookmark-list.c
+++ b/src/caja-bookmark-list.c
@@ -60,9 +60,7 @@ static CajaBookmark *
 new_bookmark_from_uri (const char *uri, const char *label)
 {
     CajaBookmark *new_bookmark;
-    CajaFile *file;
     char *name;
-    GIcon *icon;
     gboolean has_label;
     GFile *location;
     gboolean native;
@@ -88,10 +86,14 @@ new_bookmark_from_uri (const char *uri, const char *label)
 
     if (uri)
     {
+        CajaFile *file;
+        GIcon *icon;
+
         native = g_file_is_native (location);
         file = caja_file_get (location);
 
         icon = NULL;
+
         if (caja_file_check_if_ready (file,
                                       CAJA_FILE_ATTRIBUTES_FOR_ICON))
         {
@@ -417,7 +419,6 @@ caja_bookmark_list_delete_items_with_uri (CajaBookmarkList *bookmarks,
 {
     GList *node, *next;
     gboolean list_changed;
-    char *bookmark_uri;
 
     g_return_if_fail (CAJA_IS_BOOKMARK_LIST (bookmarks));
     g_return_if_fail (uri != NULL);
@@ -425,6 +426,8 @@ caja_bookmark_list_delete_items_with_uri (CajaBookmarkList *bookmarks,
     list_changed = FALSE;
     for (node = bookmarks->list; node != NULL;  node = next)
     {
+        char *bookmark_uri;
+
         next = node->next;
 
         bookmark_uri = caja_bookmark_get_uri (CAJA_BOOKMARK (node->data));

--- a/src/caja-bookmarks-window.c
+++ b/src/caja-bookmarks-window.c
@@ -684,7 +684,7 @@ on_row_changed (GtkListStore *store,
                 GtkTreeIter *iter,
                 gpointer user_data)
 {
-    CajaBookmark *bookmark = NULL, *bookmark_in_list;
+    CajaBookmark *bookmark = NULL;
     gint *indices, row;
     gboolean insert_bookmark = TRUE;
 
@@ -700,8 +700,11 @@ on_row_changed (GtkListStore *store,
        have been dragged here, so we insert it into the list. */
     if (row < (gint) caja_bookmark_list_length (bookmarks))
     {
+        CajaBookmark *bookmark_in_list;
+
         bookmark_in_list = caja_bookmark_list_item_at (bookmarks,
                            row);
+
         if (bookmark_in_list == bookmark)
             insert_bookmark = FALSE;
     }
@@ -796,7 +799,6 @@ on_selection_changed (GtkTreeSelection *treeselection,
 {
     CajaBookmark *selected;
     char *name = NULL, *entry_text = NULL;
-    GFile *location;
 
     g_assert (GTK_IS_ENTRY (name_field));
     g_assert (GTK_IS_ENTRY (uri_field));
@@ -805,6 +807,8 @@ on_selection_changed (GtkTreeSelection *treeselection,
 
     if (selected)
     {
+        GFile *location;
+
         name = caja_bookmark_get_name (selected);
         location = caja_bookmark_get_location (selected);
         entry_text = g_file_get_parse_name (location);
@@ -978,9 +982,9 @@ repopulate (void)
 {
     CajaBookmark *selected;
     GtkListStore *store;
-    GtkTreePath *path;
     GtkTreeRowReference *reference;
     guint index;
+    GtkTreePath *path = NULL;
 
     g_assert (GTK_IS_TREE_VIEW (bookmark_list_widget));
     g_assert (CAJA_IS_BOOKMARK_LIST (bookmarks));

--- a/src/caja-connect-server-dialog.c
+++ b/src/caja-connect-server-dialog.c
@@ -944,7 +944,6 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
     {
         GtkTreeIter iter;
         const gchar * const *supported;
-        int j;
 
 		/* skip methods that don't have corresponding gvfs uri schemes */
         supported = g_vfs_get_supported_uri_schemes (g_vfs_get_default ());
@@ -952,6 +951,7 @@ caja_connect_server_dialog_init (CajaConnectServerDialog *dialog)
         if (methods[i].scheme != NULL)
         {
             gboolean found;
+            int j;
 
             found = FALSE;
             for (j = 0; supported[j] != NULL; j++)

--- a/src/caja-emblem-sidebar.c
+++ b/src/caja-emblem-sidebar.c
@@ -215,14 +215,14 @@ static void
 caja_emblem_sidebar_delete_cb (GtkWidget *menu_item,
                                CajaEmblemSidebar *emblem_sidebar)
 {
-    char *error;
-
     if (caja_emblem_remove_emblem (emblem_sidebar->details->popup_emblem_keyword))
     {
         send_emblems_changed ();
     }
     else
     {
+        char *error;
+
         error = g_strdup_printf (_("Could not remove emblem with name '%s'."), emblem_sidebar->details->popup_emblem_display_name);
         eel_show_error_dialog (error, _("This is probably because the emblem is a permanent one, and not one that you added yourself."),
                                NULL);
@@ -235,7 +235,7 @@ rename_dialog_response_cb (GtkWidget *dialog, int response,
                            CajaEmblemSidebar *emblem_sidebar)
 {
     GtkWidget *entry;
-    char *keyword, *name, *error;
+    char *keyword, *name;
 
     keyword = g_object_get_data (G_OBJECT (dialog), "emblem-keyword");
 
@@ -263,6 +263,8 @@ rename_dialog_response_cb (GtkWidget *dialog, int response,
     }
     else
     {
+        char *error;
+
         error = g_strdup_printf (_("Could not rename emblem with name '%s'."), name);
         eel_show_error_dialog (error, _("This is probably because the emblem is a permanent one, and not one that you added yourself."),
                                NULL);
@@ -532,11 +534,13 @@ static GtkWidget *
 create_add_emblems_dialog (CajaEmblemSidebar *emblem_sidebar,
                            GSList *emblems)
 {
-    GtkWidget *dialog, *label, *table, *image;
-    GtkWidget *first_entry, *entry, *scroller, *hbox;
-    Emblem *emblem;
+    GtkWidget *dialog, *label, *table;
+    GtkWidget *first_entry, *entry, *scroller;
     GSList *list;
     int num_emblems;
+    GtkWidget *image = NULL;
+    GtkWidget *hbox = NULL;
+    Emblem *emblem = NULL;
 
     first_entry = NULL;
 
@@ -750,7 +754,7 @@ caja_emblem_sidebar_drag_received_cb (GtkWidget *widget,
     GSList *emblems;
     Emblem *emblem;
     GdkPixbuf *pixbuf;
-    char *uri, *error, *uri_utf8;
+    char *uri, *error;
     char **uris;
     GFile *f;
     int i;
@@ -854,6 +858,8 @@ caja_emblem_sidebar_drag_received_cb (GtkWidget *widget,
         }
         else
         {
+            char *uri_utf8;
+
             uri_utf8 = g_file_get_parse_name (f);
 
             if (uri_utf8)
@@ -975,7 +981,6 @@ caja_emblem_sidebar_populate (CajaEmblemSidebar *emblem_sidebar)
 {
     GList *icons, *l, *widgets;
     GtkWidget *emblem_widget;
-    char *name;
     char *path;
     GdkPixbuf *erase_pixbuf;
 
@@ -1006,6 +1011,8 @@ caja_emblem_sidebar_populate (CajaEmblemSidebar *emblem_sidebar)
     widgets = NULL;
     while (l != NULL)
     {
+        char *name;
+
         name = (char *)l->data;
         l = l->next;
 

--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -201,13 +201,14 @@ caja_file_management_properties_size_group_create (GtkBuilder *builder,
 {
     GtkSizeGroup *size_group;
     int i;
-    char *item_name;
-    GtkWidget *widget;
+    GtkWidget *widget = NULL;
 
     size_group = gtk_size_group_new (GTK_SIZE_GROUP_HORIZONTAL);
 
     for (i = 0; i < items; i++)
     {
+        char *item_name;
+
         item_name = g_strdup_printf ("%s_%d", prefix, i);
         widget = GTK_WIDGET (gtk_builder_get_object (builder, item_name));
         gtk_size_group_add_widget (size_group, widget);
@@ -222,7 +223,6 @@ preferences_show_help (GtkWindow *parent,
                        char const *sect_id)
 {
     GError *error = NULL;
-    GtkWidget *dialog;
     char *help_string;
 
     g_assert (helpfile != NULL);
@@ -237,6 +237,8 @@ preferences_show_help (GtkWindow *parent,
 
     if (error)
     {
+        GtkWidget *dialog;
+
         dialog = gtk_message_dialog_new (GTK_WINDOW (parent),
                                          GTK_DIALOG_DESTROY_WITH_PARENT,
                                          GTK_MESSAGE_ERROR,
@@ -259,10 +261,10 @@ caja_file_management_properties_dialog_response_cb (GtkDialog *parent,
         int response_id,
         GtkBuilder *builder)
 {
-    char *section;
-
     if (response_id == GTK_RESPONSE_HELP)
     {
+        char *section;
+
         switch (gtk_notebook_get_current_page (GTK_NOTEBOOK (gtk_builder_get_object (builder, "notebook1"))))
         {
         default:
@@ -1109,8 +1111,8 @@ bind_builder_radio (GtkBuilder *builder,
             const char *prefs,
             const char **values)
 {
-    GtkWidget *button;
     int i;
+    GtkWidget *button = NULL;
 
     for (i = 0; widget_names[i] != NULL; i++) {
         button = GTK_WIDGET (gtk_builder_get_object (builder, widget_names[i]));

--- a/src/caja-freedesktop-dbus.c
+++ b/src/caja-freedesktop-dbus.c
@@ -122,7 +122,6 @@ skeleton_handle_show_item_properties_cb (CajaFreedesktopFileManager1 *object,
                      CajaFreedesktopDBus *fdb)
 {
     CajaApplication *application;
-    CajaWindow *window;
     GList *files;
     int i;
 
@@ -137,6 +136,8 @@ skeleton_handle_show_item_properties_cb (CajaFreedesktopFileManager1 *object,
 
     if (uris[0] != NULL) {
         GFile *file;
+        CajaWindow *window;
+
         file = g_file_new_for_uri (uris[i]);
         window = caja_application_get_spatial_window (application,
                                                       NULL,

--- a/src/caja-history-sidebar.c
+++ b/src/caja-history-sidebar.c
@@ -92,11 +92,10 @@ update_history (CajaHistorySidebar *sidebar)
 {
     GtkListStore         *store;
     GtkTreeSelection     *selection;
-    CajaBookmark         *bookmark;
-    cairo_surface_t      *surface;
     GtkTreeIter           iter;
-    char *name;
     GList *l, *history;
+    CajaBookmark         *bookmark = NULL;
+    cairo_surface_t      *surface = NULL;
 
     store = GTK_LIST_STORE (gtk_tree_view_get_model (sidebar->tree_view));
 
@@ -105,6 +104,8 @@ update_history (CajaHistorySidebar *sidebar)
     history = caja_window_info_get_history (sidebar->window);
     for (l = history; l != NULL; l = l->next)
     {
+        char *name;
+
         bookmark = caja_bookmark_copy (l->data);
 
         surface = caja_bookmark_get_surface (bookmark, GTK_ICON_SIZE_MENU);

--- a/src/caja-image-properties-page.c
+++ b/src/caja-image-properties-page.c
@@ -378,9 +378,6 @@ append_xmpdata_string (XmpPtr xmp, CajaImagePropertiesPage *page)
 static void
 load_finished (CajaImagePropertiesPage *page)
 {
-    GdkPixbufFormat *format;
-    char *name, *desc;
-
     gtk_widget_destroy (page->details->loading_label);
 
     if (page->details->loader != NULL) {
@@ -389,6 +386,8 @@ load_finished (CajaImagePropertiesPage *page)
 
     if (page->details->got_size)
     {
+        GdkPixbufFormat *format;
+        char *name, *desc;
 #ifdef HAVE_EXIF
         ExifData *exif_data;
 #endif /*HAVE_EXIF*/
@@ -461,7 +460,6 @@ file_read_callback (GObject      *object,
     GInputStream *stream;
     gssize count_read;
     GError *error;
-    int exif_still_loading;
     gboolean done_reading;
 
     page = CAJA_IMAGE_PROPERTIES_PAGE (data);
@@ -473,6 +471,7 @@ file_read_callback (GObject      *object,
 
     if (count_read > 0)
     {
+        int exif_still_loading;
 
         g_assert (count_read <= sizeof(page->details->buffer));
 

--- a/src/caja-information-panel.c
+++ b/src/caja-information-panel.c
@@ -485,7 +485,6 @@ receive_dropped_uri_list (CajaInformationPanel *information_panel,
     char **uris;
     gboolean exactly_one;
     GtkWindow *window;
-    EelBackground *background;
 
     uris = g_uri_list_extract_uris ((gchar *) gtk_selection_data_get_data (selection_data));
     exactly_one = uris[0] != NULL && (uris[1] == NULL || uris[1][0] == '\0');
@@ -508,6 +507,8 @@ receive_dropped_uri_list (CajaInformationPanel *information_panel,
 
             if (action > 0)
             {
+                EelBackground *background;
+
                 background = eel_get_widget_background (GTK_WIDGET (information_panel));
                 eel_background_set_dropped_image (background, action, uris[0]);
             }
@@ -579,7 +580,6 @@ receive_dropped_color (CajaInformationPanel *information_panel,
 {
     guint16 *channels;
     char color_spec[8];
-    EelBackground *background;
 
     if (gtk_selection_data_get_length (selection_data) != 8 ||
             gtk_selection_data_get_format (selection_data) != 16)
@@ -607,6 +607,8 @@ receive_dropped_color (CajaInformationPanel *information_panel,
 
         if (action > 0)
         {
+            EelBackground *background;
+
             background = eel_get_widget_background (GTK_WIDGET (information_panel));
             eel_background_set_dropped_color (background, GTK_WIDGET (information_panel),
                                               action, x, y, selection_data);
@@ -679,7 +681,6 @@ static gboolean
 caja_information_panel_press_event (GtkWidget *widget, GdkEventButton *event)
 {
     CajaInformationPanel *information_panel;
-    GtkWidget *menu;
 
     if (gtk_widget_get_window (widget) != event->window)
     {
@@ -691,6 +692,8 @@ caja_information_panel_press_event (GtkWidget *widget, GdkEventButton *event)
     /* handle the context menu */
     if (event->button == CONTEXTUAL_MENU_BUTTON)
     {
+        GtkWidget *menu;
+
         menu = caja_information_panel_create_context_menu (information_panel);
         eel_pop_up_context_menu (GTK_MENU(menu),
                                  event);
@@ -771,7 +774,6 @@ static void
 add_buttons_from_metadata (CajaInformationPanel *information_panel, const char *button_data)
 {
     char **terms;
-    char *current_term, *temp_str;
     char *button_name, *command_string;
     const char *term;
     int index;
@@ -784,6 +786,8 @@ add_buttons_from_metadata (CajaInformationPanel *information_panel, const char *
     /* for each term, either create a button or attach a property to one */
     for (index = 0; (term = terms[index]) != NULL; index++)
     {
+        char *current_term, *temp_str;
+
         current_term = g_strdup (term);
         temp_str = strchr (current_term, '=');
         if (temp_str)
@@ -836,7 +840,6 @@ static void
 caja_information_panel_update_buttons (CajaInformationPanel *information_panel)
 {
     char *button_data;
-    GAppInfo *default_app;
 
     /* dispose of any existing buttons */
     if (information_panel->details->has_buttons)
@@ -860,6 +863,8 @@ caja_information_panel_update_buttons (CajaInformationPanel *information_panel)
     if (caja_mime_has_any_applications_for_file (information_panel->details->file) &&
             !caja_file_is_directory (information_panel->details->file))
     {
+        GAppInfo *default_app;
+
         default_app =
             caja_mime_get_default_application_for_file (information_panel->details->file);
         add_command_button (information_panel, default_app);
@@ -986,8 +991,6 @@ selection_changed_callback (CajaWindowInfo *window,
 {
     int selection_count;
     GList *selection;
-    GFile *selected;
-    CajaFile *file;
     char *uri, *name;
 
     selection = caja_window_info_get_selection (window);
@@ -995,6 +998,9 @@ selection_changed_callback (CajaWindowInfo *window,
 
     if (selection_count == 1)
     {
+        GFile *selected;
+        CajaFile *file;
+
         selection = caja_window_info_get_selection (window);
         selected = selection->data;
 

--- a/src/caja-location-bar.c
+++ b/src/caja-location-bar.c
@@ -157,15 +157,9 @@ drag_data_received_callback (GtkWidget *widget,
                              gpointer callback_data)
 {
     char **names;
-    CajaApplication *application;
     int name_count;
-    CajaWindow *new_window;
     CajaNavigationWindow *window;
-    GdkScreen      *screen;
     gboolean new_windows_for_extras;
-    char *prompt;
-    char *detail;
-    GFile *location;
     CajaLocationBar *self = CAJA_LOCATION_BAR (widget);
 
     g_assert (data != NULL);
@@ -190,6 +184,9 @@ drag_data_received_callback (GtkWidget *widget,
     name_count = g_strv_length (names);
     if (name_count > 1)
     {
+        char *prompt;
+        char *detail;
+
         prompt = g_strdup_printf (ngettext("Do you want to view %d location?",
                                            "Do you want to view %d locations?",
                                            name_count),
@@ -225,7 +222,11 @@ drag_data_received_callback (GtkWidget *widget,
 
     if (new_windows_for_extras)
     {
+        CajaApplication *application;
+        GdkScreen *screen;
         int i;
+        CajaWindow *new_window = NULL;
+        GFile *location = NULL;
 
         application = CAJA_WINDOW (window)->application;
         screen = gtk_window_get_screen (GTK_WINDOW (window));
@@ -558,9 +559,6 @@ void
 caja_location_bar_set_location (CajaLocationBar *bar,
                                 const char *location)
 {
-    char *formatted_location;
-    GFile *file;
-
     g_assert (location != NULL);
 
     /* Note: This is called in reaction to external changes, and
@@ -573,6 +571,9 @@ caja_location_bar_set_location (CajaLocationBar *bar,
     }
     else
     {
+        char *formatted_location;
+        GFile *file;
+
         file = g_file_new_for_uri (location);
         formatted_location = g_file_get_parse_name (file);
         g_object_unref (file);

--- a/src/caja-location-entry.c
+++ b/src/caja-location-entry.c
@@ -84,7 +84,7 @@ try_to_expand_path (gpointer callback_data)
 {
     CajaLocationEntry *entry;
     GtkEditable *editable;
-    char *suffix, *user_location, *absolute_location, *uri_scheme;
+    char *suffix, *user_location, *uri_scheme;
     int user_location_length, pos;
 
     entry = CAJA_LOCATION_ENTRY (callback_data);
@@ -97,6 +97,8 @@ try_to_expand_path (gpointer callback_data)
 
     if (!g_path_is_absolute (user_location) && uri_scheme == NULL && user_location[0] != '~')
     {
+        char *absolute_location;
+
         absolute_location = g_build_filename (entry->details->current_directory, user_location, NULL);
         suffix = g_filename_completer_get_completion_suffix (entry->details->completer,
                  absolute_location);
@@ -359,7 +361,7 @@ caja_location_entry_activate (GtkEntry *entry)
 {
     CajaLocationEntry *loc_entry;
     const gchar *entry_text;
-    gchar *full_path, *uri_scheme = NULL;
+    gchar *uri_scheme = NULL;
 
     loc_entry = CAJA_LOCATION_ENTRY (entry);
     entry_text = gtk_entry_get_text (entry);
@@ -370,6 +372,8 @@ caja_location_entry_activate (GtkEntry *entry)
 
         if (!g_path_is_absolute (entry_text) && uri_scheme == NULL && entry_text[0] != '~')
         {
+            gchar *full_path;
+
             /* Fix non absolute paths */
             full_path = g_build_filename (loc_entry->details->current_directory, entry_text, NULL);
             gtk_entry_set_text (entry, full_path);

--- a/src/caja-navigation-action.c
+++ b/src/caja-navigation-action.c
@@ -108,10 +108,10 @@ fill_menu (CajaNavigationWindow *window,
            gboolean back)
 {
     CajaNavigationWindowSlot *slot;
-    GtkWidget *menu_item;
     int index;
     GList *list;
     gboolean list_void;
+    GtkWidget *menu_item = NULL;
 
     g_assert (CAJA_IS_NAVIGATION_WINDOW (window));
 

--- a/src/caja-navigation-window-menus.c
+++ b/src/caja-navigation-window-menus.c
@@ -709,11 +709,12 @@ action_show_hide_search_callback (GtkAction *action,
         else
         {
             CajaQuery *query;
-            char *uri;
 
             query = caja_query_editor_get_query (slot->query_editor);
             if (query != NULL)
             {
+                char *uri;
+
                 uri = caja_query_get_location (query);
                 if (uri != NULL)
                 {

--- a/src/caja-navigation-window-pane.c
+++ b/src/caja-navigation-window-pane.c
@@ -79,10 +79,10 @@ navigation_bar_focus_in_callback (GtkWidget *widget, GdkEventFocus *event, gpoin
 static int
 bookmark_list_get_uri_index (GList *list, GFile *location)
 {
-    CajaBookmark *bookmark;
     GList *l;
-    GFile *tmp;
     int i;
+    CajaBookmark *bookmark = NULL;
+    GFile *tmp = NULL;
 
     g_return_val_if_fail (location != NULL, -1);
 
@@ -114,7 +114,7 @@ static void
 search_bar_activate_callback (CajaSearchBar *bar,
                               CajaNavigationWindowPane *pane)
 {
-    char *uri, *current_uri;
+    char *uri;
     CajaDirectory *directory;
     CajaSearchDirectory *search_directory;
     CajaQuery *query;
@@ -136,6 +136,8 @@ search_bar_activate_callback (CajaSearchBar *bar,
         CajaWindowSlot *slot = CAJA_WINDOW_PANE (pane)->active_slot;
         if (!caja_search_directory_is_indexed (search_directory))
         {
+            char *current_uri;
+
             current_uri = caja_window_slot_get_location_uri (slot);
             caja_query_set_location (query, current_uri);
             g_free (current_uri);
@@ -271,11 +273,10 @@ path_bar_path_event_callback (CajaPathBar *path_bar,
 {
     CajaWindowSlot *slot;
     CajaWindowOpenFlags flags;
-    int mask;
-    CajaView *view;
-    char *uri;
 
     if (event->type == GDK_BUTTON_RELEASE) {
+        int mask;
+
         mask = event->state & gtk_accelerator_get_default_mod_mask ();
         flags = 0;
 
@@ -300,9 +301,14 @@ path_bar_path_event_callback (CajaPathBar *path_bar,
     }
 
     if (event->button == 3) {
+        CajaView *view;
+
         slot = caja_window_get_active_slot (pane->window);
         view = slot->content_view;
+
         if (view != NULL) {
+            char *uri;
+
             uri = g_file_get_uri (location);
             caja_view_pop_up_location_context_menu (view, event, uri);
             g_free (uri);
@@ -528,7 +534,6 @@ caja_navigation_window_pane_add_slot_in_tab (CajaNavigationWindowPane *pane, Caj
 static void
 real_sync_location_widgets (CajaWindowPane *pane)
 {
-    CajaNavigationWindowSlot *navigation_slot;
     CajaNavigationWindowPane *navigation_pane;
     CajaWindowSlot *slot;
 
@@ -550,6 +555,8 @@ real_sync_location_widgets (CajaWindowPane *pane)
     /* Update window global UI if this is the active pane */
     if (pane == pane->window->details->active_pane)
     {
+        CajaNavigationWindowSlot *navigation_slot;
+
         caja_window_update_up_button (pane->window);
 
         /* Check if the back and forward buttons need enabling or disabling. */
@@ -565,7 +572,6 @@ gboolean
 caja_navigation_window_pane_hide_temporary_bars (CajaNavigationWindowPane *pane)
 {
     CajaWindowSlot *slot;
-    CajaDirectory *directory;
     gboolean success;
 
     g_assert (CAJA_IS_NAVIGATION_WINDOW_PANE (pane));
@@ -584,6 +590,8 @@ caja_navigation_window_pane_hide_temporary_bars (CajaNavigationWindowPane *pane)
     }
     if (pane->temporary_navigation_bar)
     {
+        CajaDirectory *directory;
+
         directory = caja_directory_get (slot->location);
 
         if (CAJA_IS_SEARCH_DIRECTORY (directory))

--- a/src/caja-navigation-window-slot.c
+++ b/src/caja-navigation-window-slot.c
@@ -132,7 +132,6 @@ caja_navigation_window_slot_update_query_editor (CajaWindowSlot *slot)
 {
     CajaDirectory *directory;
     CajaSearchDirectory *search_directory;
-    CajaQuery *query;
     GtkWidget *query_editor;
 
     g_assert (slot->pane->window != NULL);
@@ -163,6 +162,8 @@ caja_navigation_window_slot_update_query_editor (CajaWindowSlot *slot)
 
     if (query_editor != NULL)
     {
+        CajaQuery *query;
+
         g_signal_connect_object (query_editor, "changed",
                                  G_CALLBACK (query_editor_changed_callback), slot, 0);
 

--- a/src/caja-navigation-window.c
+++ b/src/caja-navigation-window.c
@@ -477,7 +477,7 @@ static void
 caja_navigation_window_tear_down_sidebar (CajaNavigationWindow *window)
 {
     GList *node, *next;
-    CajaSidebar *sidebar_panel;
+    CajaSidebar *sidebar_panel = NULL;
 
     g_signal_handlers_disconnect_by_func (window->sidebar,
                                           side_pane_switch_page_callback,
@@ -777,19 +777,21 @@ real_sync_title (CajaWindow *window,
 {
     CajaNavigationWindowPane *pane;
     CajaNotebook *notebook;
-    char *full_title;
-    char *window_title;
 
     EEL_CALL_PARENT (CAJA_WINDOW_CLASS,
                      sync_title, (window, slot));
 
     if (slot == window->details->active_pane->active_slot)
     {
+        char *window_title;
+
         /* if spatial mode is default, we keep "File Browser" in the window title
          * to recognize browser windows. Otherwise, we default to the directory name.
          */
         if (!g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_ALWAYS_USE_BROWSER))
         {
+            char *full_title;
+
             full_title = g_strdup_printf (_("%s - File Browser"), slot->title);
             window_title = eel_str_middle_truncate (full_title, MAX_TITLE_LENGTH);
             g_free (full_title);
@@ -933,7 +935,7 @@ add_sidebar_panels (CajaNavigationWindow *window)
     GtkWidget *current;
     GList *providers;
     GList *p;
-    CajaSidebar *sidebar_panel;
+    CajaSidebar *sidebar_panel = NULL;
 
     g_assert (CAJA_IS_NAVIGATION_WINDOW (window));
 
@@ -1170,13 +1172,14 @@ caja_navigation_window_show (GtkWidget *widget)
 static void
 caja_navigation_window_save_geometry (CajaNavigationWindow *window)
 {
-    char *geometry_string;
     gboolean is_maximized;
 
     g_assert (CAJA_IS_WINDOW (window));
 
     if (gtk_widget_get_window (GTK_WIDGET (window)))
     {
+        char *geometry_string;
+
         geometry_string = eel_gtk_window_get_geometry_string (GTK_WINDOW (window));
         is_maximized = gdk_window_get_state (gtk_widget_get_window (GTK_WIDGET (window)))
                        & GDK_WINDOW_STATE_MAXIMIZED;
@@ -1392,8 +1395,9 @@ void
 caja_navigation_window_split_view_off (CajaNavigationWindow *window)
 {
     CajaWindow *win;
-    CajaWindowPane *pane, *active_pane;
     GList *l, *next;
+    CajaWindowPane *active_pane;
+    CajaWindowPane *pane = NULL;
 
     win = CAJA_WINDOW (window);
 

--- a/src/caja-notebook.c
+++ b/src/caja-notebook.c
@@ -222,7 +222,6 @@ caja_notebook_sync_tab_label (CajaNotebook *notebook,
                               CajaWindowSlot *slot)
 {
     GtkWidget *hbox, *label;
-    char *location_name;
 
     g_return_if_fail (CAJA_IS_NOTEBOOK (notebook));
     g_return_if_fail (CAJA_IS_WINDOW_SLOT (slot));
@@ -238,6 +237,8 @@ caja_notebook_sync_tab_label (CajaNotebook *notebook,
 
     if (slot->location != NULL)
     {
+        char *location_name;
+
         /* Set the tooltip on the label's parent (the tab label hbox),
          * so it covers all of the tab label.
          */

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -266,13 +266,14 @@ caja_path_bar_slider_drag_motion (GtkWidget      *widget,
                                   gpointer        user_data)
 {
     CajaPathBar *path_bar;
-    GtkSettings *settings;
     unsigned int timeout;
 
     path_bar = CAJA_PATH_BAR (user_data);
 
     if (path_bar->drag_slider_timeout == 0)
     {
+        GtkSettings *settings;
+
         settings = gtk_widget_get_settings (widget);
 
         g_object_get (settings, "gtk-timeout-expand", &timeout, NULL);
@@ -507,13 +508,13 @@ caja_path_bar_get_preferred_width (GtkWidget *widget,
     			       gint      *minimum,
     			       gint      *natural)
 {
-    ButtonData *button_data;
     CajaPathBar *path_bar;
     GList *list;
     gint child_height;
     gint height;
     gint child_min, child_nat;
     gint slider_width;
+    ButtonData *button_data = NULL;
 
     path_bar = CAJA_PATH_BAR (widget);
 
@@ -561,10 +562,10 @@ caja_path_bar_get_preferred_height (GtkWidget *widget,
     				gint      *minimum,
     				gint      *natural)
 {
-    ButtonData *button_data;
     CajaPathBar *path_bar;
     GList *list;
     gint child_min, child_nat;
+    ButtonData *button_data = NULL;
 
     path_bar = CAJA_PATH_BAR (widget);
 
@@ -1492,8 +1493,6 @@ set_label_padding_size (ButtonData *button_data)
 static void
 caja_path_bar_update_button_appearance (ButtonData *button_data)
 {
-    CajaIconInfo *icon_info;
-    cairo_surface_t *surface;
     const gchar *dir_name = get_dir_name (button_data);
 
     if (button_data->label != NULL)
@@ -1525,6 +1524,9 @@ caja_path_bar_update_button_appearance (ButtonData *button_data)
         }
         else
         {
+            CajaIconInfo *icon_info;
+            cairo_surface_t *surface;
+
             icon_info = get_type_icon_info (button_data);
             surface = NULL;
 
@@ -1577,12 +1579,12 @@ setup_file_path_mounted_mount (GFile *location, ButtonData *button_data)
 {
     GVolumeMonitor *volume_monitor;
     GList *mounts, *l;
-    GMount *mount;
     gboolean result;
     GIcon *icon;
     CajaIconInfo *info;
     GFile *root, *default_location;
     gint scale;
+    GMount *mount = NULL;
 
     /* Return false if button has not been set up yet or has been destroyed*/
     if (!button_data->button)
@@ -1702,7 +1704,6 @@ button_drag_data_get_cb (GtkWidget          *widget,
 {
     ButtonData *button_data;
     char *uri_list[2];
-    char *tmp;
 
     button_data = user_data;
 
@@ -1711,6 +1712,8 @@ button_drag_data_get_cb (GtkWidget          *widget,
 
     if (info == CAJA_ICON_DND_MATE_ICON_LIST)
     {
+        char *tmp;
+
         tmp = g_strdup_printf ("%s\r\n", uri_list[0]);
         gtk_selection_data_set (selection_data, gtk_selection_data_get_target (selection_data),
                                 8, tmp, strlen (tmp));
@@ -1756,9 +1759,8 @@ static void
 button_data_file_changed (CajaFile *file,
                           ButtonData *button_data)
 {
-    GFile *location, *current_location, *parent, *button_parent;
+    GFile *location, *current_location;
     ButtonData *current_button_data;
-    char *display_name;
     CajaPathBar *path_bar;
     gboolean renamed, child;
 
@@ -1777,6 +1779,8 @@ button_data_file_changed (CajaFile *file,
     location = caja_file_get_location (file);
     if (!g_file_equal (button_data->path, location))
     {
+        GFile *parent, *button_parent;
+
         parent = g_file_get_parent (location);
         button_parent = g_file_get_parent (button_data->path);
 
@@ -1861,6 +1865,8 @@ button_data_file_changed (CajaFile *file,
     /* MOUNTs use the GMount as the name, so don't update for those */
     if (button_data->type != MOUNT_BUTTON)
     {
+        char *display_name;
+
         display_name = caja_file_get_display_name (file);
         if (g_strcmp0 (display_name, button_data->dir_name) != 0)
         {

--- a/src/caja-property-browser.c
+++ b/src/caja-property-browser.c
@@ -536,7 +536,6 @@ caja_property_browser_drag_begin (GtkWidget *widget,
     CajaPropertyBrowser *property_browser;
     GtkWidget *child;
     GdkPixbuf *pixbuf;
-    int x_delta, y_delta;
     char *element_name;
 
     property_browser = CAJA_PROPERTY_BROWSER (widget);
@@ -568,6 +567,8 @@ caja_property_browser_drag_begin (GtkWidget *widget,
     /* set the pixmap and mask for dragging */
     if (pixbuf != NULL)
     {
+        int x_delta, y_delta;
+
         x_delta = gdk_pixbuf_get_width (pixbuf) / 2;
         y_delta = gdk_pixbuf_get_height (pixbuf) / 2;
 
@@ -721,9 +722,7 @@ make_drag_image (CajaPropertyBrowser *property_browser, const char* file_name)
 {
     GdkPixbuf *pixbuf, *orig_pixbuf;
     char *image_file_name;
-    char *icon_name;
     gboolean is_reset;
-    CajaIconInfo *info;
 
     if (property_browser->details->category_type == CAJA_PROPERTY_EMBLEM)
     {
@@ -740,6 +739,9 @@ make_drag_image (CajaPropertyBrowser *property_browser, const char* file_name)
         }
         else
         {
+            char *icon_name;
+            CajaIconInfo *info;
+
             icon_name = caja_emblem_get_icon_name_from_keyword (file_name);
             info = caja_icon_info_lookup_from_name (icon_name, CAJA_ICON_SIZE_STANDARD, 1);
             pixbuf = caja_icon_info_get_pixbuf_at_size (info, CAJA_ICON_SIZE_STANDARD);
@@ -807,7 +809,7 @@ make_color_drag_image (CajaPropertyBrowser *property_browser, const char *color_
     GdkPixbuf *color_square;
     GdkPixbuf *ret;
     int row, col, stride;
-    char *pixels, *row_pixels;
+    char *pixels;
     GdkColor color;
 
     color_square = gdk_pixbuf_new (GDK_COLORSPACE_RGB, TRUE, 8, COLOR_SQUARE_SIZE, COLOR_SQUARE_SIZE);
@@ -823,7 +825,10 @@ make_color_drag_image (CajaPropertyBrowser *property_browser, const char *color_
     /* loop through and set each pixel */
     for (row = 0; row < COLOR_SQUARE_SIZE; row++)
     {
+        char *row_pixels;
+
         row_pixels =  (pixels + (row * stride));
+
         for (col = 0; col < COLOR_SQUARE_SIZE; col++)
         {
             *row_pixels++ = color.red;
@@ -1033,11 +1038,13 @@ update_preview_cb (GtkFileChooser *fc,
                    GtkImage *preview)
 {
     char *filename;
-    GdkPixbuf *pixbuf;
 
     filename = gtk_file_chooser_get_preview_filename (fc);
+
     if (filename)
     {
+        GdkPixbuf *pixbuf;
+
         pixbuf = gdk_pixbuf_new_from_file (filename, NULL);
 
         gtk_file_chooser_set_preview_widget_active (fc, pixbuf != NULL);
@@ -1308,8 +1315,6 @@ static void
 add_new_pattern (CajaPropertyBrowser *property_browser)
 {
     GtkWidget *dialog;
-    GtkFileFilter *filter;
-    GtkWidget *preview;
 
     if (property_browser->details->patterns_dialog)
     {
@@ -1317,6 +1322,9 @@ add_new_pattern (CajaPropertyBrowser *property_browser)
     }
     else
     {
+        GtkFileFilter *filter;
+        GtkWidget *preview;
+
         property_browser->details->patterns_dialog = dialog =
                     eel_file_chooser_dialog_new (_("Select an Image File to Add as a Pattern"),
                             GTK_WINDOW (property_browser),
@@ -1356,7 +1364,6 @@ add_color_to_file (CajaPropertyBrowser *property_browser, const char *color_spec
 {
     xmlNodePtr cur_node, new_color_node, children_node;
     xmlDocPtr document;
-    xmlChar *child_color_name;
     gboolean color_name_exists = FALSE;
 
     document = read_browser_xml (property_browser);
@@ -1373,6 +1380,8 @@ add_color_to_file (CajaPropertyBrowser *property_browser, const char *color_spec
         children_node = cur_node->xmlChildrenNode;
         while (children_node != NULL)
         {
+            xmlChar *child_color_name;
+
             child_color_name = xmlGetProp (children_node, "name");
             if (xmlStrcmp (color_name, child_color_name) == 0)
             {
@@ -1410,14 +1419,13 @@ add_color_to_file (CajaPropertyBrowser *property_browser, const char *color_spec
 static void
 add_color_to_browser (GtkWidget *widget, gint which_button, gpointer data)
 {
-    char * color_spec;
-    const char *color_name;
-    char *stripped_color_name;
-
     CajaPropertyBrowser *property_browser = CAJA_PROPERTY_BROWSER (data);
 
     if (which_button == GTK_RESPONSE_OK)
     {
+        char * color_spec;
+        const char *color_name;
+        char *stripped_color_name;
         GdkColor color;
 
         gtk_color_button_get_color (GTK_COLOR_BUTTON (property_browser->details->color_picker), &color);
@@ -1512,14 +1520,14 @@ add_new_color (CajaPropertyBrowser *property_browser)
 static void
 emblem_dialog_clicked (GtkWidget *dialog, int which_button, CajaPropertyBrowser *property_browser)
 {
-    const char *new_keyword;
-    char *stripped_keyword;
     char *emblem_path;
-    GFile *emblem_file;
-    GdkPixbuf *pixbuf;
 
     if (which_button == GTK_RESPONSE_OK)
     {
+        const char *new_keyword;
+        char *stripped_keyword;
+        GFile *emblem_file;
+        GdkPixbuf *pixbuf;
 
         /* update the image path from the file entry */
         if (property_browser->details->filename)
@@ -1664,7 +1672,6 @@ static void
 help_button_callback (GtkWidget *widget, GtkWidget *property_browser)
 {
     GError *error = NULL;
-    GtkWidget *dialog;
 
     gtk_show_uri_on_window (GTK_WINDOW (property_browser),
                             "help:mate-user-guide/goscaja-50",
@@ -1672,6 +1679,8 @@ help_button_callback (GtkWidget *widget, GtkWidget *property_browser)
 
     if (error)
     {
+        GtkWidget *dialog;
+
         dialog = gtk_message_dialog_new (GTK_WINDOW (property_browser),
                                          GTK_DIALOG_DESTROY_WITH_PARENT,
                                          GTK_MESSAGE_ERROR,
@@ -1797,20 +1806,14 @@ labeled_image_new (const char *text,
 static void
 make_properties_from_directories (CajaPropertyBrowser *property_browser)
 {
-    CajaCustomizationData *customization_data;
     char *object_name;
     char *object_label;
     GdkPixbuf *object_pixbuf;
     EelImageTable *image_table;
     GtkWidget *reset_object = NULL;
     GList *icons, *l;
-    char *icon_name;
-    char *keyword;
     GtkWidget *property_image;
-    GtkWidget *blank;
     guint num_images;
-    char *path;
-    CajaIconInfo *info;
 
     g_return_if_fail (CAJA_IS_PROPERTY_BROWSER (property_browser));
     g_return_if_fail (EEL_IS_IMAGE_TABLE (property_browser->details->content_table));
@@ -1819,6 +1822,8 @@ make_properties_from_directories (CajaPropertyBrowser *property_browser)
 
     if (property_browser->details->category_type == CAJA_PROPERTY_EMBLEM)
     {
+        CajaIconInfo *info = NULL;
+
         g_list_free_full (property_browser->details->keywords, g_free);
         property_browser->details->keywords = NULL;
 
@@ -1828,6 +1833,9 @@ make_properties_from_directories (CajaPropertyBrowser *property_browser)
         l = icons;
         while (l != NULL)
         {
+            char *icon_name;
+            char *keyword;
+
             icon_name = (char *)l->data;
             l = l->next;
 
@@ -1877,6 +1885,8 @@ make_properties_from_directories (CajaPropertyBrowser *property_browser)
     }
     else
     {
+        CajaCustomizationData *customization_data;
+
         customization_data = caja_customization_data_new (property_browser->details->category,
                              !property_browser->details->remove_mode,
                              MAX_ICON_WIDTH,
@@ -1925,6 +1935,9 @@ make_properties_from_directories (CajaPropertyBrowser *property_browser)
      */
     if (property_browser->details->category_type == CAJA_PROPERTY_EMBLEM)
     {
+        GtkWidget *blank;
+        char *path;
+
         blank = eel_image_table_add_empty_image (image_table);
         labeled_image_configure (EEL_LABELED_IMAGE (blank));
 
@@ -2181,7 +2194,6 @@ caja_property_browser_update_contents (CajaPropertyBrowser *property_browser)
     GtkRadioButton *group;
     gboolean got_categories;
     char *name, *image, *type, *description, *display_name, *path, *mode;
-    const char *text;
 
     /* load the xml document corresponding to the path and selection */
     document = read_browser_xml (property_browser);
@@ -2301,8 +2313,10 @@ caja_property_browser_update_contents (CajaPropertyBrowser *property_browser)
     }
     else
     {
+        const char *text;
         char *label_text;
         char *icon_name;
+
         if (property_browser->details->remove_mode)
         {
             icon_name = "process-stop";

--- a/src/caja-query-editor.c
+++ b/src/caja-query-editor.c
@@ -983,7 +983,6 @@ type_add_rows_from_query (CajaQueryEditor    *editor,
 {
     GList *mime_types;
     char *mime_type;
-    const char *desc;
     CajaQueryEditorRow *row;
     GtkTreeIter iter;
     int i;
@@ -1018,6 +1017,8 @@ type_add_rows_from_query (CajaQueryEditor    *editor,
 
     for (l = mime_types; l != NULL; l = l->next)
     {
+        const char *desc;
+
         mime_type = l->data;
 
         desc = g_content_type_get_description (mime_type);
@@ -1651,8 +1652,6 @@ query_is_valid (CajaQueryEditor *editor)
 static void
 caja_query_editor_changed_force (CajaQueryEditor *editor, gboolean force_reload)
 {
-    CajaQuery *query;
-
     if (editor->details->change_frozen)
     {
         return;
@@ -1660,6 +1659,8 @@ caja_query_editor_changed_force (CajaQueryEditor *editor, gboolean force_reload)
 
     if (query_is_valid (editor))
     {
+        CajaQuery *query;
+
         query = caja_query_editor_get_query (editor);
         g_signal_emit (editor, signals[CHANGED], 0,
                        query, editor->details->is_indexed || force_reload);
@@ -1688,7 +1689,7 @@ caja_query_editor_get_query (CajaQueryEditor *editor)
     const char *query_text;
     CajaQuery *query;
     GList *l;
-    CajaQueryEditorRow *row;
+    CajaQueryEditorRow *row = NULL;
 
     if (editor == NULL || editor->details == NULL || editor->details->entry == NULL)
     {

--- a/src/caja-side-pane.c
+++ b/src/caja-side-pane.c
@@ -73,7 +73,7 @@ static SidePanel *
 panel_for_widget (CajaSidePane *side_pane, GtkWidget *widget)
 {
     GList *l;
-    SidePanel *panel;
+    SidePanel *panel = NULL;
 
     for (l = side_pane->details->panels; l != NULL; l = l->next)
     {
@@ -470,7 +470,6 @@ caja_side_pane_remove_panel (CajaSidePane *side_pane,
                              GtkWidget *widget)
 {
     SidePanel *panel;
-    int page_num;
 
     g_return_if_fail (side_pane != NULL);
     g_return_if_fail (CAJA_IS_SIDE_PANE (side_pane));
@@ -483,6 +482,8 @@ caja_side_pane_remove_panel (CajaSidePane *side_pane,
 
     if (panel)
     {
+        int page_num;
+
         page_num = gtk_notebook_page_num (GTK_NOTEBOOK (side_pane->details->notebook),
                                           widget);
         gtk_notebook_remove_page (GTK_NOTEBOOK (side_pane->details->notebook),

--- a/src/caja-sidebar-title.c
+++ b/src/caja-sidebar-title.c
@@ -365,7 +365,6 @@ static void
 update_icon (CajaSidebarTitle *sidebar_title)
 {
     GdkPixbuf *pixbuf;
-    CajaIconInfo *info;
     char *icon_name;
     gboolean leave_pixbuf_unchanged;
     gint icon_scale;
@@ -377,8 +376,11 @@ update_icon (CajaSidebarTitle *sidebar_title)
     icon_scale = gtk_widget_get_scale_factor (GTK_WIDGET (sidebar_title));
 
     pixbuf = NULL;
+
     if (icon_name != NULL && icon_name[0] != '\0')
     {
+        CajaIconInfo *info;
+
         info = caja_icon_info_lookup_from_name (icon_name, CAJA_ICON_SIZE_LARGE, icon_scale);
         pixbuf = caja_icon_info_get_pixbuf_at_size (info,  CAJA_ICON_SIZE_LARGE);
         g_object_unref (info);
@@ -561,10 +563,7 @@ update_more_info (CajaSidebarTitle *sidebar_title)
 {
     CajaFile *file;
     GString *info_string;
-    char *type_string, *component_info;
-    char *date_modified_str;
-    int sidebar_width;
-    PangoLayout *layout;
+    char *component_info;
     GtkAllocation allocation;
 
     file = sidebar_title->details->file;
@@ -578,9 +577,13 @@ update_more_info (CajaSidebarTitle *sidebar_title)
     }
     else
     {
+        char *type_string;
+        int sidebar_width;
+
         info_string = g_string_new (NULL);
 
         type_string = NULL;
+
         if (file != NULL && caja_file_should_show_type (file))
         {
             type_string = caja_file_get_string_attribute (file, "type");
@@ -602,6 +605,9 @@ update_more_info (CajaSidebarTitle *sidebar_title)
         sidebar_width = allocation.width - 2 * SIDEBAR_INFO_MARGIN;
         if (sidebar_width > MINIMUM_INFO_WIDTH)
         {
+            char *date_modified_str;
+            PangoLayout *layout;
+
             layout = pango_layout_copy (gtk_label_get_layout (GTK_LABEL (sidebar_title->details->more_info_label)));
             pango_layout_set_width (layout, -1);
             date_modified_str = caja_file_fit_modified_date_as_string
@@ -631,7 +637,7 @@ static void
 update_emblems (CajaSidebarTitle *sidebar_title)
 {
     GList *pixbufs, *p;
-    GdkPixbuf *pixbuf;
+    GdkPixbuf *pixbuf = NULL;
 
     /* exit if we don't have the file yet */
     if (sidebar_title->details->file == NULL)

--- a/src/caja-spatial-window.c
+++ b/src/caja-spatial-window.c
@@ -285,7 +285,6 @@ static void
 caja_spatial_window_save_show_hidden_files_mode (CajaSpatialWindow *window,
 						 CajaFile *viewed_file)
 {
-    char *show_hidden_file_setting;
     CajaWindowShowHiddenFilesMode mode;
 
     if (viewed_file == NULL) {
@@ -295,6 +294,8 @@ caja_spatial_window_save_show_hidden_files_mode (CajaSpatialWindow *window,
     mode = CAJA_WINDOW (window)->details->show_hidden_files_mode;
 
     if (mode != CAJA_WINDOW_SHOW_HIDDEN_FILES_DEFAULT) {
+        char *show_hidden_file_setting;
+
         if (mode == CAJA_WINDOW_SHOW_HIDDEN_FILES_ENABLE) {
             show_hidden_file_setting = "1";
         } else {
@@ -650,7 +651,7 @@ location_button_clicked_callback (GtkWidget         *widget,
 {
     CajaWindowSlot *slot;
     GtkWidget *popup, *menu_item, *first_item = NULL;
-    GdkPixbuf *pixbuf;
+    GdkPixbuf *pixbuf = NULL;
     GFile *location;
     GFile *child_location;
     GMainLoop *loop;

--- a/src/caja-window-bookmarks.c
+++ b/src/caja-window-bookmarks.c
@@ -49,7 +49,6 @@ static void refresh_bookmarks_menu (CajaWindow *window);
 static void
 remove_bookmarks_for_uri_if_yes (GtkDialog *dialog, int response, gpointer callback_data)
 {
-    const char *uri;
     CajaWindow *window;
 
     g_assert (GTK_IS_DIALOG (dialog));
@@ -59,6 +58,8 @@ remove_bookmarks_for_uri_if_yes (GtkDialog *dialog, int response, gpointer callb
 
     if (response == GTK_RESPONSE_YES)
     {
+        const char *uri;
+
         uri = g_object_get_data (G_OBJECT (dialog), "uri");
         caja_bookmark_list_delete_items_with_uri (window->details->bookmark_list, uri);
     }
@@ -209,11 +210,11 @@ connect_proxy_cb (GtkActionGroup *action_group,
 static void
 update_bookmarks (CajaWindow *window)
 {
-    CajaBookmarkList *bookmarks;
-    CajaBookmark *bookmark;
     guint bookmark_count;
     guint index;
     GtkUIManager *ui_manager;
+    CajaBookmarkList *bookmarks;
+    CajaBookmark *bookmark = NULL;
 
     g_assert (CAJA_IS_WINDOW (window));
     g_assert (window->details->bookmarks_merge_id == 0);

--- a/src/caja-window-menus.c
+++ b/src/caja-window-menus.c
@@ -141,9 +141,7 @@ should_open_in_new_tab (void)
 static void
 activate_bookmark_in_menu_item (GtkAction *action, gpointer user_data)
 {
-    CajaWindowSlot *slot;
     BookmarkHolder *holder;
-    GFile *location;
 
     holder = (BookmarkHolder *)user_data;
 
@@ -153,6 +151,9 @@ activate_bookmark_in_menu_item (GtkAction *action, gpointer user_data)
     }
     else
     {
+        CajaWindowSlot *slot;
+        GFile *location;
+
         location = caja_bookmark_get_location (holder->bookmark);
         slot = caja_window_get_active_slot (holder->window);
         caja_window_slot_go_to (slot,
@@ -431,12 +432,13 @@ static void
 show_hidden_files_preference_callback (gpointer callback_data)
 {
     CajaWindow *window;
-    GtkAction *action;
 
     window = CAJA_WINDOW (callback_data);
 
     if (window->details->show_hidden_files_mode == CAJA_WINDOW_SHOW_HIDDEN_FILES_DEFAULT)
     {
+        GtkAction *action;
+
         action = gtk_action_group_get_action (window->details->main_action_group, CAJA_ACTION_SHOW_HIDDEN_FILES);
         g_assert (GTK_IS_ACTION (action));
 
@@ -456,12 +458,13 @@ static void
 show_backup_files_preference_callback (gpointer callback_data)
 {
     CajaWindow *window;
-    GtkAction *action;
 
     window = CAJA_WINDOW (callback_data);
 
     if (window->details->show_backup_files_mode == CAJA_WINDOW_SHOW_BACKUP_FILES_DEFAULT)
     {
+        GtkAction *action;
+
         action = gtk_action_group_get_action (window->details->main_action_group, CAJA_ACTION_SHOW_BACKUP_FILES);
         g_assert (GTK_IS_ACTION (action));
 
@@ -593,7 +596,6 @@ action_caja_manual_callback (GtkAction *action,
 {
     CajaWindow *window;
     GError *error;
-    GtkWidget *dialog;
 
     error = NULL;
     window = CAJA_WINDOW (user_data);
@@ -606,6 +608,8 @@ action_caja_manual_callback (GtkAction *action,
 
     if (error)
     {
+        GtkWidget *dialog;
+
         dialog = gtk_message_dialog_new (GTK_WINDOW (window),
                                          GTK_DIALOG_MODAL,
                                          GTK_MESSAGE_ERROR,

--- a/src/caja-window-pane.c
+++ b/src/caja-window-pane.c
@@ -43,7 +43,7 @@ static inline CajaWindowSlot *
 get_first_inactive_slot (CajaWindowPane *pane)
 {
     GList *l;
-    CajaWindowSlot *slot;
+    CajaWindowSlot *slot = NULL;
 
     for (l = pane->slots; l != NULL; l = l->next)
     {
@@ -133,8 +133,6 @@ caja_window_pane_zoom_to_default (CajaWindowPane *pane)
 void
 caja_window_pane_slot_close (CajaWindowPane *pane, CajaWindowSlot *slot)
 {
-    CajaWindowSlot *next_slot;
-
     if (pane->window)
     {
         CajaWindow *window;
@@ -143,6 +141,8 @@ caja_window_pane_slot_close (CajaWindowPane *pane, CajaWindowSlot *slot)
         {
             g_assert (pane->active_slots != NULL);
             g_assert (pane->active_slots->data == slot);
+
+            CajaWindowSlot *next_slot;
 
             next_slot = NULL;
             if (pane->active_slots->next != NULL)
@@ -290,8 +290,8 @@ CajaWindowSlot *
 caja_window_pane_get_slot_for_content_box (CajaWindowPane *pane,
         GtkWidget *content_box)
 {
-    CajaWindowSlot *slot;
     GList *l;
+    CajaWindowSlot *slot = NULL;
 
     for (l = pane->slots; l != NULL; l = l->next)
     {

--- a/src/caja-window-slot.c
+++ b/src/caja-window-slot.c
@@ -72,15 +72,16 @@ query_editor_changed_callback (CajaSearchBar *bar,
 static void
 real_update_query_editor (CajaWindowSlot *slot)
 {
-    GtkWidget *query_editor;
-    CajaQuery *query;
     CajaDirectory *directory;
-    CajaSearchDirectory *search_directory;
 
     directory = caja_directory_get (slot->location);
 
     if (CAJA_IS_SEARCH_DIRECTORY (directory))
     {
+        GtkWidget *query_editor;
+        CajaQuery *query;
+        CajaSearchDirectory *search_directory;
+
         search_directory = CAJA_SEARCH_DIRECTORY (directory);
 
         query_editor = caja_query_editor_new (caja_search_directory_is_saved_search (search_directory),
@@ -370,7 +371,6 @@ caja_window_slot_update_icon (CajaWindowSlot *slot)
     CajaWindow *window;
     CajaIconInfo *info;
     const char *icon_name;
-    GdkPixbuf *pixbuf;
 
     window = slot->pane->window;
 
@@ -399,6 +399,8 @@ caja_window_slot_update_icon (CajaWindowSlot *slot)
         }
         else
         {
+            GdkPixbuf *pixbuf;
+
             pixbuf = caja_icon_info_get_pixbuf_nodefault (info);
 
             if (pixbuf)

--- a/src/caja-window-toolbars.c
+++ b/src/caja-window-toolbars.c
@@ -147,13 +147,13 @@ get_extension_toolbar_items (CajaNavigationWindow *window)
 void
 caja_navigation_window_load_extension_toolbar_items (CajaNavigationWindow *window)
 {
-    GtkActionGroup *action_group;
-    GtkAction *action;
     GtkUIManager *ui_manager;
     GList *items;
     GList *l;
-    CajaMenuItem *item;
     guint merge_id;
+    GtkActionGroup *action_group;
+    GtkAction *action = NULL;
+    CajaMenuItem *item = NULL;
 
     ui_manager = caja_window_get_ui_manager (CAJA_WINDOW (window));
     if (window->details->extensions_toolbar_merge_id != 0)

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -276,16 +276,17 @@ void
 caja_window_new_tab (CajaWindow *window)
 {
     CajaWindowSlot *current_slot;
-    CajaWindowSlot *new_slot;
     CajaWindowOpenFlags flags;
     GFile *location = NULL;
-    int new_slot_position;
-    char *scheme;
 
     current_slot = window->details->active_pane->active_slot;
     location = caja_window_slot_get_location (current_slot);
 
     if (location != NULL) {
+        CajaWindowSlot *new_slot;
+        int new_slot_position;
+        char *scheme;
+
     	flags = 0;
 
     	new_slot_position = g_settings_get_enum (caja_preferences, CAJA_PREFERENCES_NEW_TAB_POSITION);
@@ -1055,12 +1056,13 @@ action_view_as_callback (GtkAction *action,
                          ActivateViewData *data)
 {
     CajaWindow *window;
-    CajaWindowSlot *slot;
 
     window = data->window;
 
     if (gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action)))
     {
+        CajaWindowSlot *slot;
+
         slot = window->details->active_pane->active_slot;
         caja_window_slot_set_content_view (slot,
                                            data->id);
@@ -1079,10 +1081,6 @@ add_view_as_menu_item (CajaWindow *window,
     char action_name[32];
     ActivateViewData *data;
 
-    char accel[32];
-    char accel_path[48];
-    unsigned int accel_keyval;
-
     info = caja_view_factory_lookup (identifier);
 
     g_snprintf (action_name, sizeof (action_name), "view_as_%d", index);
@@ -1094,6 +1092,10 @@ add_view_as_menu_item (CajaWindow *window,
 
     if (index >= 1 && index <= 9)
     {
+        char accel[32];
+        char accel_path[48];
+        unsigned int accel_keyval;
+
         g_snprintf (accel, sizeof (accel), "%d", index);
         g_snprintf (accel_path, sizeof (accel_path), "<Caja-Window>/%s", action_name);
 
@@ -1425,10 +1427,10 @@ static void
 real_sync_title (CajaWindow *window,
                  CajaWindowSlot *slot)
 {
-    char *copy;
-
     if (slot == window->details->active_pane->active_slot)
     {
+        char *copy;
+
         copy = g_strdup (slot->title);
         g_signal_emit_by_name (window, "title_changed",
                                slot->title);
@@ -1618,7 +1620,6 @@ void
 caja_window_slot_set_viewed_file (CajaWindowSlot *slot,
                                   CajaFile *file)
 {
-    CajaWindow *window;
     CajaFileAttributes attributes;
 
     if (slot->viewed_file == file)
@@ -1632,6 +1633,8 @@ caja_window_slot_set_viewed_file (CajaWindowSlot *slot,
 
     if (slot->viewed_file != NULL)
     {
+        CajaWindow *window;
+
         window = slot->pane->window;
 
         if (CAJA_IS_SPATIAL_WINDOW (window))
@@ -1702,7 +1705,6 @@ caja_add_bookmark_to_history_list (CajaBookmark *bookmark)
      * this is not a CajaNavigationWindow function. Perhaps it belongs
      * in its own file.
      */
-    int i;
     GList *l, *next;
     static gboolean free_history_list_is_set_up;
 
@@ -1721,6 +1723,8 @@ caja_add_bookmark_to_history_list (CajaBookmark *bookmark)
     if (!history_list ||
             caja_bookmark_compare_uris (history_list->data, bookmark))
     {
+        int i;
+
         g_object_ref (bookmark);
         remove_from_history_list (bookmark);
         history_list = g_list_prepend (history_list, bookmark);


### PR DESCRIPTION
Fixes all the `cppcheck` scope variables warnings into the `src` folder

Note: I will fix the scope variables in folder `/src/file-manager/` inside a separate PR