### PR TITLE
file-conflict-dialog: don't scale icons twice on hidpi monitors

### DIFF
--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -76,7 +76,7 @@ file_icons_changed (CajaFile *file,
     pixbuf = caja_file_get_icon_pixbuf (fcd->details->destination,
                                         CAJA_ICON_SIZE_LARGE,
                                         TRUE,
-                                        gtk_widget_get_scale_factor (fcd->details->dest_image),
+                                        1, /*Don't double-scale icons*/
                                         CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
 
     gtk_image_set_from_pixbuf (GTK_IMAGE (fcd->details->dest_image), pixbuf);
@@ -85,7 +85,7 @@ file_icons_changed (CajaFile *file,
     pixbuf = caja_file_get_icon_pixbuf (fcd->details->source,
                                         CAJA_ICON_SIZE_LARGE,
                                         TRUE,
-                                        gtk_widget_get_scale_factor (fcd->details->src_image),
+                                        1, /*Don't double-scale icons*/
                                         CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
 
     gtk_image_set_from_pixbuf (GTK_IMAGE (fcd->details->src_image), pixbuf);
@@ -237,7 +237,7 @@ file_list_ready_cb (GList *files,
     pixbuf = caja_file_get_icon_pixbuf (dest,
                                         CAJA_ICON_SIZE_LARGE,
                                         TRUE,
-                                        gtk_widget_get_scale_factor (fcd->details->titles_vbox),
+                                        1, /*Don't double-scale icons*/
                                         CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
     details->dest_image = gtk_image_new_from_pixbuf (pixbuf);
     gtk_box_pack_start (GTK_BOX (details->first_hbox),
@@ -248,7 +248,7 @@ file_list_ready_cb (GList *files,
     pixbuf = caja_file_get_icon_pixbuf (src,
                                         CAJA_ICON_SIZE_LARGE,
                                         TRUE,
-                                        gtk_widget_get_scale_factor (fcd->details->titles_vbox),
+                                        1, /*Don't double-scale icons*/
                                         CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
     details->src_image = gtk_image_new_from_pixbuf (pixbuf);
     gtk_box_pack_start (GTK_BOX (details->second_hbox),


### PR DESCRIPTION
Hardcode scale factor to 1 in  caja_file_get_icon_pixbuf functions in caja-file-conflict as these icons are already getting scaled elsewhere. Otherwise they get scaled twice and the whole dialog is ballooned oversize on hidpi

*Based on similar change made in Nautilus as a small part of fd01842f996b7d07baf2aafb0f68308fc5ed2055 "file-conflict-dialog: separate file logic from UI management " which was a more general refactoring of the file conflict dialog and split out the frontend and backend code.