### PR TITLE
Render file-conflict icons as cairo_surface vectors

### DIFF
--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -71,25 +71,25 @@ static void
 file_icons_changed (CajaFile *file,
                     CajaFileConflictDialog *fcd)
 {
-    GdkPixbuf *pixbuf;
+    cairo_surface_t *surface;
 
-    pixbuf = caja_file_get_icon_pixbuf (fcd->details->destination,
-                                        CAJA_ICON_SIZE_LARGE,
-                                        TRUE,
-                                        1, /*Don't double-scale icons*/
-                                        CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
+    surface = caja_file_get_icon_surface (fcd->details->destination,
+                                          CAJA_ICON_SIZE_LARGE,
+                                          FALSE,
+                                          gtk_widget_get_scale_factor (fcd->details->dest_image),
+                                          CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
 
-    gtk_image_set_from_pixbuf (GTK_IMAGE (fcd->details->dest_image), pixbuf);
-    g_object_unref (pixbuf);
+    gtk_image_set_from_surface (GTK_IMAGE (fcd->details->dest_image), surface);
+    cairo_surface_destroy (surface);
 
-    pixbuf = caja_file_get_icon_pixbuf (fcd->details->source,
-                                        CAJA_ICON_SIZE_LARGE,
-                                        TRUE,
-                                        1, /*Don't double-scale icons*/
-                                        CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
+    surface = caja_file_get_icon_surface (fcd->details->source,
+                                          CAJA_ICON_SIZE_LARGE,
+                                          FALSE,
+                                          gtk_widget_get_scale_factor (fcd->details->src_image),
+                                          CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
 
-    gtk_image_set_from_pixbuf (GTK_IMAGE (fcd->details->src_image), pixbuf);
-    g_object_unref (pixbuf);
+    gtk_image_set_from_surface (GTK_IMAGE (fcd->details->src_image), surface);
+    cairo_surface_destroy (surface);
 }
 
 static void
@@ -106,7 +106,7 @@ file_list_ready_cb (GList *files,
     char *dest_name, *dest_dir_name, *edit_name;
     char *label_text;
     char *size, *date, *type = NULL;
-    GdkPixbuf *pixbuf;
+    cairo_surface_t *surface;
     GtkWidget *label;
     GString *str;
     PangoAttrList *attr_list;
@@ -234,27 +234,27 @@ file_list_ready_cb (GList *files,
     g_free (secondary_text);
 
     /* Set up file icons */
-    pixbuf = caja_file_get_icon_pixbuf (dest,
-                                        CAJA_ICON_SIZE_LARGE,
-                                        TRUE,
-                                        1, /*Don't double-scale icons*/
-                                        CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
-    details->dest_image = gtk_image_new_from_pixbuf (pixbuf);
+    surface = caja_file_get_icon_surface (dest,
+                                          CAJA_ICON_SIZE_LARGE,
+                                          TRUE,
+                                          gtk_widget_get_scale_factor (fcd->details->titles_vbox),
+                                          CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
+    details->dest_image = gtk_image_new_from_surface (surface);
     gtk_box_pack_start (GTK_BOX (details->first_hbox),
                         details->dest_image, FALSE, FALSE, 0);
     gtk_widget_show (details->dest_image);
-    g_object_unref (pixbuf);
+    cairo_surface_destroy (surface);
 
-    pixbuf = caja_file_get_icon_pixbuf (src,
-                                        CAJA_ICON_SIZE_LARGE,
-                                        TRUE,
-                                        1, /*Don't double-scale icons*/
-                                        CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
-    details->src_image = gtk_image_new_from_pixbuf (pixbuf);
+    surface = caja_file_get_icon_surface (src,
+                                          CAJA_ICON_SIZE_LARGE,
+                                          TRUE,
+                                          gtk_widget_get_scale_factor (fcd->details->titles_vbox),
+                                          CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
+    details->src_image = gtk_image_new_from_surface (surface);
     gtk_box_pack_start (GTK_BOX (details->second_hbox),
                         details->src_image, FALSE, FALSE, 0);
     gtk_widget_show (details->src_image);
-    g_object_unref (pixbuf);
+    cairo_surface_destroy (surface);
 
     /* Set up labels */
     label = gtk_label_new (NULL);

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -4679,6 +4679,27 @@ caja_file_get_icon_pixbuf (CajaFile *file,
 	return pixbuf;
 }
 
+cairo_surface_t *
+caja_file_get_icon_surface (CajaFile *file,
+                            int size,
+                            gboolean force_size,
+                            int scale,
+                            CajaFileIconFlags flags)
+{
+	CajaIconInfo *info;
+	cairo_surface_t *surface;
+
+	info = caja_file_get_icon (file, size, scale, flags);
+	if (force_size) {
+		surface =  caja_icon_info_get_surface_at_size (info, size);
+	} else {
+		surface = caja_icon_info_get_surface (info);
+	}
+	g_object_unref (info);
+
+	return surface;
+}
+
 char *
 caja_file_get_custom_icon (CajaFile *file)
 {

--- a/libcaja-private/caja-file.h
+++ b/libcaja-private/caja-file.h
@@ -460,17 +460,22 @@ char *                  caja_file_get_drop_target_uri               (CajaFile   
 char *                  caja_file_get_custom_icon                   (CajaFile                   *file);
 
 
-GIcon *                 caja_file_get_gicon                         (CajaFile                   *file,
-        CajaFileIconFlags           flags);
-CajaIconInfo *      caja_file_get_icon                          (CajaFile                   *file,
-        int                             size,
-        int                             scale,
-        CajaFileIconFlags           flags);
-GdkPixbuf *             caja_file_get_icon_pixbuf                   (CajaFile                   *file,
-        int                             size,
-        gboolean                        force_size,
-        int                             scale,
-        CajaFileIconFlags           flags);
+GIcon           *caja_file_get_gicon        (CajaFile         *file,
+                                             CajaFileIconFlags flags);
+CajaIconInfo    *caja_file_get_icon         (CajaFile         *file,
+                                             int               size,
+                                             int               scale,
+                                             CajaFileIconFlags flags);
+GdkPixbuf       *caja_file_get_icon_pixbuf  (CajaFile         *file,
+                                             int               size,
+                                             gboolean          force_size,
+                                             int               scale,
+                                             CajaFileIconFlags flags);
+cairo_surface_t *caja_file_get_icon_surface (CajaFile         *file,
+                                             int               size,
+                                             gboolean          force_size,
+                                             int               scale,
+                                             CajaFileIconFlags flags);
 
 gboolean                caja_file_has_open_window                   (CajaFile                   *file);
 void                    caja_file_set_has_open_window               (CajaFile                   *file,


### PR DESCRIPTION
This reverts the changes in #1253 and instead renders icons using `cairo_surface_t` vectors, rather than `GdkPixbuf`. The result is the correct size, correct scale icon shown in higher quality.

Before:
![gdkpixbuf](https://user-images.githubusercontent.com/259780/60736269-5aa65500-9f24-11e9-8e95-d7fc65202d85.png)

After:
![cairo_surface](https://user-images.githubusercontent.com/259780/60736273-5e39dc00-9f24-11e9-9773-6c1ae57d28e3.png)
