### PR TITLE
Fix build using gcc 10 -fno-common flag

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -32,8 +32,6 @@
 #include <math.h>
 #include <stdio.h>
 
-#include <libcaja-private/caja-global-preferences.h>
-
 #include "eel-background.h"
 #include "eel-gdk-extensions.h"
 #include "eel-glib-extensions.h"
@@ -431,6 +429,7 @@ set_root_surface (EelBackground *self,
 static void
 init_fade (EelBackground *self)
 {
+    GSettings *mate_background_preferences;
     GtkWidget *widget = self->details->widget;
     gboolean do_fade;
 
@@ -438,8 +437,11 @@ init_fade (EelBackground *self)
         return;
     }
 
+    mate_background_preferences = g_settings_new ("org.mate.background");
     do_fade = g_settings_get_boolean (mate_background_preferences,
                                       MATE_BG_KEY_BACKGROUND_FADE);
+    g_object_unref (mate_background_preferences);
+
     if (!do_fade) {
     	return;
     }

--- a/libcaja-private/caja-global-preferences.c
+++ b/libcaja-private/caja-global-preferences.c
@@ -35,6 +35,19 @@
 #include "caja-file-utilities.h"
 #include "caja-file.h"
 
+GSettings *caja_preferences;
+GSettings *caja_media_preferences;
+GSettings *caja_window_state;
+GSettings *caja_icon_view_preferences;
+GSettings *caja_desktop_preferences;
+GSettings *caja_tree_sidebar_preferences;
+GSettings *caja_compact_view_preferences;
+GSettings *caja_list_view_preferences;
+GSettings *caja_extension_preferences;
+
+GSettings *mate_background_preferences;
+GSettings *mate_lockdown_preferences;
+
 /*
  * Public functions
  */

--- a/libcaja-private/caja-global-preferences.h
+++ b/libcaja-private/caja-global-preferences.h
@@ -212,18 +212,18 @@ typedef enum
 void caja_global_preferences_init                      (void);
 char *caja_global_preferences_get_default_folder_viewer_preference_as_iid (void);
 
-GSettings *caja_preferences;
-GSettings *caja_media_preferences;
-GSettings *caja_window_state;
-GSettings *caja_icon_view_preferences;
-GSettings *caja_desktop_preferences;
-GSettings *caja_tree_sidebar_preferences;
-GSettings *caja_compact_view_preferences;
-GSettings *caja_list_view_preferences;
-GSettings *caja_extension_preferences;
+extern GSettings *caja_preferences;
+extern GSettings *caja_media_preferences;
+extern GSettings *caja_window_state;
+extern GSettings *caja_icon_view_preferences;
+extern GSettings *caja_desktop_preferences;
+extern GSettings *caja_tree_sidebar_preferences;
+extern GSettings *caja_compact_view_preferences;
+extern GSettings *caja_list_view_preferences;
+extern GSettings *caja_extension_preferences;
 
-GSettings *mate_background_preferences;
-GSettings *mate_lockdown_preferences;
+extern GSettings *mate_background_preferences;
+extern GSettings *mate_lockdown_preferences;
 
 G_END_DECLS
 


### PR DESCRIPTION
```
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-bookmarks-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-connect-server-dialog.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-connect-server-dialog-nonmain.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-file-management-properties.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-history-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-information-panel.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-main.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-navigation-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-navigation-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-navigation-window-pane.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-notes-viewer.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-pathbar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-places-sidebar.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-property-browser.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-query-editor.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-sidebar-title.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-spatial-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-window-manage-views.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-window-menus.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-window-toolbars.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-window.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: caja-zoom-control.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-desktop-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-directory-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-container.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-icon-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-properties-window.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-tree-view.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../src/file-manager/.libs/libcaja-file-manager.a(fm-list-model.o):/home/robert/caja/src/file-manager/../../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-autorun.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link-monitor.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-desktop-link.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-async.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory-background.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-directory.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-extensions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-entry.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-operations.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file-utilities.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-file.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-global-preferences.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-container.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-mime-actions.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-progress-info.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-program-choosing.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-thumbnails.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(eel-background.o):/home/robert/caja/eel/../libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:215: multiple definition of `caja_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:215: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:226: multiple definition of `mate_lockdown_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:226: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:225: multiple definition of `mate_background_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:225: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:223: multiple definition of `caja_extension_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:223: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:222: multiple definition of `caja_list_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:222: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:221: multiple definition of `caja_compact_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:221: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:220: multiple definition of `caja_tree_sidebar_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:220: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:219: multiple definition of `caja_desktop_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:219: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:218: multiple definition of `caja_icon_view_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:218: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:217: multiple definition of `caja_window_state'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:217: first defined here
/usr/bin/ld: ../libcaja-private/.libs/libcaja-private.a(caja-icon-canvas-item.o):/home/robert/caja/libcaja-private/caja-global-preferences.h:216: multiple definition of `caja_media_preferences'; caja-application.o:/home/robert/caja/src/../libcaja-private/caja-global-preferences.h:216: first defined here
```