### PR TITLE
Set a real title on the desktop window (as provided to ATK)

### DIFF
--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -204,6 +204,8 @@ caja_desktop_window_new (CajaApplication *application,
         XFree(xch);
     }
 
+    gdk_window_set_title (gdkwin, _("Desktop"));
+
     g_signal_connect (window, "delete_event", G_CALLBACK (caja_desktop_window_delete_event), NULL);
 
     /* Point window at the desktop folder.
@@ -313,12 +315,6 @@ draw (GtkWidget *widget,
     return GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->draw (widget, cr);
 }
 
-static char *
-real_get_title (CajaWindow *window)
-{
-    return g_strdup (_("Desktop"));
-}
-
 static CajaIconInfo *
 real_get_icon (CajaWindow *window,
                CajaWindowSlot *slot)
@@ -341,7 +337,6 @@ caja_desktop_window_class_init (CajaDesktopWindowClass *klass)
     gtk_widget_class_set_accessible_type (wclass, CAJA_TYPE_DESKTOP_WINDOW_ACCESSIBLE);
 
     nclass->window_type = CAJA_WINDOW_DESKTOP;
-    nclass->get_title = real_get_title;
     nclass->get_icon = real_get_icon;
 }
 

--- a/src/caja-spatial-window.c
+++ b/src/caja-spatial-window.c
@@ -394,6 +394,10 @@ sync_window_title (CajaWindow *window)
 
     slot = caja_window_get_active_slot (window);
 
+    /* Don't change desktop's title, it would override the one already defined */
+    if (CAJA_IS_DESKTOP_WINDOW (window))
+        return;
+
     if (slot->title == NULL || slot->title[0] == '\0')
     {
         gtk_window_set_title (GTK_WINDOW (window), _("Caja"));


### PR DESCRIPTION
Even if we think that the desktop window title is never seen, it is used
by the window selector in "all windows" mode and speech synthesis.