### PR TITLE
hidpi: ensure all icons are properly scaled

### DIFF
--- a/libcaja-private/caja-icon-info.c
+++ b/libcaja-private/caja-icon-info.c
@@ -410,14 +410,14 @@ caja_icon_info_lookup (GIcon *icon,
                                                                  icon,
                                                                  size,
                                                                  scale,
-                                                                 0);
+                                                                 GTK_ICON_LOOKUP_FORCE_SIZE);
 
         if (!gtkicon_info) {
             gtkicon_info = gtk_icon_theme_lookup_icon_for_scale (icon_theme,
                                                                  "text-x-generic",
                                                                  size,
                                                                  scale,
-                                                                 0);
+                                                                 GTK_ICON_LOOKUP_FORCE_SIZE);
         }
 
         icon_info = caja_icon_info_new_for_icon_info (gtkicon_info, scale);


### PR DESCRIPTION
In caja-icon-info.c use GTK_ICON_LOOKUP_FORCE_SIZE flag to ensure that icons actually scale when window-scaling-factor is set to 2 or more. Tested at window-scaling-factor=1 and window-scaling-factor=2