### PR TITLE
Restore transparent background on icon view labels

### DIFF
--- a/data/caja-desktop.css
+++ b/data/caja-desktop.css
@@ -2,7 +2,10 @@
 /* This is loaded with GTK_STYLE_PROVIDER_PRIORITY_APPLICATION and overrides themes */
 
 .caja-desktop-window,
-.caja-desktop:not(:selected):not(:active):not(.rubberband){
+.caja-desktop:not(:selected):not(:active):not(.rubberband),
+/* unfortunately we also have to apply this to all views normal states for the
+ * split view items not to have background */
+.caja-canvas-item:not(:selected):not(:active):not(.rubberband){
 	background-color: transparent;
 	border: none;
 }


### PR DESCRIPTION
18e4fbd005bd561e4a12ed388d4d9a8c93f0b15b started always drawing the frame on canvas items for the desktop's sake, but it also impacts other icon views.  This is good in theory, but conflicts with some themes that used to work fine and now display an unwanted background because of generic rules matching these elements.

Unfortunately there don't seem to be another solution than providing overrides for this yet, so do that, as anyway before recently the background wasn't drawn at all even if specified.

Spotted in https://github.com/mate-desktop/caja/pull/1240#issuecomment-507039580