### PR TITLE
desktop: Always draw the items label frame

### DIFF
--- a/data/caja-desktop.css
+++ b/data/caja-desktop.css
@@ -4,6 +4,7 @@
 .caja-desktop-window,
 .caja-desktop:not(:selected):not(:active):not(.rubberband){
 	background-color: transparent;
+	border: none;
 }
 
 /* desktop mode */

--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -1289,23 +1289,27 @@ draw_label_text (CajaIconCanvasItem *item,
                           "activate_prelight_icon_label", &prelight_label,
                           NULL);
 
-    /* if the icon is highlighted, do some set-up */
-    if (needs_highlight &&
-        !details->is_renaming) {
-            state |= GTK_STATE_FLAG_SELECTED;
-
-            frame_x = is_rtl_label_beside ? text_rect.x0 + item->details->text_dx : text_rect.x0;
-            frame_y = text_rect.y0;
-            frame_w = is_rtl_label_beside ? text_rect.x1 - text_rect.x0 - item->details->text_dx : text_rect.x1 - text_rect.x0;
-            frame_h = text_rect.y1 - text_rect.y0;
-    } else if (!needs_highlight && have_editable &&
-               details->text_width > 0 && details->text_height > 0 &&
-               prelight_label && item->details->is_prelit) {
+    /* if the icon needs a background, do some set-up */
+    if (!needs_highlight && have_editable &&
+        details->text_width > 0 && details->text_height > 0 &&
+        prelight_label && item->details->is_prelit) {
             state |= GTK_STATE_FLAG_PRELIGHT;
 
             frame_x = text_rect.x0;
             frame_y = text_rect.y0;
             frame_w = text_rect.x1 - text_rect.x0;
+            frame_h = text_rect.y1 - text_rect.y0;
+    } else if (!details->is_renaming) {
+            /* always draw a background but when renaming where the editing
+             * area is on top already. The default background will be transparent,
+             * but drawing it already allows the theme to change that. */
+
+            if (needs_highlight)
+                state |= GTK_STATE_FLAG_SELECTED;
+
+            frame_x = is_rtl_label_beside ? text_rect.x0 + item->details->text_dx : text_rect.x0;
+            frame_y = text_rect.y0;
+            frame_w = is_rtl_label_beside ? text_rect.x1 - text_rect.x0 - item->details->text_dx : text_rect.x1 - text_rect.x0;
             frame_h = text_rect.y1 - text_rect.y0;
     } else {
             draw_frame = FALSE;


### PR DESCRIPTION
Draw the frame under the items label even when not selected and not in prelight state, so that it is possible to theme it in the other states. However we still don't draw it when editing, because there is the editing widget frame already and drawing the label's one might slightly overflow the editing widget's borders and lead to slightly ugly results.

Being able to draw a background is especially useful for accessibility purposes (e.g. a high contrast theme would typically make sure there is a background with enough contrast), but might be useful to all as desktop backgrounds are often not uniform at all.

By default this is drawn transparent on the non-selected and non-prelight states (no change in default appearance then), but allows the user to customize it with a background if need be.

Unfortunately for the moment this cannot be altered by theme, so the user will have to modify the GTK custom user CSS directly, but it still is better than nothing and can hopefully be solved better later.

---
The code change is basically reordering the branches and removing the `needs_highlight` from what was the first branch's test.

You can test the change by adding the following to *~/.config/gtk-3.0/gtk.css*:
```CSS
.caja-desktop .caja-canvas-item {
	background-color:white;
	color:black;
	text-shadow:none;
}

.caja-desktop .caja-canvas-item:selected {
	background-color:black;
	color:white;
}
```
and restart Caja.  You should then see a white background behind the desktop items labels.