### PR TITLE
[notebooks]  Add scroll tabs with mouse wheel

### DIFF
--- a/libcaja-private/Makefile.am
+++ b/libcaja-private/Makefile.am
@@ -184,6 +184,8 @@ libcaja_private_la_SOURCES = \
 	caja-window-slot-info.h \
 	caja-undostack-manager.c \
 	caja-undostack-manager.h \
+	caja-dialog-notebook.c \
+	caja-dialog-notebook.h \
 	$(NULL)
 
 nodist_libcaja_private_la_SOURCES =\

--- a/libcaja-private/caja-dialog-notebook.c
+++ b/libcaja-private/caja-dialog-notebook.c
@@ -1,0 +1,83 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+
+/* caja-dialog-notebook.h - GTKNotebook management for dialog windows
+
+   The Mate Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   The Mate Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with the Mate Library; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+
+   Authors: Laurent Napias <tamplan@free.fr>
+*/
+
+#include <gtk/gtk.h>
+
+gboolean
+dialog_page_scroll_event_cb (GtkWidget *widget, GdkEventScroll *event, GtkWindow *window)
+{
+    GtkNotebook *notebook = GTK_NOTEBOOK (widget);
+    GtkWidget *child, *event_widget, *action_widget;
+
+    child = gtk_notebook_get_nth_page (notebook, gtk_notebook_get_current_page (notebook));
+    if (child == NULL)
+        return FALSE;
+
+    event_widget = gtk_get_event_widget ((GdkEvent *) event);
+
+    /* Ignore scroll events from the content of the page */
+    if (event_widget == NULL ||
+        event_widget == child ||
+        gtk_widget_is_ancestor (event_widget, child))
+        return FALSE;
+
+    /* And also from the action widgets */
+    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_START);
+    if (event_widget == action_widget ||
+        (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
+        return FALSE;
+    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_END);
+    if (event_widget == action_widget ||
+        (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
+        return FALSE;
+
+    switch (event->direction) {
+    case GDK_SCROLL_RIGHT:
+    case GDK_SCROLL_DOWN:
+        gtk_notebook_next_page (notebook);
+        break;
+    case GDK_SCROLL_LEFT:
+    case GDK_SCROLL_UP:
+        gtk_notebook_prev_page (notebook);
+        break;
+    case GDK_SCROLL_SMOOTH:
+        switch (gtk_notebook_get_tab_pos (notebook)) {
+            case GTK_POS_LEFT:
+            case GTK_POS_RIGHT:
+                if (event->delta_y > 0)
+                    gtk_notebook_next_page (notebook);
+                else if (event->delta_y < 0)
+                    gtk_notebook_prev_page (notebook);
+                break;
+            case GTK_POS_TOP:
+            case GTK_POS_BOTTOM:
+                if (event->delta_x > 0)
+                    gtk_notebook_next_page (notebook);
+                else if (event->delta_x < 0)
+                    gtk_notebook_prev_page (notebook);
+                break;
+            }
+        break;
+    }
+
+    return TRUE;
+}

--- a/libcaja-private/caja-dialog-notebook.c
+++ b/libcaja-private/caja-dialog-notebook.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
 
-/* caja-dialog-notebook.h - GTKNotebook management for dialog windows
+/* caja-dialog-notebook.c - GTKNotebook management for dialog windows
 
    The Mate Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Library General Public License as

--- a/libcaja-private/caja-dialog-notebook.h
+++ b/libcaja-private/caja-dialog-notebook.h
@@ -1,0 +1,31 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+
+/* caja-dialog-notebook.h - GTKNotebook management for dialog windows
+
+   The Mate Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   The Mate Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with the Mate Library; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+
+   Authors: Laurent Napias <tamplan@free.fr>
+*/
+
+#ifndef CAJA_DIALOG_NOTEBOOK_H
+#define CAJA_DIALOG_NOTEBOOK_H
+
+#include <gtk/gtk.h>
+
+gboolean
+dialog_page_scroll_event_cb (GtkWidget *widget, GdkEventScroll *event, GtkWindow *window);
+
+#endif /* CAJA_DIALOG_NOTEBOOK_H */

--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -40,6 +40,7 @@
 #include <libcaja-private/caja-autorun.h>
 
 #include <libcaja-extension/caja-configurable.h>
+#include <libcaja-private/caja-dialog-notebook.h>
 
 #include "caja-file-management-properties.h"
 
@@ -193,66 +194,6 @@ enum
 };
 
 static void caja_file_management_properties_dialog_update_media_sensitivity (GtkBuilder *builder);
-
-static gboolean
-dialog_page_scroll_event_cb (GtkWidget *widget, GdkEventScroll *event, GtkWindow *window)
-{
-    GtkNotebook *notebook = GTK_NOTEBOOK (widget);
-    GtkWidget *child, *event_widget, *action_widget;
-
-    child = gtk_notebook_get_nth_page (notebook, gtk_notebook_get_current_page (notebook));
-    if (child == NULL)
-        return FALSE;
-
-    event_widget = gtk_get_event_widget ((GdkEvent *) event);
-
-    /* Ignore scroll events from the content of the page */
-    if (event_widget == NULL ||
-        event_widget == child ||
-        gtk_widget_is_ancestor (event_widget, child))
-        return FALSE;
-
-    /* And also from the action widgets */
-    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_START);
-    if (event_widget == action_widget ||
-        (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
-        return FALSE;
-    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_END);
-    if (event_widget == action_widget ||
-        (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
-        return FALSE;
-
-    switch (event->direction) {
-    case GDK_SCROLL_RIGHT:
-    case GDK_SCROLL_DOWN:
-        gtk_notebook_next_page (notebook);
-        break;
-    case GDK_SCROLL_LEFT:
-    case GDK_SCROLL_UP:
-        gtk_notebook_prev_page (notebook);
-        break;
-    case GDK_SCROLL_SMOOTH:
-        switch (gtk_notebook_get_tab_pos (notebook)) {
-            case GTK_POS_LEFT:
-            case GTK_POS_RIGHT:
-                if (event->delta_y > 0)
-                    gtk_notebook_next_page (notebook);
-                else if (event->delta_y < 0)
-                    gtk_notebook_prev_page (notebook);
-                break;
-            case GTK_POS_TOP:
-            case GTK_POS_BOTTOM:
-                if (event->delta_x > 0)
-                    gtk_notebook_next_page (notebook);
-                else if (event->delta_x < 0)
-                    gtk_notebook_prev_page (notebook);
-                break;
-            }
-        break;
-    }
-
-    return TRUE;
-}
 
 static void
 caja_file_management_properties_size_group_create (GtkBuilder *builder,

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -235,7 +235,71 @@ static GtkLabel *attach_ellipsizing_value_label   (GtkGrid *grid,
 
 static GtkWidget* create_pie_widget 		  (FMPropertiesWindow *window);
 
+static gboolean dialog_page_scroll_event_cb       (GtkWidget          *widget,
+                           GdkEventScroll     *event,
+                           GtkWindow          *window);
+
 G_DEFINE_TYPE_WITH_PRIVATE (FMPropertiesWindow, fm_properties_window, GTK_TYPE_DIALOG);
+
+static gboolean
+dialog_page_scroll_event_cb (GtkWidget *widget, GdkEventScroll *event, GtkWindow *window)
+{
+    GtkNotebook *notebook = GTK_NOTEBOOK (widget);
+    GtkWidget *child, *event_widget, *action_widget;
+
+    child = gtk_notebook_get_nth_page (notebook, gtk_notebook_get_current_page (notebook));
+    if (child == NULL)
+        return FALSE;
+
+    event_widget = gtk_get_event_widget ((GdkEvent *) event);
+
+    /* Ignore scroll events from the content of the page */
+    if (event_widget == NULL ||
+        event_widget == child ||
+        gtk_widget_is_ancestor (event_widget, child))
+        return FALSE;
+
+    /* And also from the action widgets */
+    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_START);
+    if (event_widget == action_widget ||
+        (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
+        return FALSE;
+    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_END);
+    if (event_widget == action_widget ||
+        (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
+        return FALSE;
+
+    switch (event->direction) {
+    case GDK_SCROLL_RIGHT:
+    case GDK_SCROLL_DOWN:
+        gtk_notebook_next_page (notebook);
+        break;
+    case GDK_SCROLL_LEFT:
+    case GDK_SCROLL_UP:
+        gtk_notebook_prev_page (notebook);
+        break;
+    case GDK_SCROLL_SMOOTH:
+        switch (gtk_notebook_get_tab_pos (notebook)) {
+            case GTK_POS_LEFT:
+            case GTK_POS_RIGHT:
+                if (event->delta_y > 0)
+                    gtk_notebook_next_page (notebook);
+                else if (event->delta_y < 0)
+                    gtk_notebook_prev_page (notebook);
+                break;
+            case GTK_POS_TOP:
+            case GTK_POS_BOTTOM:
+                if (event->delta_x > 0)
+                    gtk_notebook_next_page (notebook);
+                else if (event->delta_x < 0)
+                    gtk_notebook_prev_page (notebook);
+                break;
+            }
+        break;
+    }
+
+    return TRUE;
+}
 
 static gboolean
 is_multi_file_window (FMPropertiesWindow *window)
@@ -5160,6 +5224,13 @@ create_properties_window (StartupData *startup_data)
 
 	/* Create the notebook tabs. */
 	window->details->notebook = GTK_NOTEBOOK (gtk_notebook_new ());
+        gtk_notebook_set_scrollable (GTK_NOTEBOOK (window->details->notebook), TRUE);
+        gtk_widget_add_events (GTK_WIDGET (window->details->notebook), GDK_SCROLL_MASK);
+        g_signal_connect (window->details->notebook,
+                          "scroll-event",
+                          G_CALLBACK (dialog_page_scroll_event_cb),
+                          window);
+
 	gtk_widget_show (GTK_WIDGET (window->details->notebook));
 	gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (window))),
 			    GTK_WIDGET (window->details->notebook),

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -58,6 +58,7 @@
 #include <libcaja-private/caja-metadata.h>
 #include <libcaja-private/caja-module.h>
 #include <libcaja-private/caja-mime-actions.h>
+#include <libcaja-private/caja-dialog-notebook.h>
 
 #include "fm-properties-window.h"
 #include "fm-ditem-page.h"
@@ -235,71 +236,7 @@ static GtkLabel *attach_ellipsizing_value_label   (GtkGrid *grid,
 
 static GtkWidget* create_pie_widget 		  (FMPropertiesWindow *window);
 
-static gboolean dialog_page_scroll_event_cb       (GtkWidget          *widget,
-                           GdkEventScroll     *event,
-                           GtkWindow          *window);
-
 G_DEFINE_TYPE_WITH_PRIVATE (FMPropertiesWindow, fm_properties_window, GTK_TYPE_DIALOG);
-
-static gboolean
-dialog_page_scroll_event_cb (GtkWidget *widget, GdkEventScroll *event, GtkWindow *window)
-{
-    GtkNotebook *notebook = GTK_NOTEBOOK (widget);
-    GtkWidget *child, *event_widget, *action_widget;
-
-    child = gtk_notebook_get_nth_page (notebook, gtk_notebook_get_current_page (notebook));
-    if (child == NULL)
-        return FALSE;
-
-    event_widget = gtk_get_event_widget ((GdkEvent *) event);
-
-    /* Ignore scroll events from the content of the page */
-    if (event_widget == NULL ||
-        event_widget == child ||
-        gtk_widget_is_ancestor (event_widget, child))
-        return FALSE;
-
-    /* And also from the action widgets */
-    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_START);
-    if (event_widget == action_widget ||
-        (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
-        return FALSE;
-    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_END);
-    if (event_widget == action_widget ||
-        (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
-        return FALSE;
-
-    switch (event->direction) {
-    case GDK_SCROLL_RIGHT:
-    case GDK_SCROLL_DOWN:
-        gtk_notebook_next_page (notebook);
-        break;
-    case GDK_SCROLL_LEFT:
-    case GDK_SCROLL_UP:
-        gtk_notebook_prev_page (notebook);
-        break;
-    case GDK_SCROLL_SMOOTH:
-        switch (gtk_notebook_get_tab_pos (notebook)) {
-            case GTK_POS_LEFT:
-            case GTK_POS_RIGHT:
-                if (event->delta_y > 0)
-                    gtk_notebook_next_page (notebook);
-                else if (event->delta_y < 0)
-                    gtk_notebook_prev_page (notebook);
-                break;
-            case GTK_POS_TOP:
-            case GTK_POS_BOTTOM:
-                if (event->delta_x > 0)
-                    gtk_notebook_next_page (notebook);
-                else if (event->delta_x < 0)
-                    gtk_notebook_prev_page (notebook);
-                break;
-            }
-        break;
-    }
-
-    return TRUE;
-}
 
 static gboolean
 is_multi_file_window (FMPropertiesWindow *window)


### PR DESCRIPTION
Add scroll tabs with mouse wheel for file's properties and caja's preferences windows.

I plan to work on pane's notebook once this PR merges, i have seen gsettings key 'ctrl-tab-switch-tabs' without GUI that should be add in 'caja-file-management-properties.c'.

Regards