### PR TITLE
Fix a french grammar mistake in fr.po ("Copie" instead of "Copy")

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -1239,12 +1239,12 @@ msgstr "e copie)"
 #. localizers: tag used to detect the x1st copy of a file
 #: ../libcaja-private/caja-file-operations.c:492
 msgid "st copy)"
-msgstr "re copy)"
+msgstr "re copie)"
 
 #. localizers: tag used to detect the x2nd copy of a file
 #: ../libcaja-private/caja-file-operations.c:494
 msgid "nd copy)"
-msgstr "e copy)"
+msgstr "e copie)"
 
 #. localizers: tag used to detect the x3rd copy of a file
 #: ../libcaja-private/caja-file-operations.c:496


### PR DESCRIPTION
Fixed "Copie" instead of "Copy" in **fr.po** for _caja-file-operations_