### PR TITLE
caja-window-slot: "folder-saved-search" icon instead "text-x-generic"

### DIFF
--- a/src/caja-window-slot.c
+++ b/src/caja-window-slot.c
@@ -394,7 +394,10 @@ caja_window_slot_update_icon (CajaWindowSlot *slot)
              */
             if (g_strcmp0 (icon_name, gtk_window_get_icon_name (GTK_WINDOW (window))) != 0)
             {
-                gtk_window_set_icon_name (GTK_WINDOW (window), icon_name);
+                if (g_strcmp0 (icon_name, "text-x-generic") == 0)
+                    gtk_window_set_icon_name (GTK_WINDOW (window), "folder-saved-search");
+                else
+                    gtk_window_set_icon_name (GTK_WINDOW (window), icon_name);
             }
         }
         else


### PR DESCRIPTION
Before:

![2019-08-28_20-49](https://user-images.githubusercontent.com/7734191/63884927-7cc5cc00-c9d7-11e9-9962-c9f51f7fe0a2.png)

Later:

![2019-08-28_20-49_2](https://user-images.githubusercontent.com/7734191/63884943-83ecda00-c9d7-11e9-9431-7bb060b7c3a7.png)

Before:

![2019-08-28_20-49_1](https://user-images.githubusercontent.com/7734191/63884963-8b13e800-c9d7-11e9-8211-e06104c7aa03.png)

Later:

![2019-08-28_20-50](https://user-images.githubusercontent.com/7734191/63884976-9109c900-c9d7-11e9-82b9-b9d0100d3e0d.png)