### PR TITLE
fm-properties: Remove use of mate-desktop-thumbnail helper

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_PREREQ(2.54)
 
 dnl ===========================================================================
 
+m4_define(gdk-pixbuf_minver,           2.36.5)
 m4_define(glib_minver,                 2.58.1)
 m4_define(gio_minver,                  2.50.0)
 m4_define(mate_desktop_minver,         1.17.3)
@@ -33,6 +34,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE
 AC_SUBST([ACLOCAL_AMFLAGS], ["\${ACLOCAL_FLAGS}"])
 
+AC_SUBST(GDKPIXBUF_REQUIRED, [gdk-pixbuf_minver])
 AC_SUBST(GLIB_REQUIRED, [glib_minver])
 AC_SUBST(GIO_REQUIRED, [gio_minver])
 AC_SUBST(MATE_DESKTOP_REQUIRED, [mate_desktop_minver])
@@ -64,6 +66,7 @@ AC_PATH_PROG([GLA11Y], [gla11y], [true])
 AC_CHECK_LIB(m, floor)
 
 PKG_CHECK_MODULES(ALL, [
+    gdk-pixbuf-2.0 >= gdk-pixbuf_minver
     glib-2.0 >= glib_minver
     mate-desktop-2.0 >= mate_desktop_minver
     gthread-2.0

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -31,9 +31,6 @@
 #include <glib/gi18n.h>
 #include <sys/stat.h>
 
-#define MATE_DESKTOP_USE_UNSTABLE_API
-#include <libmate-desktop/mate-desktop-thumbnail.h>
-
 #include <eel/eel-accessibility.h>
 #include <eel/eel-gdk-pixbuf-extensions.h>
 #include <eel/eel-glib-extensions.h>
@@ -5677,10 +5674,11 @@ update_preview_callback (GtkFileChooser *icon_chooser,
 			scale = (double)gdk_pixbuf_get_height (pixbuf) /
 				gdk_pixbuf_get_width (pixbuf);
 
-			scaled_pixbuf = mate_desktop_thumbnail_scale_down_pixbuf
+			scaled_pixbuf = gdk_pixbuf_scale_simple
 				(pixbuf,
 				 PREVIEW_IMAGE_WIDTH,
-				 scale * PREVIEW_IMAGE_WIDTH);
+				 scale * PREVIEW_IMAGE_WIDTH,
+				 GDK_INTERP_HYPER);
 			g_object_unref (pixbuf);
 			pixbuf = scaled_pixbuf;
 		}


### PR DESCRIPTION
don't use mate_desktop_thumbnail_scale_down_pixbuf().
gdk-pixbuf doesn't have the same bugs when shrinking images by large
factors.

Please review.