### PR TITLE
canvas-item: Don't hyphenate filenames

### DIFF
--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -60,6 +60,14 @@
 #define MAX_TEXT_WIDTH_BESIDE 90
 #define MAX_TEXT_WIDTH_BESIDE_TOP_TO_BOTTOM 150
 
+#ifndef PANGO_CHECK_VERSION
+#define PANGO_CHECK_VERSION(major, minor, micro)                          \
+     (PANGO_VERSION_MAJOR > (major) ||                                    \
+     (PANGO_VERSION_MAJOR == (major) && PANGO_VERSION_MINOR > (minor)) || \
+     (PANGO_VERSION_MAJOR == (major) && PANGO_VERSION_MINOR == (minor) && \
+      PANGO_VERSION_MICRO >= (micro)))
+#endif
+
 /* special text height handling
  * each item has three text height variables:
  *  + text_height: actual height of the displayed (i.e. on-screen) PangoLayout.
@@ -1973,12 +1981,18 @@ create_label_layout (CajaIconCanvasItem *item,
     CajaIconContainer *container;
     EelCanvasItem *canvas_item;
     char *zeroified_text;
+    #if PANGO_CHECK_VERSION (1, 44, 0)
+    PangoAttrList *attr_list;
+    #endif
 
     canvas_item = EEL_CANVAS_ITEM (item);
 
     container = CAJA_ICON_CONTAINER (canvas_item->canvas);
     context = gtk_widget_get_pango_context (GTK_WIDGET (canvas_item->canvas));
     layout = pango_layout_new (context);
+    #if PANGO_CHECK_VERSION (1, 44, 0)
+    attr_list = pango_attr_list_new ();
+    #endif
 
     zeroified_text = NULL;
 
@@ -2028,6 +2042,11 @@ create_label_layout (CajaIconCanvasItem *item,
     pango_layout_set_spacing (layout, LABEL_LINE_SPACING);
     pango_layout_set_wrap (layout, PANGO_WRAP_WORD_CHAR);
 
+    #if PANGO_CHECK_VERSION (1, 44, 0)
+    pango_attr_list_insert (attr_list, pango_attr_insert_hyphens_new (FALSE));
+    pango_layout_set_attributes (layout, attr_list);
+    #endif
+
     /* Create a font description */
     if (container->details->font)
     {
@@ -2043,6 +2062,9 @@ create_label_layout (CajaIconCanvasItem *item,
     pango_layout_set_font_description (layout, desc);
     pango_font_description_free (desc);
     g_free (zeroified_text);
+    #if PANGO_CHECK_VERSION (1, 44, 0)
+    pango_attr_list_unref (attr_list);
+    #endif
 
     return layout;
 }


### PR DESCRIPTION
fixes https://github.com/mate-desktop/caja/issues/1284

Pango 1.44 got the ability to automatically hyphenate on line breaks,
which is on by default, but can be set off by a new attribute.

As a result, we now hyphenate filenames, which is confusing, because
a filename may already include hyphens.

To restore the previous behavior, let's not insert hyphens when
breaking filenames in multiple lines.

Inspired by https://gitlab.gnome.org/GNOME/nautilus/commit/9738d85

Please test.