### PR TITLE
Drop GLIB version check

### DIFF
--- a/src/file-manager/fm-directory-view.h
+++ b/src/file-manager/fm-directory-view.h
@@ -30,7 +30,6 @@
 
 #include <gtk/gtk.h>
 #include <gio/gio.h>
-#include <glib.h>
 
 #include <eel/eel-background.h>
 
@@ -343,9 +342,7 @@ struct FMDirectoryViewClass
 /* GObject support */
 GType               fm_directory_view_get_type                         (void);
 
-#if GLIB_CHECK_VERSION(2, 44, 0)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FMDirectoryView, g_object_unref);
-#endif
 
 /* Functions callable from the user interface and elsewhere. */
 CajaWindowInfo *fm_directory_view_get_caja_window              (FMDirectoryView  *view);


### PR DESCRIPTION
In the `configure.ac` file, we defined that GLIB requires version 2.58.1, It can be safely droped here.
```
m4_define(glib_minver,                 2.58.1)
```