### PR TITLE
Fix cppcheck warnings appeared since the silence of deprecated gtkaction warnings

### DIFF
--- a/libcaja-private/caja-clipboard.c
+++ b/libcaja-private/caja-clipboard.c
@@ -147,7 +147,7 @@ received_clipboard_contents (GtkClipboard     *clipboard,
 
     action_group = data;
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action = gtk_action_group_get_action (action_group,
                                           "Paste");
     if (action != NULL)
@@ -155,7 +155,7 @@ received_clipboard_contents (GtkClipboard     *clipboard,
         gtk_action_set_sensitive (action,
                                   gtk_selection_data_targets_include_text (selection_data));
     }
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 
     g_object_unref (action_group);
 }
@@ -176,11 +176,11 @@ set_paste_sensitive_if_clipboard_contains_data (GtkActionGroup *action_group)
         GtkAction *action;
 
         /* If selection notification isn't supported, always activate Paste */
-        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         action = gtk_action_group_get_action (action_group,
                                               "Paste");
         gtk_action_set_sensitive (action, TRUE);
-        G_GNUC_END_IGNORE_DEPRECATIONS
+        G_GNUC_END_IGNORE_DEPRECATIONS;
     }
 }
 
@@ -189,14 +189,14 @@ set_clipboard_menu_items_sensitive (GtkActionGroup *action_group)
 {
     GtkAction *action;
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action = gtk_action_group_get_action (action_group,
                                           "Cut");
     gtk_action_set_sensitive (action, TRUE);
     action = gtk_action_group_get_action (action_group,
                                           "Copy");
     gtk_action_set_sensitive (action, TRUE);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -204,14 +204,14 @@ set_clipboard_menu_items_insensitive (GtkActionGroup *action_group)
 {
     GtkAction *action;
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action = gtk_action_group_get_action (action_group,
                                           "Cut");
     gtk_action_set_sensitive (action, FALSE);
     action = gtk_action_group_get_action (action_group,
                                           "Copy");
     gtk_action_set_sensitive (action, FALSE);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static gboolean
@@ -493,13 +493,13 @@ initialize_clipboard_component_with_callback_data (GtkEditable *target,
     GtkActionGroup *action_group;
     TargetCallbackData *target_data;
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action_group = gtk_action_group_new ("ClipboardActions");
     gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
     gtk_action_group_add_actions (action_group,
                                   clipboard_entries, G_N_ELEMENTS (clipboard_entries),
                                   target);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 
     /* Do the actual connection of the UI to the container at
      * focus time, and disconnect at both focus and destroy

--- a/libcaja-private/caja-ui-utilities.c
+++ b/libcaja-private/caja-ui-utilities.c
@@ -61,10 +61,10 @@ caja_ui_prepare_merge_ui (GtkUIManager *ui_manager,
                           GtkActionGroup **action_group)
 {
     *merge_id = gtk_ui_manager_new_merge_id (ui_manager);
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     *action_group = gtk_action_group_new (name);
     gtk_action_group_set_translation_domain (*action_group, GETTEXT_PACKAGE);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
     gtk_ui_manager_insert_action_group (ui_manager, *action_group, 0);
     g_object_unref (*action_group); /* owned by ui manager */
 }
@@ -139,9 +139,9 @@ extension_action_sensitive_callback (CajaMenuItem *item,
                   "sensitive", &value,
                   NULL);
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     gtk_action_set_sensitive (GTK_ACTION (user_data), value);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static cairo_surface_t *
@@ -184,12 +184,12 @@ caja_action_from_menu_item (CajaMenuItem *item,
                   "priority", &priority,
                   NULL);
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action = gtk_action_new (name,
                              label,
                              tip,
                              icon_name);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 
     if (icon_name != NULL)
     {
@@ -206,9 +206,9 @@ caja_action_from_menu_item (CajaMenuItem *item,
         }
     }
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     gtk_action_set_sensitive (action, sensitive);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
     g_object_set (action, "is-important", priority, NULL);
 
     g_signal_connect_data (action, "activate",
@@ -238,12 +238,12 @@ caja_toolbar_action_from_menu_item (CajaMenuItem *item, GtkWidget *parent_widget
                   "priority", &priority,
                   NULL);
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action = gtk_action_new (name,
                              label,
                              tip,
                              icon_name);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 
     if (icon_name != NULL)
     {
@@ -260,9 +260,9 @@ caja_toolbar_action_from_menu_item (CajaMenuItem *item, GtkWidget *parent_widget
         }
     }
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     gtk_action_set_sensitive (action, sensitive);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
     g_object_set (action, "is-important", priority, NULL);
 
     g_signal_connect_data (action, "activate",

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -726,29 +726,29 @@ real_update_menus (FMDirectoryView *view)
 
     /* New Launcher */
     disable_command_line = g_settings_get_boolean (mate_lockdown_preferences, CAJA_PREFERENCES_LOCKDOWN_COMMAND_LINE);
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action = gtk_action_group_get_action (desktop_view->priv->desktop_action_group,
                                           FM_ACTION_NEW_LAUNCHER_DESKTOP);
     gtk_action_set_visible (action,
                             !disable_command_line);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 
     /* Empty Trash */
     include_empty_trash = trash_link_is_selection (view);
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action = gtk_action_group_get_action (desktop_view->priv->desktop_action_group,
                                           FM_ACTION_EMPTY_TRASH_CONDITIONAL);
     gtk_action_set_visible (action,
                             include_empty_trash);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
     if (include_empty_trash)
     {
         label = g_strdup (_("E_mpty Trash"));
         g_object_set (action , "label", label, NULL);
-        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         gtk_action_set_sensitive (action,
                                   !caja_trash_monitor_is_empty ());
-        G_GNUC_END_IGNORE_DEPRECATIONS
+        G_GNUC_END_IGNORE_DEPRECATIONS;
         g_free (label);
     }
 }
@@ -798,14 +798,14 @@ real_merge_menus (FMDirectoryView *view)
 
     ui_manager = fm_directory_view_get_ui_manager (view);
 
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action_group = gtk_action_group_new ("DesktopViewActions");
     gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
     desktop_view->priv->desktop_action_group = action_group;
     gtk_action_group_add_actions (action_group,
                                   desktop_view_entries, G_N_ELEMENTS (desktop_view_entries),
                                   view);
-    G_GNUC_END_IGNORE_DEPRECATIONS
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 
 
     gtk_ui_manager_insert_action_group (ui_manager, action_group, 0);

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -995,7 +995,7 @@ trash_or_delete_selected_files (FMDirectoryView *view)
 static gboolean
 real_trash (FMDirectoryView *view)
 {
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GtkAction *action;
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
@@ -1004,7 +1004,7 @@ real_trash (FMDirectoryView *view)
 	    gtk_action_get_visible (action)) {
 		trash_or_delete_selected_files (view);
 		return TRUE;
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	}
 	return FALSE;
 }
@@ -1068,7 +1068,7 @@ action_restore_from_trash_callback (GtkAction *action,
 static gboolean
 real_delete (FMDirectoryView *view)
 {
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GtkAction *action;
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
@@ -1077,7 +1077,7 @@ real_delete (FMDirectoryView *view)
 	    gtk_action_get_visible (action)) {
 		delete_selected_files (view);
 		return TRUE;
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	}
 	return FALSE;
 }
@@ -4440,12 +4440,12 @@ add_submenu (GtkUIManager *ui_manager,
 		escaped_label = eel_str_double_underscores (label);
 
 		if (add_action) {
-			G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+			G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 			action = gtk_action_new (action_name,
 						 escaped_label,
 						 NULL,
 						 NULL);
-			G_GNUC_END_IGNORE_DEPRECATIONS
+			G_GNUC_END_IGNORE_DEPRECATIONS;
 			if (surface != NULL) {
 				g_object_set_data_full (G_OBJECT (action), "menu-icon",
 							cairo_surface_reference (surface),
@@ -4454,10 +4454,10 @@ add_submenu (GtkUIManager *ui_manager,
 
 			g_object_set (action, "hide-if-empty", FALSE, NULL);
 
-			G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+			G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 			gtk_action_group_add_action (action_group,
 						     action);
-			G_GNUC_END_IGNORE_DEPRECATIONS
+			G_GNUC_END_IGNORE_DEPRECATIONS;
 			g_object_unref (action);
 		}
 
@@ -4510,12 +4510,12 @@ add_application_to_open_with_menu (FMDirectoryView *view,
 
 	action_name = g_strdup_printf ("open_with_%d", index);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_new (action_name,
 				 label,
 				 tip,
 				 NULL);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	app_icon = g_app_info_get_icon (application);
 	if (app_icon != NULL) {
@@ -4524,9 +4524,9 @@ add_application_to_open_with_menu (FMDirectoryView *view,
 		app_icon = g_themed_icon_new ("application-x-executable");
 	}
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_set_gicon (action, app_icon);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_unref (app_icon);
 
 	g_signal_connect_data (action, "activate",
@@ -4534,10 +4534,10 @@ add_application_to_open_with_menu (FMDirectoryView *view,
 			       launch_parameters,
 			       (GClosureNotify)application_launch_parameters_free, 0);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_group_add_action (view->details->open_with_action_group,
 				     action);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_unref (action);
 
 	gtk_ui_manager_add_ui (caja_window_info_get_ui_manager (view->details->window),
@@ -4601,23 +4601,23 @@ add_parent_folder_to_open_menu (FMDirectoryView *view,
 	tip = g_strdup (_("Open parent location for the selected item"));
 	action_name = g_strdup ("open_location");
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_new (action_name,
 				 label,
 				 tip,
 				 NULL);
 
 	gtk_action_set_icon_name (action, "folder");
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_signal_connect_data (action, "activate",
 			       G_CALLBACK (open_parent_folder_callback),
 			       uri, (GClosureNotify)g_free, 0);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_group_add_action (view->details->open_with_action_group,
 				     action);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_unref (action);
 
 	gtk_ui_manager_add_ui (caja_window_info_get_ui_manager (view->details->window),
@@ -4807,7 +4807,7 @@ reset_open_with_menu (FMDirectoryView *view, GList *selection)
 	open_with_chooser_visible = other_applications_visible &&
 				    g_list_length (selection) == 1;
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	if (submenu_visible) {
 		action = gtk_action_group_get_action (view->details->dir_action_group,
 						      FM_ACTION_OTHER_APPLICATION1);
@@ -4823,7 +4823,7 @@ reset_open_with_menu (FMDirectoryView *view, GList *selection)
 						      FM_ACTION_OTHER_APPLICATION2);
 		gtk_action_set_visible (action, open_with_chooser_visible);
 	}
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static GList *
@@ -4995,12 +4995,12 @@ add_extension_action_for_files (FMDirectoryView *view,
 		      "priority", &priority,
 		      NULL);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_new (name,
 				 label,
 				 tip,
 				 icon);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	if (icon != NULL) {
 		surface = get_menu_icon (icon, GTK_WIDGET (view));
@@ -5011,9 +5011,9 @@ add_extension_action_for_files (FMDirectoryView *view,
 		}
 	}
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_set_sensitive (action, sensitive);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_set (action, "is-important", priority, NULL);
 
 	data = g_new0 (ExtensionActionCallbackData, 1);
@@ -5027,10 +5027,10 @@ add_extension_action_for_files (FMDirectoryView *view,
 			       data,
 			       (GClosureNotify)extension_action_callback_data_free, 0);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_group_add_action (view->details->extensions_menu_action_group,
 				     GTK_ACTION (action));
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_unref (action);
 
 	g_free (name);
@@ -5066,9 +5066,9 @@ add_extension_menu_items (FMDirectoryView *view,
 		action = add_extension_action_for_files (view, item, files);
 
 		path = g_build_path ("/", FM_DIRECTORY_VIEW_POPUP_PATH_EXTENSION_ACTIONS, subdirectory, NULL);
-		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action_name = gtk_action_get_name (action);
-		G_GNUC_END_IGNORE_DEPRECATIONS
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		gtk_ui_manager_add_ui (ui_manager,
 				       view->details->extensions_menu_merge_id,
@@ -5096,9 +5096,9 @@ add_extension_menu_items (FMDirectoryView *view,
 
 			children = caja_menu_get_items (menu);
 
-			G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+			G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 			subdir = g_build_path ("/", subdirectory, gtk_action_get_name (action), NULL);
-			G_GNUC_END_IGNORE_DEPRECATIONS
+			G_GNUC_END_IGNORE_DEPRECATIONS;
 			add_extension_menu_items (view,
 						  files,
 						  children,
@@ -5476,12 +5476,12 @@ add_script_to_scripts_menus (FMDirectoryView *directory_view,
 	action_name = escape_action_name (uri, "script_");
 	escaped_label = eel_str_double_underscores (name);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_new (action_name,
 				 escaped_label,
 				 tip,
 				 NULL);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	surface = get_menu_icon_for_file (file, GTK_WIDGET (directory_view));
 	if (surface != NULL) {
@@ -5495,10 +5495,10 @@ add_script_to_scripts_menus (FMDirectoryView *directory_view,
 			       launch_parameters,
 			       (GClosureNotify)script_launch_parameters_free, 0);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_group_add_action_with_accel (directory_view->details->scripts_action_group,
 						action, NULL);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_unref (action);
 
 	ui_manager = caja_window_info_get_ui_manager (directory_view->details->window);
@@ -5691,10 +5691,10 @@ update_scripts_menu (FMDirectoryView *view)
 	}
 	caja_directory_list_free (sorted_copy);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group, FM_ACTION_SCRIPTS);
 	gtk_action_set_visible (action, any_scripts);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -5733,12 +5733,12 @@ add_template_to_templates_menus (FMDirectoryView *directory_view,
 
 	parameters = create_template_parameters_new (file, directory_view);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_new (action_name,
 				 escaped_label,
 				 tip,
 				 NULL);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	surface = get_menu_icon_for_file (file, GTK_WIDGET (directory_view));
 	if (surface != NULL) {
@@ -5752,10 +5752,10 @@ add_template_to_templates_menus (FMDirectoryView *directory_view,
 			       parameters,
 			       (GClosureNotify)create_templates_parameters_free, 0);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_group_add_action (directory_view->details->templates_action_group,
 				     action);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_unref (action);
 
 	ui_manager = caja_window_info_get_ui_manager (directory_view->details->window);
@@ -5962,10 +5962,10 @@ update_templates_menu (FMDirectoryView *view)
 	}
 	caja_directory_list_free (sorted_copy);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group, FM_ACTION_NO_TEMPLATES);
 	gtk_action_set_visible (action, !any_templates);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_free (templates_directory_uri);
 }
@@ -7680,9 +7680,9 @@ connect_proxy (FMDirectoryView *view,
 	cairo_surface_t *surface;
 	GtkWidget *image;
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_name = gtk_action_get_name (action);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	if (strcmp (action_name, FM_ACTION_NEW_EMPTY_FILE) == 0 &&
 	    GTK_IS_IMAGE_MENU_ITEM (proxy)) {
 		surface = get_menu_icon ("text-x-generic", GTK_WIDGET (view));
@@ -7742,18 +7742,18 @@ real_merge_menus (FMDirectoryView *view)
 
 	ui_manager = caja_window_info_get_ui_manager (view->details->window);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_group = gtk_action_group_new ("DirViewActions");
 	gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
 	view->details->dir_action_group = action_group;
 	gtk_action_group_add_actions (action_group,
 				      directory_view_entries, G_N_ELEMENTS (directory_view_entries),
 				      view);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	/* Translators: %s is a directory */
 	tooltip = g_strdup_printf(_("Run or manage scripts from %s"), "~/.config/caja/scripts");
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	/* Create a script action here specially because its tooltip is dynamic */
 	action = gtk_action_new ("Scripts", _("_Scripts"), tooltip, NULL);
 	gtk_action_group_add_action (action_group, action);
@@ -7762,7 +7762,7 @@ real_merge_menus (FMDirectoryView *view)
 
 	action = gtk_action_group_get_action (action_group, FM_ACTION_NO_TEMPLATES);
 	gtk_action_set_sensitive (action, FALSE);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_signal_connect_object (action_group, "connect-proxy",
 				 G_CALLBACK (connect_proxy), G_OBJECT (view),
@@ -7851,7 +7851,7 @@ clipboard_targets_received (GtkClipboard     *clipboard,
 	selection = fm_directory_view_get_selection (view);
 	count = g_list_length (selection);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_PASTE);
 	gtk_action_set_sensitive (action,
@@ -7865,17 +7865,17 @@ clipboard_targets_received (GtkClipboard     *clipboard,
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_PASTE_FILES_INTO);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_set_data (G_OBJECT (action),
 			   "can-paste-according-to-clipboard",
 			   GINT_TO_POINTER (can_paste));
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_set_sensitive (action,
 				  GPOINTER_TO_INT (g_object_get_data (G_OBJECT (action),
 						   "can-paste-according-to-clipboard")) &&
 				  GPOINTER_TO_INT (g_object_get_data (G_OBJECT (action),
 						   "can-paste-according-to-destination")));
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	caja_file_list_free (selection);
 
@@ -8150,9 +8150,9 @@ update_restore_from_trash_action (GtkAction *action,
 	}
 
 	if (original_file != NULL || original_dirs != NULL) {
-		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_set_visible (action, TRUE);
-		G_GNUC_END_IGNORE_DEPRECATIONS
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		if (original_file != NULL) {
 			original_location = caja_file_get_location (original_file);
@@ -8207,9 +8207,9 @@ update_restore_from_trash_action (GtkAction *action,
 			g_object_unref (original_location);
 		}
 	} else {
-		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_set_visible (action, FALSE);
-		G_GNUC_END_IGNORE_DEPRECATIONS
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 	}
 
 	caja_file_unref (original_file);
@@ -8294,7 +8294,7 @@ real_update_menus_volumes (FMDirectoryView *view,
 		show_poll &= show_poll_one;
 	}
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_CONNECT_TO_SERVER_LINK);
 	gtk_action_set_visible (action, show_connect);
@@ -8376,7 +8376,7 @@ real_update_menus_volumes (FMDirectoryView *view,
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_POLL);
 	gtk_action_set_visible (action, show_poll);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	show_self_mount = show_self_unmount = show_self_eject =
 		show_self_format = show_self_start = show_self_stop = show_self_poll = FALSE;
@@ -8392,7 +8392,7 @@ real_update_menus_volumes (FMDirectoryView *view,
 			       &show_self_poll,
 			       &self_start_stop_type);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_SELF_MOUNT_VOLUME);
 	gtk_action_set_visible (action, show_self_mount);
@@ -8470,7 +8470,7 @@ real_update_menus_volumes (FMDirectoryView *view,
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_SELF_POLL);
 	gtk_action_set_visible (action, show_self_poll);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 }
 
@@ -8504,7 +8504,7 @@ real_update_location_menu_volumes (FMDirectoryView *view)
 				  &show_poll,
 				  &start_stop_type);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_MOUNT_VOLUME);
 	gtk_action_set_visible (action, show_mount);
@@ -8582,7 +8582,7 @@ real_update_location_menu_volumes (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_POLL);
 	gtk_action_set_visible (action, show_poll);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 /* TODO: we should split out this routine into two functions:
@@ -8608,7 +8608,7 @@ real_update_paste_menu (FMDirectoryView *view,
 	can_paste_files_into = (selection_count == 1 &&
 	                        can_paste_into_file (CAJA_FILE (selection->data)));
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_PASTE);
 	gtk_action_set_sensitive (action, !is_read_only);
@@ -8617,7 +8617,7 @@ real_update_paste_menu (FMDirectoryView *view,
 					      FM_ACTION_PASTE_FILES_INTO);
 	gtk_action_set_visible (action, can_paste_files_into);
 	gtk_action_set_sensitive (action, !selection_is_read_only);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	/* Ask the clipboard */
 	g_object_ref (view); /* Need to keep the object alive until we get the reply */
@@ -8657,7 +8657,7 @@ real_update_location_menu (FMDirectoryView *view)
 		label = g_strdup (ngettext ("_Browse Folder",
 					    "_Browse Folders", 1));
 	}
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_OPEN_ALTERNATE);
 	g_object_set (action,
@@ -8667,7 +8667,7 @@ real_update_location_menu (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_OPEN_IN_NEW_TAB);
 	gtk_action_set_visible (action, show_open_in_new_tab);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	if (show_open_in_new_tab) {
 		if (g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_ALWAYS_USE_BROWSER)) {
@@ -8680,11 +8680,11 @@ real_update_location_menu (FMDirectoryView *view)
 			      NULL);
 	}
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_OPEN_FOLDER_WINDOW);
 	gtk_action_set_visible (action, show_open_folder_window);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	file = view->details->location_popup_directory_as_file;
 	g_assert (CAJA_IS_FILE (file));
@@ -8701,24 +8701,24 @@ real_update_location_menu (FMDirectoryView *view)
 		!is_special_link &&
 		!is_desktop_or_home_dir;
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_CUT);
 	gtk_action_set_sensitive (action, can_delete_file);
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_PASTE_FILES_INTO);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_set_data (G_OBJECT (action),
 			   "can-paste-according-to-destination",
 			   GINT_TO_POINTER (can_paste_into_file (file)));
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_set_sensitive (action,
 				  GPOINTER_TO_INT (g_object_get_data (G_OBJECT (action),
 						   "can-paste-according-to-clipboard")) &&
 				  GPOINTER_TO_INT (g_object_get_data (G_OBJECT (action),
 						   "can-paste-according-to-destination")));
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	show_delete = TRUE;
 
@@ -8737,7 +8737,7 @@ real_update_location_menu (FMDirectoryView *view)
 		show_separate_delete_command = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_ENABLE_DELETE);
 	}
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_TRASH);
 	g_object_set (action,
@@ -8763,7 +8763,7 @@ real_update_location_menu (FMDirectoryView *view)
 
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_LOCATION_RESTORE_FROM_TRASH);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	l.prev = NULL;
 	l.next = NULL;
 	l.data = file;
@@ -8872,7 +8872,7 @@ real_update_menus (FMDirectoryView *view)
 
 	vfolder_directory = we_are_in_vfolder_desktop_dir (view);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_RENAME);
 	gtk_action_set_sensitive (action,
@@ -8886,7 +8886,7 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_OPEN);
 	gtk_action_set_sensitive (action, selection_count != 0);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	can_open = show_app = selection_count != 0;
 
@@ -8960,12 +8960,12 @@ real_update_menus (FMDirectoryView *view)
 		app_icon = g_themed_icon_new ("document-open");
 	}
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_set_gicon (action, app_icon);
 	g_object_unref (app_icon);
 
 	gtk_action_set_visible (action, can_open);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	g_free (label_with_underscore);
 
@@ -9001,7 +9001,7 @@ real_update_menus (FMDirectoryView *view)
 							    selection_count));
 	}
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_OPEN_ALTERNATE);
 	g_object_set (action, "label",
@@ -9011,7 +9011,7 @@ real_update_menus (FMDirectoryView *view)
 
 	gtk_action_set_sensitive (action,  selection_count != 0);
 	gtk_action_set_visible (action, show_open_alternate);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	/* Open in New Tab action */
 	if (caja_window_info_get_window_type (view->details->window) == CAJA_WINDOW_NAVIGATION) {
@@ -9035,7 +9035,7 @@ real_update_menus (FMDirectoryView *view)
 									 selection_count);
 			}
 		}
-		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = gtk_action_group_get_action (view->details->dir_action_group,
 						      FM_ACTION_OPEN_IN_NEW_TAB);
 		gtk_action_set_sensitive (action, selection_count != 0);
@@ -9048,12 +9048,12 @@ real_update_menus (FMDirectoryView *view)
 		action = gtk_action_group_get_action (view->details->dir_action_group,
 						      FM_ACTION_OPEN_IN_NEW_TAB);
 		gtk_action_set_visible (action, FALSE);
-		G_GNUC_END_IGNORE_DEPRECATIONS
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 	}
 
 	/* next pane actions, only in navigation mode */
 	if (caja_window_info_get_window_type (view->details->window) != CAJA_WINDOW_NAVIGATION) {
-		G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = gtk_action_group_get_action (view->details->dir_action_group,
 						      FM_ACTION_COPY_TO_NEXT_PANE);
 		gtk_action_set_visible (action, FALSE);
@@ -9065,7 +9065,7 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_OPEN_FOLDER_WINDOW);
 	gtk_action_set_visible (action, show_open_folder_window);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	/* Broken into its own function just for convenience */
 	reset_open_with_menu (view, selection);
@@ -9081,7 +9081,7 @@ real_update_menus (FMDirectoryView *view)
 		show_separate_delete_command = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_ENABLE_DELETE);
 	}
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_TRASH);
 	g_object_set (action,
@@ -9116,7 +9116,7 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_CREATE_LINK);
 	gtk_action_set_sensitive (action, can_link_files);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_set (action, "label",
 		      ngettext ("Ma_ke Link",
 			      	"Ma_ke Links",
@@ -9126,7 +9126,7 @@ real_update_menus (FMDirectoryView *view)
 	show_properties = (!FM_IS_DESKTOP_ICON_VIEW (view) || selection_count > 0) &&
 			   fm_directory_view_supports_properties (view);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_PROPERTIES);
 
@@ -9152,7 +9152,7 @@ real_update_menus (FMDirectoryView *view)
 		      NULL);
 	gtk_action_set_sensitive (action, !caja_trash_monitor_is_empty ());
 	gtk_action_set_visible (action, should_show_empty_trash (view));
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	show_save_search = FALSE;
 	save_search_sensitive = FALSE;
@@ -9169,7 +9169,7 @@ real_update_menus (FMDirectoryView *view)
 			show_save_search_as = TRUE;
 		}
 	}
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_SAVE_SEARCH);
 	gtk_action_set_visible (action, show_save_search);
@@ -9198,17 +9198,17 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_COPY);
 	gtk_action_set_sensitive (action, can_copy_files);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	real_update_paste_menu (view, selection, selection_count);
 
 	disable_command_line = g_settings_get_boolean (mate_lockdown_preferences, CAJA_PREFERENCES_LOCKDOWN_COMMAND_LINE);
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_NEW_LAUNCHER);
 	gtk_action_set_visible (action, vfolder_directory && !disable_command_line);
 	gtk_action_set_sensitive (action, can_create_files);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	real_update_menus_volumes (view, selection, selection_count);
 
@@ -9220,11 +9220,11 @@ real_update_menus (FMDirectoryView *view)
 		update_scripts_menu (view);
 	}
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_NEW_DOCUMENTS);
 	gtk_action_set_sensitive (action, can_create_files);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	if (can_create_files && view->details->templates_invalid) {
 		update_templates_menu (view);
@@ -9232,7 +9232,7 @@ real_update_menus (FMDirectoryView *view)
 
 	next_pane_is_writable = has_writable_extra_pane (view);
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	/* next pane: works if file is copyable, and next pane is writable */
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_COPY_TO_NEXT_PANE);
@@ -9264,7 +9264,7 @@ real_update_menus (FMDirectoryView *view)
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      "MoveToMenu");
 	gtk_action_set_sensitive (action, can_delete_files);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 /**
@@ -11290,11 +11290,11 @@ undo_update_menu (FMDirectoryView *view)
 	gchar* label;
 	gchar* tooltip;
 
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	/* Update undo entry */
 	action = gtk_action_group_get_action (view->details->dir_action_group,
 					      FM_ACTION_UNDO);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	available = view->details->undo_active;
 	if (available) {
 		label = view->details->undo_action_label;
@@ -11308,13 +11308,13 @@ undo_update_menu (FMDirectoryView *view)
 		      "label", label,
 		      "tooltip", tooltip,
 		      NULL);
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_set_sensitive (action, available);
 
 	/* Update redo entry */
 	action = gtk_action_group_get_action (view->details->dir_action_group,
                                           FM_ACTION_REDO);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	available = view->details->redo_active;
 	if (available) {
 		label = view->details->redo_action_label;
@@ -11328,7 +11328,7 @@ undo_update_menu (FMDirectoryView *view)
 		      "label", label,
 		      "tooltip", tooltip,
 		      NULL);
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_set_sensitive (action, available);
-	G_GNUC_END_IGNORE_DEPRECATIONS
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }


### PR DESCRIPTION
https://caja.mate-desktop.dev

cppcheck warnings:

master branch: 397

this PR: 350

seems `G_GNUC_BEGIN_IGNORE_DEPRECATIONS` and `G_GNUC_END_IGNORE_DEPRECATIONS` need semicolon

gtk code already have semicolon, for reference, see: https://github.com/GNOME/gtk/blob/gtk-3-22/gtk/deprecated/gtkaction.c#L226