### PR TITLE
Render icons as cairo surfaces, backport to 1.22

### DIFF
--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -479,15 +479,15 @@ eel_image_menu_item_new_from_icon (const gchar *icon_name,
 }
 
 GtkWidget *
-eel_image_menu_item_new_from_pixbuf (GdkPixbuf   *icon_pixbuf,
-                                     const gchar *label_name)
+eel_image_menu_item_new_from_surface (cairo_surface_t *icon_surface,
+                                      const gchar     *label_name)
 {
     gchar *concat;
     GtkWidget *icon;
     GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
 
-    if (icon_pixbuf)
-        icon = gtk_image_new_from_pixbuf (icon_pixbuf);
+    if (icon_surface)
+        icon = gtk_image_new_from_surface (icon_surface);
     else
         icon = gtk_image_new ();
 

--- a/eel/eel-gtk-extensions.h
+++ b/eel/eel-gtk-extensions.h
@@ -28,7 +28,6 @@
 #ifndef EEL_GTK_EXTENSIONS_H
 #define EEL_GTK_EXTENSIONS_H
 
-#include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gtk/gtk.h>
 #include <eel/eel-gdk-extensions.h>
 
@@ -71,7 +70,7 @@ void                  eel_gtk_message_dialog_set_details_label        (GtkMessag
 GtkWidget *           eel_image_menu_item_new_from_icon               (const gchar          *icon_name,
                                                                        const gchar          *label_name);
 
-GtkWidget *           eel_image_menu_item_new_from_pixbuf               (GdkPixbuf          *icon_pixbuf,
+GtkWidget *           eel_image_menu_item_new_from_surface              (cairo_surface_t    *icon_surface,
                                                                          const gchar        *label_name);
 
 #endif /* EEL_GTK_EXTENSIONS_H */

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -4638,27 +4638,6 @@ caja_file_get_icon (CajaFile *file,
 	}
 }
 
-GdkPixbuf *
-caja_file_get_icon_pixbuf (CajaFile *file,
-			       int size,
-			       gboolean force_size,
-			       int scale,
-			       CajaFileIconFlags flags)
-{
-	CajaIconInfo *info;
-	GdkPixbuf *pixbuf;
-
-	info = caja_file_get_icon (file, size, scale, flags);
-	if (force_size) {
-		pixbuf =  caja_icon_info_get_pixbuf_at_size (info, size);
-	} else {
-		pixbuf = caja_icon_info_get_pixbuf (info);
-	}
-	g_object_unref (info);
-
-	return pixbuf;
-}
-
 cairo_surface_t *
 caja_file_get_icon_surface (CajaFile *file,
                             int size,

--- a/libcaja-private/caja-file.h
+++ b/libcaja-private/caja-file.h
@@ -465,11 +465,6 @@ CajaIconInfo    *caja_file_get_icon         (CajaFile         *file,
                                              int               size,
                                              int               scale,
                                              CajaFileIconFlags flags);
-GdkPixbuf       *caja_file_get_icon_pixbuf  (CajaFile         *file,
-                                             int               size,
-                                             gboolean          force_size,
-                                             int               scale,
-                                             CajaFileIconFlags flags);
 cairo_surface_t *caja_file_get_icon_surface (CajaFile         *file,
                                              int               size,
                                              gboolean          force_size,

--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -32,6 +32,7 @@
 #include <gio/gio.h>
 
 #include <glib/gi18n.h>
+#include <cairo-gobject.h>
 
 #include <eel/eel-glib-extensions.h>
 
@@ -778,7 +779,7 @@ caja_file_management_properties_dialog_setup_media_page (GtkBuilder *builder)
     other_type_combo_box = GTK_WIDGET (gtk_builder_get_object (builder, "media_other_type_combobox"));
 
     other_type_list_store = gtk_list_store_new (3,
-                            GDK_TYPE_PIXBUF,
+                            CAIRO_GOBJECT_TYPE_SURFACE,
                             G_TYPE_STRING,
                             G_TYPE_STRING);
 
@@ -794,7 +795,7 @@ caja_file_management_properties_dialog_setup_media_page (GtkBuilder *builder)
         char *description;
         GIcon *icon;
         CajaIconInfo *icon_info;
-        GdkPixbuf *pixbuf;
+        cairo_surface_t *surface;
         int icon_size, icon_scale;
 
         if (!g_str_has_prefix (content_type, "x-content/"))
@@ -817,21 +818,21 @@ caja_file_management_properties_dialog_setup_media_page (GtkBuilder *builder)
         {
             icon_info = caja_icon_info_lookup (icon, icon_size, icon_scale);
             g_object_unref (icon);
-            pixbuf = caja_icon_info_get_pixbuf_nodefault_at_size (icon_info, icon_size);
+            surface = caja_icon_info_get_surface_nodefault_at_size (icon_info, icon_size);
             g_object_unref (icon_info);
         }
         else
         {
-            pixbuf = NULL;
+            surface = NULL;
         }
 
         gtk_list_store_set (other_type_list_store, &iter,
-                            0, pixbuf,
+                            0, surface,
                             1, description,
                             2, content_type,
                             -1);
-        if (pixbuf != NULL)
-            g_object_unref (pixbuf);
+        if (surface != NULL)
+            cairo_surface_destroy (surface);
         g_free (description);
 skip:
         ;
@@ -844,7 +845,7 @@ skip:
     renderer = gtk_cell_renderer_pixbuf_new ();
     gtk_cell_layout_pack_start (GTK_CELL_LAYOUT (other_type_combo_box), renderer, FALSE);
     gtk_cell_layout_set_attributes (GTK_CELL_LAYOUT (other_type_combo_box), renderer,
-                                    "pixbuf", 0,
+                                    "surface", 0,
                                     NULL);
     renderer = gtk_cell_renderer_text_new ();
     gtk_cell_layout_pack_start (GTK_CELL_LAYOUT (other_type_combo_box), renderer, TRUE);

--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -190,9 +190,9 @@ static const char * const icon_captions_components[] =
 enum
 {
 	EXT_STATE_COLUMN,
-    EXT_ICON_COLUMN,
+	EXT_ICON_COLUMN,
 	EXT_INFO_COLUMN,
-    EXT_STRUCT_COLUMN
+	EXT_STRUCT_COLUMN
 };
 
 static void caja_file_management_properties_dialog_update_media_sensitivity (GtkBuilder *builder);
@@ -872,7 +872,7 @@ caja_file_management_properties_dialog_setup_extension_page (GtkBuilder *builder
     GtkTreeSelection *selection;
     GtkTreeIter iter;
     GtkIconTheme *icon_theme;
-    GdkPixbuf *ext_pixbuf_icon;
+    cairo_surface_t *ext_surface_icon;
     GtkButton *about_button, *configure_button;
     gchar *ext_text_info;
     
@@ -901,15 +901,15 @@ caja_file_management_properties_dialog_setup_extension_page (GtkBuilder *builder
 
         if (ext->icon != NULL)
         {
-            ext_pixbuf_icon = gtk_icon_theme_load_icon (icon_theme, ext->icon,
-                                                        24,
-                                                        GTK_ICON_LOOKUP_USE_BUILTIN, NULL);
+            ext_surface_icon = gtk_icon_theme_load_surface (icon_theme, ext->icon,
+                                                            24, gtk_widget_get_scale_factor (GTK_WIDGET (view)),
+                                                            NULL, GTK_ICON_LOOKUP_USE_BUILTIN, NULL);
         }
         else
         {
-            ext_pixbuf_icon = gtk_icon_theme_load_icon (icon_theme, "system-run",
-                                                        24,
-                                                        GTK_ICON_LOOKUP_USE_BUILTIN, NULL);
+            ext_surface_icon = gtk_icon_theme_load_surface (icon_theme, "system-run",
+                                                            24, gtk_widget_get_scale_factor (GTK_WIDGET (view)),
+                                                            NULL, GTK_ICON_LOOKUP_USE_BUILTIN, NULL);
         }
 
         if (ext->description != NULL)
@@ -927,13 +927,13 @@ caja_file_management_properties_dialog_setup_extension_page (GtkBuilder *builder
         gtk_list_store_append (store, &iter);
         gtk_list_store_set (store, &iter,
                             EXT_STATE_COLUMN, ext->state,
-                            EXT_ICON_COLUMN, ext_pixbuf_icon, 
+                            EXT_ICON_COLUMN, ext_surface_icon,
                             EXT_INFO_COLUMN, ext_text_info,
                             EXT_STRUCT_COLUMN, ext, -1);
 
         g_free (ext_text_info);
-        if (ext_pixbuf_icon)
-            g_object_unref (ext_pixbuf_icon);
+        if (ext_surface_icon)
+            cairo_surface_destroy (ext_surface_icon);
     }
 
     about_button = GTK_BUTTON (gtk_builder_get_object (builder, "about_extension_button"));

--- a/src/caja-file-management-properties.ui
+++ b/src/caja-file-management-properties.ui
@@ -7,7 +7,7 @@
       <!-- column-name ext-state -->
       <column type="gboolean"/>
       <!-- column-name ext-icon -->
-      <column type="GdkPixbuf"/>
+      <column type="CairoSurface"/>
       <!-- column-name ext-info -->
       <column type="gchararray"/>
       <!-- column-name ext-struct -->
@@ -2537,7 +2537,7 @@
                             <child>
                               <object class="GtkCellRendererPixbuf" id="cellrendererpixbuf1"/>
                               <attributes>
-                                <attribute name="pixbuf">1</attribute>
+                                <attribute name="surface">1</attribute>
                               </attributes>
                             </child>
                           </object>

--- a/src/caja-spatial-window.c
+++ b/src/caja-spatial-window.c
@@ -43,7 +43,6 @@
 #include <eel/eel-gtk-extensions.h>
 #include <eel/eel-gtk-macros.h>
 #include <eel/eel-string.h>
-#include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gdk/gdkkeysyms.h>
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
@@ -647,7 +646,7 @@ location_button_clicked_callback (GtkWidget         *widget,
 {
     CajaWindowSlot *slot;
     GtkWidget *popup, *menu_item, *first_item = NULL;
-    GdkPixbuf *pixbuf;
+    cairo_surface_t *surface;
     GFile *location;
     GFile *child_location;
     GMainLoop *loop;
@@ -672,18 +671,18 @@ location_button_clicked_callback (GtkWidget         *widget,
 
         name = caja_file_get_display_name (file);
 
-        pixbuf = NULL;
+        surface = NULL;
 
-        pixbuf = caja_file_get_icon_pixbuf (file,
-                                            caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU),
-                                            TRUE,
-                                            gtk_widget_get_scale_factor (widget),
-                                            CAJA_FILE_ICON_FLAGS_IGNORE_VISITING);
+        surface = caja_file_get_icon_surface (file,
+                                              caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU),
+                                              TRUE,
+                                              gtk_widget_get_scale_factor (widget),
+                                              CAJA_FILE_ICON_FLAGS_IGNORE_VISITING);
 
-        if (pixbuf != NULL)
+        if (surface != NULL)
         {
-            menu_item = eel_image_menu_item_new_from_pixbuf (pixbuf, name);
-            g_object_unref (pixbuf);
+            menu_item = eel_image_menu_item_new_from_surface (surface, name);
+            cairo_surface_destroy (surface);
         }
         else
         {
@@ -772,19 +771,19 @@ location_button_drag_begin_callback (GtkWidget             *widget,
                                      CajaSpatialWindow *window)
 {
     CajaWindowSlot *slot;
-    GdkPixbuf *pixbuf;
+    cairo_surface_t *surface;
 
     slot = CAJA_WINDOW (window)->details->active_pane->active_slot;
 
-    pixbuf = caja_file_get_icon_pixbuf (slot->viewed_file,
-                                        get_dnd_icon_size (window),
-                                        FALSE,
-                                        gtk_widget_get_scale_factor (widget),
-                                        CAJA_FILE_ICON_FLAGS_IGNORE_VISITING | CAJA_FILE_ICON_FLAGS_FOR_DRAG_ACCEPT);
+    surface = caja_file_get_icon_surface (slot->viewed_file,
+                                          get_dnd_icon_size (window),
+                                          FALSE,
+                                          gtk_widget_get_scale_factor (widget),
+                                          CAJA_FILE_ICON_FLAGS_IGNORE_VISITING | CAJA_FILE_ICON_FLAGS_FOR_DRAG_ACCEPT);
 
-    gtk_drag_set_icon_pixbuf (context, pixbuf, 0, 0);
+    gtk_drag_set_icon_surface (context, surface);
 
-    g_object_unref (pixbuf);
+    cairo_surface_destroy (surface);
 }
 
 /* build MATE icon list, which only contains the window's URI.
@@ -852,18 +851,18 @@ caja_spatial_window_set_location_button  (CajaSpatialWindow *window,
         error = caja_file_get_file_info_error (file);
         if (error == NULL)
         {
-            GdkPixbuf *pixbuf;
+            cairo_surface_t *surface;
 
-            pixbuf = caja_file_get_icon_pixbuf (file,
-                                                caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU),
-                                                TRUE,
-                                                gtk_widget_get_scale_factor (window->details->location_button),
-                                                CAJA_FILE_ICON_FLAGS_IGNORE_VISITING);
+            surface = caja_file_get_icon_surface (file,
+                                                  caja_get_icon_size_for_stock_size (GTK_ICON_SIZE_MENU),
+                                                  TRUE,
+                                                  gtk_widget_get_scale_factor (window->details->location_button),
+                                                  CAJA_FILE_ICON_FLAGS_IGNORE_VISITING);
 
-            if (pixbuf != NULL)
+            if (surface != NULL)
             {
-                gtk_image_set_from_pixbuf (GTK_IMAGE (window->details->location_icon),  pixbuf);
-                g_object_unref (pixbuf);
+                gtk_image_set_from_surface (GTK_IMAGE (window->details->location_icon), surface);
+                cairo_surface_destroy (surface);
             }
             else
             {

--- a/src/file-manager/fm-empty-view.c
+++ b/src/file-manager/fm-empty-view.c
@@ -57,17 +57,17 @@ fm_empty_view_add_file (FMDirectoryView *view, CajaFile *file, CajaDirectory *di
     static GTimer *timer = NULL;
     static gdouble cumu = 0, elaps;
     FM_EMPTY_VIEW (view)->details->number_of_files++;
-    GdkPixbuf *icon;
+    cairo_surface_t *icon;
 
     if (!timer) timer = g_timer_new ();
 
     g_timer_start (timer);
-    icon = caja_file_get_icon_pixbuf (file, caja_get_icon_size_for_zoom_level (CAJA_ZOOM_LEVEL_STANDARD), TRUE, 0);
+    icon = caja_file_get_icon_surface (file, caja_get_icon_size_for_zoom_level (CAJA_ZOOM_LEVEL_STANDARD), TRUE, 0);
 
     elaps = g_timer_elapsed (timer, NULL);
     g_timer_stop (timer);
 
-    g_object_unref (icon);
+    cairo_surface_destroy (icon);
 
     cumu += elaps;
     g_message ("entire loading: %.3f, cumulative %.3f", elaps, cumu);


### PR DESCRIPTION
Just a port of https://github.com/mate-desktop/caja/pull/1258 to 1.22 branch. Had to do some manual work due to conflicts, so please check I didn't mess up somewhere.