### PR TITLE
Updated French Localisation from Transifex

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -4,35 +4,38 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Louis-Martin Carrière <louismc@gmail.com>, 2018
-# Lionel Brianto <kinobi@kinobiweb.com>, 2018
-# Scoubidou <david.vantyghem@free.fr>, 2018
-# Benjamin Teissier <enatheme@enatheme.org>, 2018
-# jeremy shields <jeremy.shields@orange.fr>, 2018
-# yoplait <yoplait@tememe.org>, 2018
-# Xorg, 2018
-# Nicolas Roelandt (Personnel), 2018
-# Nicolas Dobigeon <dobigeon@gmail.com>, 2018
-# sire cartier <ppd491@gmail.com>, 2018
-# mauron, 2018
-# Tubuntu <tubuntu@testimonium.be>, 2018
-# Charles Monzat <c.monzat@laposte.net>, 2018
-# L'Africain <lafricain79@gmail.com>, 2018
-# bf437f16c5a5796ac2a6f350075b40dc, 2018
-# Laurent Napias <tamplan+transifex@free.fr>, 2018
+# Louis-Martin Carrière <louismc@gmail.com>, 2019
+# Lionel Brianto <kinobi@kinobiweb.com>, 2019
+# Scoubidou <david.vantyghem@free.fr>, 2019
+# Benjamin Teissier <enatheme@enatheme.org>, 2019
+# jeremy shields <jeremy.shields@orange.fr>, 2019
+# yoplait <yoplait@tememe.org>, 2019
+# Xorg, 2019
+# Nicolas Roelandt (Personnel), 2019
+# Nicolas Dobigeon <dobigeon@gmail.com>, 2019
+# bf437f16c5a5796ac2a6f350075b40dc, 2019
+# L'Africain <lafricain79@gmail.com>, 2019
+# sire cartier <ppd491@gmail.com>, 2019
+# mauron, 2019
+# Tubuntu <tubuntu@testimonium.be>, 2019
+# Charles Monzat <c.monzat@laposte.net>, 2019
 # Étienne Deparis <etienne@depar.is>, 2019
-# Stefano Karapetsas <stefano@karapetsas.com>, 2019
+# Laurent Napias <tamplan+transifex@free.fr>, 2019
 # David D, 2019
+# Frédéric MASSOT <frederic@juliana-multimedia.com>, 2019
 # clefebvre <clement.lefebvre@linuxmint.com>, 2019
+# Stefano Karapetsas <stefano@karapetsas.com>, 2019
+# Stéphane PETRUS <stephane.petrus@posteo.net>, 2019
+# Wolferos, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: MATE Desktop Environment\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-16 22:36+0100\n"
-"PO-Revision-Date: 2018-03-11 14:48+0000\n"
-"Last-Translator: clefebvre <clement.lefebvre@linuxmint.com>, 2019\n"
+"POT-Creation-Date: 2019-09-17 17:38+0200\n"
+"PO-Revision-Date: 2019-03-11 12:13+0000\n"
+"Last-Translator: Wolferos, 2019\n"
 "Language-Team: French (https://www.transifex.com/mate/teams/13566/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -305,7 +308,7 @@ msgid "Drag an emblem to an object to add it to the object"
 msgstr "Glissez un emblème sur un objet pour le lui ajouter"
 
 #. translators: this is the name of an emblem
-#: ../data/browser.xml.h:68 ../src/caja-emblem-sidebar.c:993
+#: ../data/browser.xml.h:68 ../src/caja-emblem-sidebar.c:992
 #: ../src/caja-property-browser.c:1947
 msgid "Erase"
 msgstr "Gommage"
@@ -336,8 +339,8 @@ msgstr "Invite d'exécution automatique"
 
 #. Set initial window title
 #: ../data/caja-browser.desktop.in.h:1 ../data/caja.desktop.in.h:1
-#: ../data/caja-folder-handler.desktop.in.h:1 ../src/caja-spatial-window.c:396
-#: ../src/caja-window-menus.c:636 ../src/caja-window.c:164
+#: ../data/caja-folder-handler.desktop.in.h:1 ../src/caja-spatial-window.c:395
+#: ../src/caja-window-menus.c:557 ../src/caja-window.c:164
 msgid "Caja"
 msgstr "Caja"
 
@@ -355,7 +358,7 @@ msgid "Computer"
 msgstr "Ordinateur"
 
 #. tooltip
-#: ../data/caja-computer.desktop.in.h:2 ../src/caja-window-menus.c:999
+#: ../data/caja-computer.desktop.in.h:2 ../src/caja-window-menus.c:918
 msgid ""
 "Browse all local and remote disks and folders accessible from this computer"
 msgstr ""
@@ -377,7 +380,7 @@ msgstr ""
 "fichiers"
 
 #: ../data/caja-folder-handler.desktop.in.h:2
-#: ../libcaja-private/caja-autorun.c:578
+#: ../libcaja-private/caja-autorun.c:581
 msgid "Open Folder"
 msgstr "Ouvrir un dossier"
 
@@ -387,7 +390,7 @@ msgstr "Dossier personnel"
 
 #. tooltip
 #: ../data/caja-home.desktop.in.h:2 ../src/caja-places-sidebar.c:523
-#: ../src/caja-window-menus.c:994
+#: ../src/caja-window-menus.c:913
 msgid "Open your personal folder"
 msgstr "Ouvrir votre dossier personnel"
 
@@ -488,16 +491,16 @@ msgstr "Afficher plus de _détails"
 
 #: ../eel/eel-stock-dialogs.c:238 ../eel/eel-stock-dialogs.c:294
 #: ../eel/eel-stock-dialogs.c:449 ../eel/eel-stock-dialogs.c:650
-#: ../libcaja-private/caja-autorun.c:1150
+#: ../libcaja-private/caja-autorun.c:1153
 #: ../libcaja-private/caja-file-conflict-dialog.c:655
 #: ../libcaja-private/caja-file-operations.c:186
 #: ../libcaja-private/caja-mime-actions.c:819
 #: ../libcaja-private/caja-mime-actions.c:1732
-#: ../libcaja-private/caja-open-with-dialog.c:960
+#: ../libcaja-private/caja-open-with-dialog.c:963
 #: ../src/file-manager/fm-directory-view.c:1211
 #: ../src/file-manager/fm-directory-view.c:1364
 #: ../src/file-manager/fm-directory-view.c:7026
-#: ../src/file-manager/fm-directory-view.c:10349
+#: ../src/file-manager/fm-directory-view.c:10353
 #: ../src/caja-connect-server-dialog.c:1121 ../src/caja-emblem-sidebar.c:288
 #: ../src/caja-emblem-sidebar.c:545 ../src/caja-location-dialog.c:194
 #: ../src/caja-property-browser.c:1107 ../src/caja-property-browser.c:1187
@@ -508,7 +511,7 @@ msgstr "_Annuler"
 #. label, accelerator
 #. add the "open" menu item
 #: ../eel/eel-stock-dialogs.c:240
-#: ../libcaja-private/caja-open-with-dialog.c:976
+#: ../libcaja-private/caja-open-with-dialog.c:979
 #: ../src/file-manager/fm-directory-view.c:7342
 #: ../src/file-manager/fm-directory-view.c:8858
 #: ../src/file-manager/fm-tree-view.c:1266 ../src/caja-location-dialog.c:199
@@ -525,7 +528,7 @@ msgid "You can stop this operation by clicking cancel."
 msgstr "Vous pouvez arrêter cette opération en cliquant sur annuler."
 
 #: ../eel/eel-stock-dialogs.c:296 ../eel/eel-stock-dialogs.c:451
-#: ../eel/eel-stock-dialogs.c:655 ../libcaja-private/caja-autorun.c:1155
+#: ../eel/eel-stock-dialogs.c:655 ../libcaja-private/caja-autorun.c:1158
 #: ../libcaja-private/caja-mime-actions.c:1376
 #: ../src/file-manager/fm-directory-view.c:1216
 #: ../src/caja-emblem-sidebar.c:293 ../src/caja-emblem-sidebar.c:550
@@ -542,80 +545,80 @@ msgstr "_Effacer"
 msgid " (invalid Unicode)"
 msgstr " (Unicode non valide)"
 
-#: ../libcaja-private/caja-autorun.c:522
+#: ../libcaja-private/caja-autorun.c:525
 msgid "No applications found"
 msgstr "Aucune application trouvée"
 
-#: ../libcaja-private/caja-autorun.c:543
+#: ../libcaja-private/caja-autorun.c:546
 msgid "Ask what to do"
 msgstr "Demander ce qu'il faut faire"
 
-#: ../libcaja-private/caja-autorun.c:561
+#: ../libcaja-private/caja-autorun.c:564
 msgid "Do Nothing"
 msgstr "Ne rien faire"
 
-#: ../libcaja-private/caja-autorun.c:611 ../src/caja-x-content-bar.c:147
+#: ../libcaja-private/caja-autorun.c:614 ../src/caja-x-content-bar.c:147
 #, c-format
 msgid "Open %s"
 msgstr "Ouvrir %s"
 
-#: ../libcaja-private/caja-autorun.c:655
+#: ../libcaja-private/caja-autorun.c:658
 msgid "Open with other Application..."
 msgstr "Ouvrir avec une autre application..."
 
-#: ../libcaja-private/caja-autorun.c:1044
+#: ../libcaja-private/caja-autorun.c:1047
 msgid "You have just inserted an Audio CD."
 msgstr "Un CD audio a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1048
+#: ../libcaja-private/caja-autorun.c:1051
 msgid "You have just inserted an Audio DVD."
 msgstr "Un DVD audio a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1052
+#: ../libcaja-private/caja-autorun.c:1055
 msgid "You have just inserted a Video DVD."
 msgstr "Un DVD vidéo a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1056
+#: ../libcaja-private/caja-autorun.c:1059
 msgid "You have just inserted a Video CD."
 msgstr "Un Vidéo CD (VCD) a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1060
+#: ../libcaja-private/caja-autorun.c:1063
 msgid "You have just inserted a Super Video CD."
 msgstr "Un Super Vidéo CD (SVCD) a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1064
+#: ../libcaja-private/caja-autorun.c:1067
 msgid "You have just inserted a blank CD."
 msgstr "Un CD vierge a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1068
+#: ../libcaja-private/caja-autorun.c:1071
 msgid "You have just inserted a blank DVD."
 msgstr "Un DVD vierge a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1072
+#: ../libcaja-private/caja-autorun.c:1075
 msgid "You have just inserted a blank Blu-Ray disc."
 msgstr "Un disque Blu-Ray vierge a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1076
+#: ../libcaja-private/caja-autorun.c:1079
 msgid "You have just inserted a blank HD DVD."
 msgstr "Un HD-DVD vierge a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1080
+#: ../libcaja-private/caja-autorun.c:1083
 msgid "You have just inserted a Photo CD."
 msgstr "Un CD Photo a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1084
+#: ../libcaja-private/caja-autorun.c:1087
 msgid "You have just inserted a Picture CD."
 msgstr "Un Picture CD a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1088
+#: ../libcaja-private/caja-autorun.c:1091
 msgid "You have just inserted a medium with digital photos."
 msgstr "Un support contenant des photos numériques a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1092
+#: ../libcaja-private/caja-autorun.c:1095
 msgid "You have just inserted a digital audio player."
 msgstr "Un baladeur audio a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1096
+#: ../libcaja-private/caja-autorun.c:1099
 msgid ""
 "You have just inserted a medium with software intended to be automatically "
 "started."
@@ -624,15 +627,15 @@ msgstr ""
 "été inséré."
 
 #. fallback to generic greeting
-#: ../libcaja-private/caja-autorun.c:1101
+#: ../libcaja-private/caja-autorun.c:1104
 msgid "You have just inserted a medium."
 msgstr "Un support a été inséré."
 
-#: ../libcaja-private/caja-autorun.c:1103
+#: ../libcaja-private/caja-autorun.c:1106
 msgid "Choose what application to launch."
 msgstr "Choisissez une application à lancer."
 
-#: ../libcaja-private/caja-autorun.c:1113
+#: ../libcaja-private/caja-autorun.c:1116
 #, c-format
 msgid ""
 "Select how to open \"%s\" and whether to perform this action in the future "
@@ -641,14 +644,14 @@ msgstr ""
 "Sélectionnez comment ouvrir « %s » et si cette action doit être effectuée "
 "par la suite pour les autres supports de type « %s »."
 
-#: ../libcaja-private/caja-autorun.c:1141
+#: ../libcaja-private/caja-autorun.c:1144
 msgid "_Always perform this action"
 msgstr "_Toujours effectuer cette action"
 
 #. name, icon name
 #. label, accelerator
 #. add the "Eject" menu item
-#: ../libcaja-private/caja-autorun.c:1164
+#: ../libcaja-private/caja-autorun.c:1167
 #: ../src/file-manager/fm-directory-view.c:7469
 #: ../src/file-manager/fm-directory-view.c:7497
 #: ../src/file-manager/fm-directory-view.c:7578
@@ -659,7 +662,7 @@ msgstr "É_jecter"
 #. name, icon name
 #. label, accelerator
 #. add the "Unmount" menu item
-#: ../libcaja-private/caja-autorun.c:1179
+#: ../libcaja-private/caja-autorun.c:1182
 #: ../src/file-manager/fm-directory-view.c:7465
 #: ../src/file-manager/fm-directory-view.c:7493
 #: ../src/file-manager/fm-directory-view.c:7574
@@ -1175,7 +1178,7 @@ msgstr[1] "environ %'d heures"
 #. * to that kind of file (e.g. "link to folder").
 #: ../libcaja-private/caja-file-operations.c:409
 #: ../libcaja-private/caja-file.c:6759
-#: ../src/file-manager/fm-directory-view.c:10593
+#: ../src/file-manager/fm-directory-view.c:10597
 #, c-format
 msgid "Link to %s"
 msgstr "Lien vers %s"
@@ -1954,7 +1957,7 @@ msgid "today at 00:00:00 PM"
 msgstr "aujourd'hui à 00:00:00"
 
 #: ../libcaja-private/caja-file.c:4739
-#: ../src/caja-file-management-properties.c:531
+#: ../src/caja-file-management-properties.c:532
 msgid "today at %-I:%M:%S %p"
 msgstr "aujourd'hui à %-H:%M:%S"
 
@@ -2241,12 +2244,12 @@ msgstr[0] "Cela ouvrira %d fenêtre séparée."
 msgstr[1] "Cela ouvrira %d fenêtres séparées."
 
 #: ../libcaja-private/caja-mime-actions.c:1267
-#: ../src/caja-window-manage-views.c:2101
-#: ../src/caja-window-manage-views.c:2109
-#: ../src/caja-window-manage-views.c:2129
-#: ../src/caja-window-manage-views.c:2143
-#: ../src/caja-window-manage-views.c:2149
-#: ../src/caja-window-manage-views.c:2176
+#: ../src/caja-window-manage-views.c:2114
+#: ../src/caja-window-manage-views.c:2122
+#: ../src/caja-window-manage-views.c:2142
+#: ../src/caja-window-manage-views.c:2156
+#: ../src/caja-window-manage-views.c:2162
+#: ../src/caja-window-manage-views.c:2189
 #, c-format
 msgid "Could not display \"%s\"."
 msgstr "Impossible d'afficher « %s »."
@@ -2328,14 +2331,14 @@ msgstr[0] "Ouverture de %d élément."
 msgstr[1] "Ouverture de %d éléments."
 
 #: ../libcaja-private/caja-mime-application-chooser.c:162
-#: ../libcaja-private/caja-open-with-dialog.c:300
+#: ../libcaja-private/caja-open-with-dialog.c:303
 #, c-format
 msgid "Could not set application as the default: %s"
 msgstr ""
 "Impossible de définir l'application en tant qu'application par défaut : %s"
 
 #: ../libcaja-private/caja-mime-application-chooser.c:163
-#: ../libcaja-private/caja-open-with-dialog.c:301
+#: ../libcaja-private/caja-open-with-dialog.c:304
 msgid "Could not set as default application"
 msgstr "Impossible de définir l'application en tant qu'application par défaut"
 
@@ -2352,12 +2355,12 @@ msgid "Could not remove application"
 msgstr "Impossible d'enlever l'application"
 
 #: ../libcaja-private/caja-mime-application-chooser.c:420
-#: ../libcaja-private/caja-open-with-dialog.c:1132
+#: ../libcaja-private/caja-open-with-dialog.c:1135
 msgid "_Add"
 msgstr "A_jouter"
 
 #: ../libcaja-private/caja-mime-application-chooser.c:430
-#: ../libcaja-private/caja-open-with-dialog.c:951
+#: ../libcaja-private/caja-open-with-dialog.c:954
 #: ../src/caja-bookmarks-window.ui.h:4
 msgid "_Remove"
 msgstr "_Enlever"
@@ -2372,7 +2375,7 @@ msgid "%s document"
 msgstr "Document %s"
 
 #: ../libcaja-private/caja-mime-application-chooser.c:599
-#: ../libcaja-private/caja-open-with-dialog.c:1091
+#: ../libcaja-private/caja-open-with-dialog.c:1094
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -2408,76 +2411,80 @@ msgstr ""
 "Impossible d'ajouter l'application à la base de données des applications : "
 "%s"
 
+#: ../libcaja-private/caja-open-with-dialog.c:252
+msgid "Unknown error"
+msgstr "Erreur inconnue"
+
 #: ../libcaja-private/caja-open-with-dialog.c:253
 msgid "Could not add application"
 msgstr "Impossible d'ajouter l'application"
 
-#: ../libcaja-private/caja-open-with-dialog.c:451
+#: ../libcaja-private/caja-open-with-dialog.c:454
 msgid "Select an Application"
 msgstr "Sélectionner une application"
 
-#: ../libcaja-private/caja-open-with-dialog.c:856
+#: ../libcaja-private/caja-open-with-dialog.c:859
 #: ../src/file-manager/fm-properties-window.c:5080
 msgid "Open With"
 msgstr "Ouvrir avec"
 
-#: ../libcaja-private/caja-open-with-dialog.c:894
+#: ../libcaja-private/caja-open-with-dialog.c:897
 msgid "Select an application to view its description."
 msgstr "Sélectionnez une application pour voir sa description."
 
-#: ../libcaja-private/caja-open-with-dialog.c:920
+#: ../libcaja-private/caja-open-with-dialog.c:923
 msgid "_Use a custom command"
 msgstr "_Utiliser une commande personnalisée"
 
-#: ../libcaja-private/caja-open-with-dialog.c:937
+#: ../libcaja-private/caja-open-with-dialog.c:940
 msgid "_Browse..."
 msgstr "_Parcourir..."
 
 #. first %s is a filename and second %s is a file extension
-#: ../libcaja-private/caja-open-with-dialog.c:1061
+#: ../libcaja-private/caja-open-with-dialog.c:1064
 #, c-format
 msgid "Open %s and other %s document with:"
 msgstr "Ouvrir %s et les autres documents %s avec :"
 
 #. the %s here is a file name
 #. %s is a filename
-#: ../libcaja-private/caja-open-with-dialog.c:1067
-#: ../libcaja-private/caja-open-with-dialog.c:1107
+#: ../libcaja-private/caja-open-with-dialog.c:1070
+#: ../libcaja-private/caja-open-with-dialog.c:1110
 #, c-format
 msgid "Open %s with:"
 msgstr "Ouvrir %s avec :"
 
-#: ../libcaja-private/caja-open-with-dialog.c:1068
+#: ../libcaja-private/caja-open-with-dialog.c:1071
 #, c-format
 msgid "_Remember this application for %s documents"
 msgstr "_Mémoriser cette application pour les documents %s"
 
 #. Only in add mode - the %s here is a file extension
-#: ../libcaja-private/caja-open-with-dialog.c:1079
+#: ../libcaja-private/caja-open-with-dialog.c:1082
 #, c-format
 msgid "Open all %s documents with:"
 msgstr "Ouvrir tous les documents « %s » avec :"
 
 #. First %s is a filename, second is a description
 #. * of the type, eg "plain text document"
-#: ../libcaja-private/caja-open-with-dialog.c:1101
+#: ../libcaja-private/caja-open-with-dialog.c:1104
 #, c-format
 msgid "Open %s and other \"%s\" files with:"
 msgstr "Ouvrir %s et les autres fichiers « %s » avec :"
 
 #. %s is a file type description
-#: ../libcaja-private/caja-open-with-dialog.c:1109
+#: ../libcaja-private/caja-open-with-dialog.c:1112
 #, c-format
 msgid "_Remember this application for \"%s\" files"
 msgstr "_Mémoriser cette application pour les fichiers « %s »"
 
 #. Only in add mode
-#: ../libcaja-private/caja-open-with-dialog.c:1120
+#: ../libcaja-private/caja-open-with-dialog.c:1123
 #, c-format
 msgid "Open all \"%s\" files with:"
 msgstr "Ouvrir tous les fichiers « %s » avec :"
 
-#: ../libcaja-private/caja-open-with-dialog.c:1133
+#: ../libcaja-private/caja-open-with-dialog.c:1136
 msgid "Add Application"
 msgstr "Ajouter une application"
 
@@ -2565,34 +2572,34 @@ msgstr ""
 msgid "Details: "
 msgstr "Détails : "
 
-#: ../libcaja-private/caja-progress-info.c:242
+#: ../libcaja-private/caja-progress-info.c:244
 msgid "File Operations"
 msgstr "Opérations sur les fichiers"
 
-#: ../libcaja-private/caja-progress-info.c:314
+#: ../libcaja-private/caja-progress-info.c:316
 msgid "paused"
 msgstr "en pause"
 
-#: ../libcaja-private/caja-progress-info.c:317
+#: ../libcaja-private/caja-progress-info.c:319
 msgid "pausing"
 msgstr "mise en pause"
 
-#: ../libcaja-private/caja-progress-info.c:320
+#: ../libcaja-private/caja-progress-info.c:322
 msgid "queued"
 msgstr "ajouté à la file"
 
-#: ../libcaja-private/caja-progress-info.c:323
+#: ../libcaja-private/caja-progress-info.c:325
 msgid "queuing"
 msgstr "mise en file"
 
-#: ../libcaja-private/caja-progress-info.c:610
+#: ../libcaja-private/caja-progress-info.c:603
 #, c-format
 msgid "%'d file operation active"
 msgid_plural "%'d file operations active"
 msgstr[0] "%'d opération de fichier active"
 msgstr[1] "%'d opérations de fichier actives"
 
-#: ../libcaja-private/caja-progress-info.c:629
+#: ../libcaja-private/caja-progress-info.c:625
 msgid "Process completed"
 msgstr "Processus terminé"
 
@@ -3991,13 +3998,13 @@ msgstr "Options de gestion de sessions :"
 msgid "Show session management options"
 msgstr "Afficher les options de gestion de sessions"
 
-#: ../src/file-manager/fm-desktop-icon-view.c:672
+#: ../src/file-manager/fm-desktop-icon-view.c:662
 msgid "Background"
 msgstr "Arrière-plan"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/file-manager/fm-desktop-icon-view.c:749
+#: ../src/file-manager/fm-desktop-icon-view.c:739
 #: ../src/file-manager/fm-directory-view.c:7374
 #: ../src/file-manager/fm-directory-view.c:9058
 msgid "E_mpty Trash"
@@ -4006,24 +4013,24 @@ msgstr "_Vider la corbeille"
 #. label, accelerator
 #. name, icon name
 #. label, accelerator
-#: ../src/file-manager/fm-desktop-icon-view.c:763
+#: ../src/file-manager/fm-desktop-icon-view.c:753
 #: ../src/file-manager/fm-directory-view.c:7338
 msgid "Create L_auncher..."
 msgstr "Créer un _lanceur..."
 
 #. tooltip
-#: ../src/file-manager/fm-desktop-icon-view.c:765
+#: ../src/file-manager/fm-desktop-icon-view.c:755
 #: ../src/file-manager/fm-directory-view.c:7339
 msgid "Create a new launcher"
 msgstr "Crée un nouveau lanceur"
 
 #. label, accelerator
-#: ../src/file-manager/fm-desktop-icon-view.c:772
+#: ../src/file-manager/fm-desktop-icon-view.c:762
 msgid "Change Desktop _Background"
 msgstr "Changer l'_arrière-plan du bureau"
 
 #. tooltip
-#: ../src/file-manager/fm-desktop-icon-view.c:774
+#: ../src/file-manager/fm-desktop-icon-view.c:764
 msgid ""
 "Show a window that lets you set your desktop background's pattern or color"
 msgstr ""
@@ -4031,21 +4038,21 @@ msgstr ""
 "'arrière-plan de votre bureau"
 
 #. label, accelerator
-#: ../src/file-manager/fm-desktop-icon-view.c:781
+#: ../src/file-manager/fm-desktop-icon-view.c:771
 msgid "Empty Trash"
 msgstr "Vider la corbeille"
 
 #. tooltip
-#: ../src/file-manager/fm-desktop-icon-view.c:783
+#: ../src/file-manager/fm-desktop-icon-view.c:773
 #: ../src/file-manager/fm-directory-view.c:7375 ../src/caja-trash-bar.c:202
 msgid "Delete all items in the Trash"
 msgstr "Supprime tous les éléments de la corbeille"
 
-#: ../src/file-manager/fm-desktop-icon-view.c:883
+#: ../src/file-manager/fm-desktop-icon-view.c:873
 msgid "The desktop view encountered an error."
 msgstr "La vue sous forme de bureau a rencontré une erreur."
 
-#: ../src/file-manager/fm-desktop-icon-view.c:884
+#: ../src/file-manager/fm-desktop-icon-view.c:874
 msgid "The desktop view encountered an error while starting up."
 msgstr ""
 "La vue sous forme de bureau a rencontré une erreur lors de son démarrage."
@@ -4083,7 +4090,7 @@ msgstr "Sélection d'éléments selon un motif"
 #: ../src/caja-emblem-sidebar.c:555
 #: ../src/caja-file-management-properties.ui.h:42
 #: ../src/caja-location-dialog.c:189 ../src/caja-property-browser.c:386
-#: ../src/caja-window-menus.c:911
+#: ../src/caja-window-menus.c:830
 msgid "_Help"
 msgstr "_Aide"
 
@@ -4648,7 +4655,7 @@ msgstr "A_nnuler"
 
 #. tooltip
 #: ../src/file-manager/fm-directory-view.c:7439
-#: ../src/file-manager/fm-directory-view.c:11197
+#: ../src/file-manager/fm-directory-view.c:11201
 msgid "Undo the last action"
 msgstr "Annuler la dernière action"
 
@@ -4660,7 +4667,7 @@ msgstr "_Restaurer"
 
 #. tooltip
 #: ../src/file-manager/fm-directory-view.c:7443
-#: ../src/file-manager/fm-directory-view.c:11215
+#: ../src/file-manager/fm-directory-view.c:11219
 msgid "Redo the last undone action"
 msgstr "Restaure la dernière action annulée"
 
@@ -4760,7 +4767,7 @@ msgstr "Démarre le volume sélectionné"
 #: ../src/file-manager/fm-directory-view.c:8383
 #: ../src/file-manager/fm-directory-view.c:8493
 #: ../src/caja-places-sidebar.c:1805 ../src/caja-places-sidebar.c:2763
-#: ../src/caja-window-menus.c:938
+#: ../src/caja-window-menus.c:857
 msgid "_Stop"
 msgstr "_Arrêter"
 
@@ -4941,7 +4948,7 @@ msgstr "Déplace la sélection actuelle vers l'autre panneau de cette fenêtre"
 #. name, icon name
 #. label, accelerator
 #: ../src/file-manager/fm-directory-view.c:7610
-#: ../src/file-manager/fm-directory-view.c:7614 ../src/caja-window-menus.c:993
+#: ../src/file-manager/fm-directory-view.c:7614 ../src/caja-window-menus.c:912
 msgid "_Home Folder"
 msgstr "_Dossier personnel"
 
@@ -5232,57 +5239,57 @@ msgstr "Supprime définitivement tous les éléments sélectionnés"
 msgid "View or modify the properties of the open folder"
 msgstr "Affiche ou modifie les propriétés du dossier ouvert"
 
-#: ../src/file-manager/fm-directory-view.c:10340
+#: ../src/file-manager/fm-directory-view.c:10344
 msgid "Download location?"
 msgstr "Télécharger l'emplacement ?"
 
-#: ../src/file-manager/fm-directory-view.c:10343
+#: ../src/file-manager/fm-directory-view.c:10347
 msgid "You can download it or make a link to it."
 msgstr "Vous pouvez le télécharger ou créer un lien vers lui."
 
-#: ../src/file-manager/fm-directory-view.c:10346
+#: ../src/file-manager/fm-directory-view.c:10350
 msgid "Make a _Link"
 msgstr "Créer un _lien"
 
-#: ../src/file-manager/fm-directory-view.c:10353
+#: ../src/file-manager/fm-directory-view.c:10357
 msgid "_Download"
 msgstr "_Télécharger"
 
-#: ../src/file-manager/fm-directory-view.c:10514
-#: ../src/file-manager/fm-directory-view.c:10573
-#: ../src/file-manager/fm-directory-view.c:10678
+#: ../src/file-manager/fm-directory-view.c:10518
+#: ../src/file-manager/fm-directory-view.c:10577
+#: ../src/file-manager/fm-directory-view.c:10682
 msgid "Drag and drop is not supported."
 msgstr "Le glisser-déposer n'est pas pris en charge."
 
-#: ../src/file-manager/fm-directory-view.c:10515
+#: ../src/file-manager/fm-directory-view.c:10519
 msgid "Drag and drop is only supported on local file systems."
 msgstr ""
 "Le glisser-déposer n'est pris en charge que sur les systèmes de fichiers "
 "locaux."
 
-#: ../src/file-manager/fm-directory-view.c:10574
-#: ../src/file-manager/fm-directory-view.c:10679
+#: ../src/file-manager/fm-directory-view.c:10578
+#: ../src/file-manager/fm-directory-view.c:10683
 msgid "An invalid drag type was used."
 msgstr "Un type de glisser non valide a été utilisé."
 
 #. Translator: This is the filename used for when you dnd text to a directory
-#: ../src/file-manager/fm-directory-view.c:10756
+#: ../src/file-manager/fm-directory-view.c:10760
 msgid "dropped text.txt"
 msgstr "texte déposé.txt"
 
 #. Translator: This is the filename used for when you dnd raw
 #. * data to a directory, if the source didn't supply a name.
-#: ../src/file-manager/fm-directory-view.c:10801
+#: ../src/file-manager/fm-directory-view.c:10805
 msgid "dropped data"
 msgstr "données déposées"
 
 #. Reset to default info
-#: ../src/file-manager/fm-directory-view.c:11196
+#: ../src/file-manager/fm-directory-view.c:11200
 msgid "Undo"
 msgstr "Annuler"
 
 #. Reset to default info
-#: ../src/file-manager/fm-directory-view.c:11214
+#: ../src/file-manager/fm-directory-view.c:11218
 msgid "Redo"
 msgstr "Restaurer"
 
@@ -5413,7 +5420,7 @@ msgstr "Renommage de « %s » en « %s »."
 #. translators: this is used in the view selection dropdown
 #. * of navigation windows and in the preferences dialog
 #: ../src/file-manager/fm-icon-container.c:614
-#: ../src/file-manager/fm-icon-view.c:3399
+#: ../src/file-manager/fm-icon-view.c:3403
 #: ../src/caja-file-management-properties.ui.h:1
 msgid "Icon View"
 msgstr "Vue en icônes"
@@ -5623,53 +5630,53 @@ msgid "pointing at \"%s\""
 msgstr "pointe sur « %s »"
 
 #. translators: this is used in the view menu
-#: ../src/file-manager/fm-icon-view.c:3401
+#: ../src/file-manager/fm-icon-view.c:3405
 msgid "_Icons"
 msgstr "_Icônes"
 
-#: ../src/file-manager/fm-icon-view.c:3402
+#: ../src/file-manager/fm-icon-view.c:3406
 msgid "The icon view encountered an error."
 msgstr "La vue icône a rencontré une erreur."
 
-#: ../src/file-manager/fm-icon-view.c:3403
+#: ../src/file-manager/fm-icon-view.c:3407
 msgid "The icon view encountered an error while starting up."
 msgstr "La vue icône a rencontré une erreur lors de son démarrage."
 
-#: ../src/file-manager/fm-icon-view.c:3404
+#: ../src/file-manager/fm-icon-view.c:3408
 msgid "Display this location with the icon view."
 msgstr "Affiche cet emplacement avec la vue icône."
 
 #. translators: this is used in the view selection dropdown
 #. * of navigation windows and in the preferences dialog
-#: ../src/file-manager/fm-icon-view.c:3414
+#: ../src/file-manager/fm-icon-view.c:3418
 #: ../src/caja-file-management-properties.ui.h:3
 msgid "Compact View"
 msgstr "Vue compacte"
 
 #. translators: this is used in the view menu
-#: ../src/file-manager/fm-icon-view.c:3416
+#: ../src/file-manager/fm-icon-view.c:3420
 msgid "_Compact"
 msgstr "_Compact"
 
-#: ../src/file-manager/fm-icon-view.c:3417
+#: ../src/file-manager/fm-icon-view.c:3421
 msgid "The compact view encountered an error."
 msgstr "La vue compacte a rencontré une erreur."
 
-#: ../src/file-manager/fm-icon-view.c:3418
+#: ../src/file-manager/fm-icon-view.c:3422
 msgid "The compact view encountered an error while starting up."
 msgstr "La vue compacte a rencontré une erreur lors de son démarrage."
 
-#: ../src/file-manager/fm-icon-view.c:3419
+#: ../src/file-manager/fm-icon-view.c:3423
 msgid "Display this location with the compact view."
 msgstr "Affiche cet emplacement avec la vue compacte."
 
 #: ../src/file-manager/fm-list-model.c:448
-#: ../src/file-manager/fm-tree-model.c:1366
+#: ../src/file-manager/fm-tree-model.c:1370
 msgid "(Empty)"
 msgstr "(vide)"
 
 #: ../src/file-manager/fm-list-model.c:452
-#: ../src/file-manager/fm-tree-model.c:1366 ../src/caja-window-slot.c:207
+#: ../src/file-manager/fm-tree-model.c:1370 ../src/caja-window-slot.c:207
 msgid "Loading..."
 msgstr "Chargement..."
 
@@ -5693,7 +5700,7 @@ msgstr "%s colonnes visibles"
 #: ../src/file-manager/fm-properties-window.c:5188
 #: ../src/caja-bookmarks-window.ui.h:5
 #: ../src/caja-file-management-properties.ui.h:43
-#: ../src/caja-property-browser.c:394 ../src/caja-window-menus.c:913
+#: ../src/caja-property-browser.c:394 ../src/caja-window-menus.c:832
 msgid "_Close"
 msgstr "_Fermer"
 
@@ -5868,7 +5875,7 @@ msgid "Free space:"
 msgstr "Espace libre :"
 
 #: ../src/file-manager/fm-properties-window.c:3437
-#: ../src/caja-emblem-sidebar.c:1096
+#: ../src/caja-emblem-sidebar.c:1095
 msgid "Emblems"
 msgstr "Emblèmes"
 
@@ -5929,7 +5936,7 @@ msgstr "Accès au fichier :"
 #. Translators: this is referred to captions under icons.
 #: ../src/file-manager/fm-properties-window.c:4211
 #: ../src/file-manager/fm-properties-window.c:4222
-#: ../src/caja-file-management-properties.c:339
+#: ../src/caja-file-management-properties.c:340
 msgid "None"
 msgstr "Aucun"
 
@@ -6067,12 +6074,12 @@ msgstr "Arborescence"
 msgid "Show Tree"
 msgstr "Afficher l'arborescence"
 
-#: ../src/caja-application.c:542
+#: ../src/caja-application.c:549
 #, c-format
 msgid "Caja could not create the required folder \"%s\"."
 msgstr "Caja est incapable de créer le dossier requis « %s »."
 
-#: ../src/caja-application.c:544
+#: ../src/caja-application.c:551
 msgid ""
 "Before running Caja, please create the following folder, or set permissions "
 "such that Caja can create it."
@@ -6080,12 +6087,12 @@ msgstr ""
 "Avant d'exécuter Caja, veuillez créer ce dossier, ou définir les permissions"
 " de telle sorte que Caja puisse le créer."
 
-#: ../src/caja-application.c:549
+#: ../src/caja-application.c:556
 #, c-format
 msgid "Caja could not create the following required folders: %s."
 msgstr "Caja est incapable de créer les dossiers requis : %s."
 
-#: ../src/caja-application.c:551
+#: ../src/caja-application.c:558
 msgid ""
 "Before running Caja, please create these folders, or set permissions such "
 "that Caja can create them."
@@ -6093,46 +6100,46 @@ msgstr ""
 "Avant d'exécuter Caja, veuillez créer ces dossiers, ou définir les "
 "permissions de telle sorte que Caja puisse les créer."
 
-#: ../src/caja-application.c:1325 ../src/caja-places-sidebar.c:2210
+#: ../src/caja-application.c:1332 ../src/caja-places-sidebar.c:2210
 #: ../src/caja-places-sidebar.c:2241 ../src/caja-places-sidebar.c:2276
 #, c-format
 msgid "Unable to eject %s"
 msgstr "Impossible d'éjecter %s"
 
-#: ../src/caja-application.c:1998
+#: ../src/caja-application.c:2005
 msgid "--check cannot be used with other options."
 msgstr "--check ne peut pas être utilisé avec d'autres options."
 
-#: ../src/caja-application.c:2004
+#: ../src/caja-application.c:2011
 msgid "--quit cannot be used with URIs."
 msgstr "--quit ne peut pas être utilisé avec des URIs."
 
-#: ../src/caja-application.c:2011
+#: ../src/caja-application.c:2018
 msgid "--geometry cannot be used with more than one URI."
 msgstr "--la géométrie ne peut pas être utilisée avec plus d'une URI."
 
-#: ../src/caja-application.c:2075
+#: ../src/caja-application.c:2082
 msgid "Perform a quick set of self-check tests."
 msgstr "Effectue des rapides tests de cohérence."
 
-#: ../src/caja-application.c:2078
+#: ../src/caja-application.c:2085
 msgid "Show the version of the program."
 msgstr "Affiche la version du programme."
 
-#: ../src/caja-application.c:2080
+#: ../src/caja-application.c:2087
 msgid "Create the initial window with the given geometry."
 msgstr "Crée la fenêtre initiale avec la géométrie donnée."
 
-#: ../src/caja-application.c:2080
+#: ../src/caja-application.c:2087
 msgid "GEOMETRY"
 msgstr "GÉOMÉTRIE"
 
-#: ../src/caja-application.c:2082
+#: ../src/caja-application.c:2089
 msgid "Only create windows for explicitly specified URIs."
 msgstr ""
 "Ne crée de nouvelles fenêtres que pour les URIs explicitement précisés."
 
-#: ../src/caja-application.c:2084
+#: ../src/caja-application.c:2091
 msgid ""
 "Do not manage the desktop (ignore the preference set in the preferences "
 "dialog)."
@@ -6140,7 +6147,7 @@ msgstr ""
 "Ne pas gérer le bureau (ignore l'option choisie dans la boîte de dialogue "
 "Préférences)."
 
-#: ../src/caja-application.c:2086
+#: ../src/caja-application.c:2093
 msgid ""
 "Manage the desktop regardless of set preferences or environment (on new "
 "startup only)"
@@ -6148,23 +6155,23 @@ msgstr ""
 "Gérer le bureau indépendamment des préférences définies de l'environnement "
 "(sur un nouveau démarrage seulement) "
 
-#: ../src/caja-application.c:2088
+#: ../src/caja-application.c:2095
 msgid "Open URIs in tabs."
 msgstr "Ouvre les URIs dans des onglets."
 
-#: ../src/caja-application.c:2090
+#: ../src/caja-application.c:2097
 msgid "Open a browser window."
 msgstr "Ouvrir une fenêtre de navigateur."
 
-#: ../src/caja-application.c:2092
+#: ../src/caja-application.c:2099
 msgid "Quit Caja."
 msgstr "Quitte Caja."
 
-#: ../src/caja-application.c:2093
+#: ../src/caja-application.c:2100
 msgid "[URI...]"
 msgstr "[URI...]"
 
-#: ../src/caja-application.c:2104
+#: ../src/caja-application.c:2111
 msgid ""
 "\n"
 "\n"
@@ -6208,8 +6215,8 @@ msgstr ""
 "En cas de doute, cliquez sur Annuler."
 
 #: ../src/caja-bookmarks-window.c:159
-#: ../src/caja-file-management-properties.c:246
-#: ../src/caja-property-browser.c:1676 ../src/caja-window-menus.c:692
+#: ../src/caja-file-management-properties.c:247
+#: ../src/caja-property-browser.c:1676 ../src/caja-window-menus.c:611
 #, c-format
 msgid ""
 "There was an error displaying help: \n"
@@ -6450,24 +6457,24 @@ msgstr "Les emblèmes ne semblent pas être des images valides."
 msgid "None of the files could be added as emblems."
 msgstr "Aucun des fichiers ne peut être ajouté comme emblème."
 
-#: ../src/caja-emblem-sidebar.c:858 ../src/caja-emblem-sidebar.c:921
+#: ../src/caja-emblem-sidebar.c:858 ../src/caja-emblem-sidebar.c:920
 #, c-format
 msgid "The file '%s' does not appear to be a valid image."
 msgstr "Le fichier « %s » ne semble pas être une image valide."
 
-#: ../src/caja-emblem-sidebar.c:863
+#: ../src/caja-emblem-sidebar.c:862
 msgid "The dragged file does not appear to be a valid image."
 msgstr "Le fichier déposé ne semble pas être une image valide."
 
-#: ../src/caja-emblem-sidebar.c:865 ../src/caja-emblem-sidebar.c:922
+#: ../src/caja-emblem-sidebar.c:864 ../src/caja-emblem-sidebar.c:921
 msgid "The emblem cannot be added."
 msgstr "Impossible d'ajouter l'emblème."
 
-#: ../src/caja-emblem-sidebar.c:1102
+#: ../src/caja-emblem-sidebar.c:1101
 msgid "Show Emblems"
 msgstr "Afficher les emblèmes"
 
-#: ../src/caja-file-management-properties.c:643
+#: ../src/caja-file-management-properties.c:644
 msgid "About Extension"
 msgstr "À propos de l'extension"
 
@@ -7119,7 +7126,7 @@ msgstr "Ferme toutes les fenêtres de navigation"
 msgid "_Location..."
 msgstr "_Emplacement..."
 
-#: ../src/caja-navigation-window-menus.c:833 ../src/caja-spatial-window.c:939
+#: ../src/caja-navigation-window-menus.c:833 ../src/caja-spatial-window.c:938
 msgid "Specify a location to open"
 msgstr "Indique un emplacement à ouvrir"
 
@@ -7151,20 +7158,20 @@ msgid "Go to the same location as in the extra pane"
 msgstr "Se place au même endroit que dans le panneau supplémentaire"
 
 #. name, icon name, label
-#: ../src/caja-navigation-window-menus.c:848 ../src/caja-spatial-window.c:952
+#: ../src/caja-navigation-window-menus.c:848 ../src/caja-spatial-window.c:951
 msgid "_Add Bookmark"
 msgstr "_Ajouter un favori"
 
-#: ../src/caja-navigation-window-menus.c:849 ../src/caja-spatial-window.c:953
+#: ../src/caja-navigation-window-menus.c:849 ../src/caja-spatial-window.c:952
 msgid "Add a bookmark for the current location to this menu"
 msgstr "Ajoute un signet sur l'emplacement actuel dans ce menu"
 
 #. name, icon name, label
-#: ../src/caja-navigation-window-menus.c:852 ../src/caja-spatial-window.c:956
+#: ../src/caja-navigation-window-menus.c:852 ../src/caja-spatial-window.c:955
 msgid "_Edit Bookmarks..."
 msgstr "Mo_difier les signets..."
 
-#: ../src/caja-navigation-window-menus.c:853 ../src/caja-spatial-window.c:957
+#: ../src/caja-navigation-window-menus.c:853 ../src/caja-spatial-window.c:956
 msgid "Display a window that allows editing the bookmarks in this menu"
 msgstr "Affiche une fenêtre qui permet de modifier les signets de ce menu"
 
@@ -7257,7 +7264,7 @@ msgstr "Modifie la visibilité de la barre d'état de cette fenêtre"
 #. name, icon name
 #. label, accelerator
 #. name, icon name, label
-#: ../src/caja-navigation-window-menus.c:910 ../src/caja-spatial-window.c:960
+#: ../src/caja-navigation-window-menus.c:910 ../src/caja-spatial-window.c:959
 msgid "_Search for Files..."
 msgstr "_Recherche des fichiers..."
 
@@ -7670,10 +7677,10 @@ msgstr "Autre type..."
 
 #: ../src/caja-query-editor.c:1063 ../src/caja-query-editor.c:1202
 msgid "Less than or equal to"
-msgstr "Inférieur(e) ou égal à"
+msgstr "Inférieur ou égal à"
 
 #: ../src/caja-query-editor.c:1065 ../src/caja-query-editor.c:1204
-msgid "Greater or equal to"
+msgid "Greater than or equal to"
 msgstr "Supérieur(e) ou égal à"
 
 #: ../src/caja-query-editor.c:1078
@@ -7686,7 +7693,7 @@ msgstr "1 jour"
 
 #: ../src/caja-query-editor.c:1082
 msgid "1 Week"
-msgstr "1 semain"
+msgstr "1 mois"
 
 #: ../src/caja-query-editor.c:1084
 msgid "1 Month"
@@ -7801,34 +7808,34 @@ msgid "Close the side pane"
 msgstr "Ferme le panneau latéral"
 
 #. name, icon name, label
-#: ../src/caja-spatial-window.c:936
+#: ../src/caja-spatial-window.c:935
 msgid "_Places"
 msgstr "_Raccourcis"
 
 #. name, icon name, label
-#: ../src/caja-spatial-window.c:938
+#: ../src/caja-spatial-window.c:937
 msgid "Open _Location..."
 msgstr "Ouvrir un _emplacement..."
 
 #. name, icon name, label
-#: ../src/caja-spatial-window.c:943
+#: ../src/caja-spatial-window.c:942
 msgid "Close P_arent Folders"
 msgstr "Fermer tous les dossiers p_arents"
 
-#: ../src/caja-spatial-window.c:944
+#: ../src/caja-spatial-window.c:943
 msgid "Close this folder's parents"
 msgstr "Ferme les parents de ce dossier"
 
 #. name, icon name, label
-#: ../src/caja-spatial-window.c:948
+#: ../src/caja-spatial-window.c:947
 msgid "Clos_e All Folders"
 msgstr "Fermer tous les _dossiers"
 
-#: ../src/caja-spatial-window.c:949
+#: ../src/caja-spatial-window.c:948
 msgid "Close all folder windows"
 msgstr "Ferme toutes les fenêtres de dossier"
 
-#: ../src/caja-spatial-window.c:961
+#: ../src/caja-spatial-window.c:960
 msgid "Locate documents and folders on this computer by name or content"
 msgstr ""
 "Localiser les documents et dossiers de cet ordinateur par leur nom ou leur "
@@ -7863,45 +7870,45 @@ msgstr ""
 msgid "The location cannot be displayed with this viewer."
 msgstr "Impossible d'afficher l'emplacement avec cette visionneuse."
 
-#: ../src/caja-window-manage-views.c:1412
+#: ../src/caja-window-manage-views.c:1425
 msgid "Content View"
 msgstr "Vue du contenu"
 
-#: ../src/caja-window-manage-views.c:1413
+#: ../src/caja-window-manage-views.c:1426
 msgid "View of the current folder"
 msgstr "Vue du dossier actuel"
 
-#: ../src/caja-window-manage-views.c:2104
+#: ../src/caja-window-manage-views.c:2117
 msgid "Caja has no installed viewer capable of displaying the folder."
 msgstr "Caja n'a aucune visionneuse installée capable d'afficher le dossier."
 
-#: ../src/caja-window-manage-views.c:2112
+#: ../src/caja-window-manage-views.c:2125
 msgid "The location is not a folder."
 msgstr "L'emplacement n'est pas un dossier."
 
-#: ../src/caja-window-manage-views.c:2121
+#: ../src/caja-window-manage-views.c:2134
 #, c-format
 msgid "Could not find \"%s\"."
 msgstr "Impossible de trouver « %s »."
 
-#: ../src/caja-window-manage-views.c:2124
+#: ../src/caja-window-manage-views.c:2137
 msgid "Please check the spelling and try again."
 msgstr "Vérifiez l'orthographe et essayez à nouveau."
 
-#: ../src/caja-window-manage-views.c:2133
+#: ../src/caja-window-manage-views.c:2146
 #, c-format
 msgid "Caja cannot handle \"%s\" locations."
 msgstr "Caja ne reconnaît pas les emplacements « %s »."
 
-#: ../src/caja-window-manage-views.c:2138
+#: ../src/caja-window-manage-views.c:2151
 msgid "Caja cannot handle this kind of location."
 msgstr "Caja ne reconnaît pas ce type d'emplacement."
 
-#: ../src/caja-window-manage-views.c:2145
+#: ../src/caja-window-manage-views.c:2158
 msgid "Unable to mount the location."
 msgstr "Impossible de monter l'emplacement."
 
-#: ../src/caja-window-manage-views.c:2151
+#: ../src/caja-window-manage-views.c:2164
 msgid "Access was denied."
 msgstr "L'accès a été refusé."
 
@@ -7909,19 +7916,19 @@ msgstr "L'accès a été refusé."
 #. * the code that guesses web addresses when there's no initial "/".
 #. * But this case is also hit for legitimate web addresses when
 #. * the proxy is set up wrong.
-#: ../src/caja-window-manage-views.c:2160
+#: ../src/caja-window-manage-views.c:2173
 #, c-format
 msgid "Could not display \"%s\", because the host could not be found."
 msgstr "Impossible d'afficher « %s », car l'hôte ne peut être trouvé."
 
-#: ../src/caja-window-manage-views.c:2162
+#: ../src/caja-window-manage-views.c:2175
 msgid ""
 "Check that the spelling is correct and that your proxy settings are correct."
 msgstr ""
 "Vérifiez que l'orthographe ainsi que vos paramètres de serveur mandataire "
 "sont corrects."
 
-#: ../src/caja-window-manage-views.c:2178
+#: ../src/caja-window-manage-views.c:2191
 #, c-format
 msgid ""
 "Error: %s\n"
@@ -7934,7 +7941,7 @@ msgstr ""
 msgid "Go to the location specified by this bookmark"
 msgstr "Va à l'emplacement indiqué par ce signet"
 
-#: ../src/caja-window-menus.c:618
+#: ../src/caja-window-menus.c:518
 msgid ""
 "Caja is free software; you can redistribute it and/or modify it under the "
 "terms of the GNU General Public License as published by the Free Software "
@@ -7946,7 +7953,7 @@ msgstr ""
 "la Free Software Foundation ; version 2 de la licence, ou (à votre "
 "discrétion) toute version ultérieure."
 
-#: ../src/caja-window-menus.c:622
+#: ../src/caja-window-menus.c:522
 msgid ""
 "Caja is distributed in the hope that it will be useful, but WITHOUT ANY "
 "WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS "
@@ -7958,7 +7965,7 @@ msgstr ""
 "D'ADÉQUATION À UN BESOIN PARTICULIER. Consultez la Licence Publique Générale"
 " GNU pour plus de détails."
 
-#: ../src/caja-window-menus.c:626
+#: ../src/caja-window-menus.c:526
 msgid ""
 "You should have received a copy of the GNU General Public License along with"
 " Caja; if not, write to the Free Software Foundation, Inc., 51 Franklin "
@@ -7968,18 +7975,18 @@ msgstr ""
 "temps que Caja ; si ce n'est pas le cas, écrivez à la Free Software "
 "Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA"
 
-#: ../src/caja-window-menus.c:637
+#: ../src/caja-window-menus.c:558
 msgid "About Caja"
 msgstr "À propos de Caja"
 
-#: ../src/caja-window-menus.c:639
+#: ../src/caja-window-menus.c:560
 msgid ""
 "Caja lets you organize files and folders, both on your computer and online."
 msgstr ""
 "Caja permet d'organiser vos fichiers et vos dossiers, aussi bien sur votre "
 "ordinateur que dans un réseau."
 
-#: ../src/caja-window-menus.c:642
+#: ../src/caja-window-menus.c:563
 msgid ""
 "Copyright © 1999-2009 The Nautilus authors\n"
 "Copyright © 2011-2019 The Caja authors"
@@ -7987,10 +7994,7 @@ msgstr ""
 "Copyright © 1999-2009 Les auteurs de Nautilus\n"
 "Copyright © 2011-2019 Les auteurs de  Caja"
 
-#. Translators should localize the following string
-#. * which will be displayed at the bottom of the about
-#. * box to give credit to the translator(s).
-#: ../src/caja-window-menus.c:652
+#: ../src/caja-window-menus.c:569
 msgid "translator-credits"
 msgstr ""
 "Contributeurs au projet MATE :\n"
@@ -8008,35 +8012,35 @@ msgstr ""
 "Claude Paroz <claude@2xlibre.net>, 2008-2010.\n"
 "Gérard Baylard <gerard dot b at bbox dot fr>, 2010"
 
-#: ../src/caja-window-menus.c:655
+#: ../src/caja-window-menus.c:572
 msgid "MATE Web Site"
 msgstr "Site Internet de MATE"
 
 #. name, icon name, label
-#: ../src/caja-window-menus.c:908
+#: ../src/caja-window-menus.c:827
 msgid "_File"
 msgstr "_Fichier"
 
 #. name, icon name, label
-#: ../src/caja-window-menus.c:909
+#: ../src/caja-window-menus.c:828
 msgid "_Edit"
 msgstr "_Editer"
 
 #. name, icon name, label
-#: ../src/caja-window-menus.c:910
+#: ../src/caja-window-menus.c:829
 msgid "_View"
 msgstr "_Affichage"
 
 #. tooltip
-#: ../src/caja-window-menus.c:914
+#: ../src/caja-window-menus.c:833
 msgid "Close this folder"
 msgstr "Ferme ce dossier"
 
-#: ../src/caja-window-menus.c:919
+#: ../src/caja-window-menus.c:838
 msgid "_Backgrounds and Emblems..."
 msgstr "_Arrière-plans et emblèmes..."
 
-#: ../src/caja-window-menus.c:920
+#: ../src/caja-window-menus.c:839
 msgid ""
 "Display patterns, colors, and emblems that can be used to customize "
 "appearance"
@@ -8044,174 +8048,174 @@ msgstr ""
 "Affiche les motifs, couleurs, et emblèmes qui peuvent être utilisés pour "
 "personnaliser l'apparence"
 
-#: ../src/caja-window-menus.c:925
+#: ../src/caja-window-menus.c:844
 msgid "Prefere_nces"
 msgstr "_Préférences"
 
-#: ../src/caja-window-menus.c:926
+#: ../src/caja-window-menus.c:845
 msgid "Edit Caja preferences"
 msgstr "Modifie les préférences de Caja"
 
 #. name, icon name, label
-#: ../src/caja-window-menus.c:929
+#: ../src/caja-window-menus.c:848
 msgid "Open _Parent"
 msgstr "Ouvrir le dossier _parent"
 
-#: ../src/caja-window-menus.c:930
+#: ../src/caja-window-menus.c:849
 msgid "Open the parent folder"
 msgstr "Ouvre le dossier parent"
 
 #. tooltip
-#: ../src/caja-window-menus.c:939
+#: ../src/caja-window-menus.c:858
 msgid "Stop loading the current location"
 msgstr "Arrête le chargement de l'emplacement actuel"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:943
+#: ../src/caja-window-menus.c:862
 msgid "_Reload"
 msgstr "_Recharger"
 
 #. tooltip
-#: ../src/caja-window-menus.c:944
+#: ../src/caja-window-menus.c:863
 msgid "Reload the current location"
 msgstr "Actualise l'emplacement actuel"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:948
+#: ../src/caja-window-menus.c:867
 msgid "_Contents"
 msgstr "_Sommaire"
 
 #. tooltip
-#: ../src/caja-window-menus.c:949
+#: ../src/caja-window-menus.c:868
 msgid "Display Caja help"
 msgstr "Affiche l'aide de Caja"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:953
+#: ../src/caja-window-menus.c:872
 msgid "_About"
 msgstr "_À propos"
 
 #. tooltip
-#: ../src/caja-window-menus.c:954
+#: ../src/caja-window-menus.c:873
 msgid "Display credits for the creators of Caja"
 msgstr "Affiche la liste des créateurs de Caja"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:958
+#: ../src/caja-window-menus.c:877
 msgid "Zoom _In"
 msgstr "Zoom a_vant"
 
 #. tooltip
-#: ../src/caja-window-menus.c:959 ../src/caja-zoom-control.c:96
+#: ../src/caja-window-menus.c:878 ../src/caja-zoom-control.c:96
 #: ../src/caja-zoom-control.c:309
 msgid "Increase the view size"
 msgstr "Agrandit l'affichage"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:973
+#: ../src/caja-window-menus.c:892
 msgid "Zoom _Out"
 msgstr "Zoom a_rrière"
 
 #. tooltip
-#: ../src/caja-window-menus.c:974 ../src/caja-zoom-control.c:97
+#: ../src/caja-window-menus.c:893 ../src/caja-zoom-control.c:97
 #: ../src/caja-zoom-control.c:254
 msgid "Decrease the view size"
 msgstr "Diminue l'affichage"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:983
+#: ../src/caja-window-menus.c:902
 msgid "Normal Si_ze"
 msgstr "Taille _normale"
 
 #. tooltip
-#: ../src/caja-window-menus.c:984 ../src/caja-zoom-control.c:98
+#: ../src/caja-window-menus.c:903 ../src/caja-zoom-control.c:98
 #: ../src/caja-zoom-control.c:270
 msgid "Use the normal view size"
 msgstr "Affiche les éléments avec la taille normale"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:988
+#: ../src/caja-window-menus.c:907
 msgid "Connect to _Server..."
 msgstr "Se connecter à un _serveur..."
 
 #. tooltip
-#: ../src/caja-window-menus.c:989
+#: ../src/caja-window-menus.c:908
 msgid "Connect to a remote computer or shared disk"
 msgstr "Se connecte à un serveur distant ou à un disque partagé"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:998
+#: ../src/caja-window-menus.c:917
 msgid "_Computer"
 msgstr "_Poste de travail"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:1003
+#: ../src/caja-window-menus.c:922
 msgid "_Network"
 msgstr "_Réseau"
 
 #. tooltip
-#: ../src/caja-window-menus.c:1004 ../src/mate-network-scheme.desktop.in.h:2
+#: ../src/caja-window-menus.c:923 ../src/mate-network-scheme.desktop.in.h:2
 msgid "Browse bookmarked and local network locations"
 msgstr "Parcourir les emplacements mis en signets et du réseau local"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:1008
+#: ../src/caja-window-menus.c:927
 msgid "T_emplates"
 msgstr "_Modèles"
 
 #. tooltip
-#: ../src/caja-window-menus.c:1009
+#: ../src/caja-window-menus.c:928
 msgid "Open your personal templates folder"
 msgstr "Ouvrir le dossier des modèles personnels"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:1013
+#: ../src/caja-window-menus.c:932
 msgid "_Trash"
 msgstr "_Corbeille"
 
 #. tooltip
-#: ../src/caja-window-menus.c:1014
+#: ../src/caja-window-menus.c:933
 msgid "Open your personal trash folder"
 msgstr "Ouvrir votre dossier de corbeille personnel"
 
 #. name, icon name
 #. label, accelerator
-#: ../src/caja-window-menus.c:1022
+#: ../src/caja-window-menus.c:941
 msgid "Show _Hidden Files"
 msgstr "Afficher les fic_hiers cachés"
 
 #. tooltip
-#: ../src/caja-window-menus.c:1023
+#: ../src/caja-window-menus.c:942
 msgid "Toggle the display of hidden files in the current window"
 msgstr "Affiche ou non les fichiers cachés dans la fenêtre actuelle"
 
 #. name, stock id
 #. label, accelerator
-#: ../src/caja-window-menus.c:1028
+#: ../src/caja-window-menus.c:947
 msgid "Show Bac_kup Files"
 msgstr "Afficher les fichiers de sauvegardes"
 
 #. tooltip
-#: ../src/caja-window-menus.c:1029
+#: ../src/caja-window-menus.c:948
 msgid "Toggle the display of backup files in the current window"
 msgstr "Affiche ou non les fichiers de sauvegarde dans la fenêtre actuelle"
 
-#: ../src/caja-window-menus.c:1061
+#: ../src/caja-window-menus.c:980
 msgid "_Up"
 msgstr "_Haut"
 
-#: ../src/caja-window-menus.c:1064
+#: ../src/caja-window-menus.c:983
 msgid "_Home"
 msgstr "_Dossier personnel"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -1239,12 +1239,12 @@ msgstr "e copie)"
 #. localizers: tag used to detect the x1st copy of a file
 #: ../libcaja-private/caja-file-operations.c:492
 msgid "st copy)"
-msgstr "re copy)"
+msgstr "re copie)"
 
 #. localizers: tag used to detect the x2nd copy of a file
 #: ../libcaja-private/caja-file-operations.c:494
 msgid "nd copy)"
-msgstr "e copy)"
+msgstr "e copie)"
 
 #. localizers: tag used to detect the x3rd copy of a file
 #: ../libcaja-private/caja-file-operations.c:496


### PR DESCRIPTION
As requested by @raveit65 https://github.com/mate-desktop/caja/pull/1330#issuecomment-567109522 I've joined the french translation team on _Transifex_.

I've modified small misspellings ("copie" instead of "copy") on Transifex and the French Loc from this PR is now synchronized with the last version from _Transifex_.