### PR TITLE
build: show compiler flags on configuration summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -349,6 +349,8 @@ caja-$VERSION:
     prefix:                       ${prefix}
     source code location:         ${srcdir}
     compiler:                     ${CC}
+    compiler flags:               ${CFLAGS}
+    warning flags:                ${WARNING_CFLAGS}
     xmp support:                  $msg_xmp
     PackageKit support:           $msg_packagekit
     Self check:                   $msg_self_check


### PR DESCRIPTION
```shell
$ ./autogen.sh --enable-more-warnings
<cut>
caja-1.23.4:

    prefix:                       /usr/local
    source code location:         .
    compiler:                     gcc
    compiler flags:               -g -O2
    warning flags:                    -Wall     -Wmissing-declarations -Wmissing-prototypes     -Wnested-externs -Wpointer-arith     -Wcast-align     -Werror -Wstrict-aliasing=0 -Wno-pointer-sign
    xmp support:                  yes
    PackageKit support:           yes
    Self check:                   yes

    caja-extension documentation: no
    caja-extension introspection: yes

Now type `make' to compile caja
```