### PR TITLE
Bump required version of mate-desktop since pixbuf helper was removed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ dnl ===========================================================================
 m4_define(gdk-pixbuf_minver,           2.36.5)
 m4_define(glib_minver,                 2.58.1)
 m4_define(gio_minver,                  2.50.0)
-m4_define(mate_desktop_minver,         1.17.3)
+m4_define(mate_desktop_minver,         1.23.3)
 m4_define(pango_minver,                1.1.2)
 m4_define(gtk_minver,                  3.22.0)
 m4_define(xml_minver,                  2.4.7)


### PR DESCRIPTION
See https://github.com/mate-desktop/mate-desktop/commit/8f6e3df4ce1b570a9f71ed0383427b85b4378144
Closes #1343