### PR TITLE
Copy file and keep timestamps of original file including remotes

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -3718,7 +3718,7 @@ copy_move_directory (CopyMoveJob *copy_job,
 
 	if (create_dest) {
 		flags = (readonly_source_fs) ? G_FILE_COPY_NOFOLLOW_SYMLINKS | G_FILE_COPY_TARGET_DEFAULT_PERMS
-					     : G_FILE_COPY_NOFOLLOW_SYMLINKS;
+					     : G_FILE_COPY_NOFOLLOW_SYMLINKS | G_FILE_COPY_ALL_METADATA;
 		/* Ignore errors here. Failure to copy metadata is not a hard error */
 		g_file_copy_attributes (src, *dest,
 					flags,
@@ -4274,6 +4274,13 @@ copy_move_file (CopyMoveJob *copy_job,
 	}
 
 	if (res) {
+		if (!copy_job->is_move) {
+			/* Ignore errors here. Failure to copy metadata is not a hard error */
+			g_file_copy_attributes (src, dest,
+			                        flags | G_FILE_COPY_ALL_METADATA,
+			                        job->cancellable, NULL);
+		}
+
 		transfer_info->num_files ++;
 		report_copy_progress (copy_job, source_info, transfer_info);
 


### PR DESCRIPTION
The timestamps are reset to the current time, even if the source &
target folders support these GFileInfo attributes.

Closes #1226