### PR TITLE
fix build error about fm-empty-view

### DIFF
--- a/src/file-manager/fm-empty-view.c
+++ b/src/file-manager/fm-empty-view.c
@@ -64,7 +64,8 @@ fm_empty_view_add_file (FMDirectoryView *view, CajaFile *file, CajaDirectory *di
     if (!timer) timer = g_timer_new ();
 
     g_timer_start (timer);
-    icon = caja_file_get_icon_surface (file, caja_get_icon_size_for_zoom_level (CAJA_ZOOM_LEVEL_STANDARD), TRUE, 0);
+    icon = caja_file_get_icon_surface (file, caja_get_icon_size_for_zoom_level (CAJA_ZOOM_LEVEL_STANDARD),
+                                       TRUE, gtk_widget_get_scale_factor (GTK_WIDGET(view)), 0);
 
     elaps = g_timer_elapsed (timer, NULL);
     g_timer_stop (timer);


### PR DESCRIPTION
Fix build error when run `./configure --enable-empty-view`:
```
fm-empty-view.c: In function 'fm_empty_view_add_file':
fm-empty-view.c:67:12: error: too few arguments to function 'caja_file_get_icon_surface'
   67 |     icon = caja_file_get_icon_surface (file, caja_get_icon_size_for_zoom_level (CAJA_ZOOM_LEVEL_STANDARD), TRUE, 0);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from fm-directory-view.h:37,
                 from fm-empty-view.h:28,
                 from fm-empty-view.c:36:
../../libcaja-private/caja-file.h:469:18: note: declared here
  469 | cairo_surface_t *caja_file_get_icon_surface (CajaFile         *file,
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~
```