### PR TITLE
Add support for theme-specific desktop CSS overrides

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -39,6 +39,8 @@ cajadata_DATA = \
 	caja.css \
 	caja-desktop.css \
 	a11y-caja-desktop-base.css \
+	caja-desktop-ContrastHigh.css \
+	caja-desktop-ContrastHighInverse.css \
 	caja-desktop-HighContrast.css \
 	caja-desktop-HighContrastInverse.css \
 	$(NULL)

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -38,6 +38,9 @@ cajadata_DATA = \
 	caja-suggested.placeholder \
 	caja.css \
 	caja-desktop.css \
+	a11y-caja-desktop-base.css \
+	caja-desktop-HighContrast.css \
+	caja-desktop-HighContrastInverse.css \
 	$(NULL)
 
 # app data file

--- a/data/a11y-caja-desktop-base.css
+++ b/data/a11y-caja-desktop-base.css
@@ -1,0 +1,18 @@
+/* base rules for highly contrasted desktop items */
+
+.caja-desktop.caja-canvas-item {
+  text-shadow: none;
+}
+
+.caja-desktop.caja-canvas-item {
+  color: @theme_fg_color;
+  background: @theme_bg_color;
+}
+
+.caja-desktop.caja-canvas-item:selected {
+  color: @theme_selected_fg_color;
+  background: @theme_selected_bg_color;
+}
+.caja-desktop.caja-canvas-item:selected:backdrop {
+  background: mix(@theme_selected_bg_color, @theme_selected_fg_color, 0.3);
+}

--- a/data/caja-desktop-ContrastHigh.css
+++ b/data/caja-desktop-ContrastHigh.css
@@ -1,0 +1,1 @@
+@import url("a11y-caja-desktop-base.css");

--- a/data/caja-desktop-ContrastHighInverse.css
+++ b/data/caja-desktop-ContrastHighInverse.css
@@ -1,0 +1,1 @@
+@import url("a11y-caja-desktop-base.css");

--- a/data/caja-desktop-HighContrast.css
+++ b/data/caja-desktop-HighContrast.css
@@ -1,0 +1,1 @@
+@import url("a11y-caja-desktop-base.css");

--- a/data/caja-desktop-HighContrastInverse.css
+++ b/data/caja-desktop-HighContrastInverse.css
@@ -1,0 +1,1 @@
+@import url("a11y-caja-desktop-base.css");

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -2024,43 +2024,38 @@ caja_application_local_command_line (GApplication *application,
     return TRUE;
 }
 
+static void
+load_custom_css (const gchar *filename,
+                 guint priority)
+{
+    GtkCssProvider *provider;
+    GError *error = NULL;
+    gchar *path = g_build_filename (CAJA_DATADIR, filename, NULL);
+
+    provider = gtk_css_provider_new ();
+    gtk_css_provider_load_from_path (provider, path, &error);
+
+    if (error != NULL) {
+        g_warning ("Can't parse Caja' CSS custom description '%s': %s\n",
+                   filename, error->message);
+        g_error_free (error);
+    } else {
+        gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
+                                                   GTK_STYLE_PROVIDER (provider),
+                                                   priority);
+    }
+
+    g_object_unref (provider);
+    g_free (path);
+}
 
 static void
 init_icons_and_styles (void)
 {
-    GtkCssProvider *provider;
-    GError *error = NULL;
-
     /* add our custom CSS provider */
-    provider = gtk_css_provider_new ();
-    gtk_css_provider_load_from_path (provider,
-				CAJA_DATADIR G_DIR_SEPARATOR_S "caja.css", &error);
-
-    if (error != NULL) {
-        g_warning ("Can't parse Caja' CSS custom description: %s\n", error->message);
-        g_error_free (error);
-    } else {
-        gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
-                               GTK_STYLE_PROVIDER (provider),
-                               GTK_STYLE_PROVIDER_PRIORITY_THEME);
-    }
-
-/* add our desktop CSS provider,  ensures the desktop background does not get covered */
-    provider = gtk_css_provider_new ();
-
-    gtk_css_provider_load_from_path (provider, CAJA_DATADIR G_DIR_SEPARATOR_S "caja-desktop.css", &error);
-
-    if (error != NULL) {
-        g_warning ("Can't parse Caja' CSS custom description: %s\n", error->message);
-        g_error_free (error);
-    } else {
-        gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
-                               GTK_STYLE_PROVIDER (provider),
-                               GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-    }
-
-
-    g_object_unref (provider);
+    load_custom_css ("caja.css", GTK_STYLE_PROVIDER_PRIORITY_THEME);
+    /* add our desktop CSS provider,  ensures the desktop background does not get covered */
+    load_custom_css ("caja-desktop.css", GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 
     /* initialize search path for custom icons */
     gtk_icon_theme_append_search_path (gtk_icon_theme_get_default (),


### PR DESCRIPTION
This allows to have a theme file to better fit desktop theming to a specific theme.  This is designed for themes with specific semantics, like High Contrast ones.

Support for HighContrast themes (both of the ones provided by GTK3, plus both current MATE's and an older of MATE's) is included, and can be used to test the feature: enable one of the High Contrast themes, and see the desktop items labels get drawn on plain background for optimal readability.

Adding support for a new theme is a simple matter of adding the rules in a file named `$caja_datadir/caja-desktop-$THEME.css`, it'll get automatically loaded when that theme `$THEME` is in use.