### PR TITLE
Travis CI: debian build: show all the warnings of deprecated functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,6 +174,12 @@ variables:
     -enable-checker alpha.core.FixedAddr
     -enable-checker security.insecureAPI.strcpy"'
 
+before_scripts:
+  - if [ ${DISTRO_NAME} == "debian" ];then
+  -     egrep -lRZ 'G_GNUC_BEGIN_IGNORE_DEPRECATIONS' . | xargs -0 -l sed -i -e 's/G_GNUC_BEGIN_IGNORE_DEPRECATIONS/ /g'
+  -     egrep -lRZ 'G_GNUC_END_IGNORE_DEPRECATIONS' . | xargs -0 -l sed -i -e 's/G_GNUC_END_IGNORE_DEPRECATIONS/ /g'
+  - fi
+
 build_scripts:
 # build failed with f30 und using clang patch, fixed in f30?
 #  - if [ ${DISTRO_NAME} == "fedora" ];then


### PR DESCRIPTION
The warnings of deprecated GtkAction are silenced by the PR https://github.com/mate-desktop/caja/pull/1221

I don't agree, and I did this PR to show all the warnings in debian build with travis.