### PR TITLE
Look for caja extensions at $CAJA_EXTENSION_DIRS

### DIFF
--- a/libcaja-private/caja-module.c
+++ b/libcaja-private/caja-module.c
@@ -261,7 +261,19 @@ caja_module_setup (void)
 
     if (!initialized)
     {
+        const gchar *caja_extension_dirs = g_getenv ("CAJA_EXTENSION_DIRS");
+
         initialized = TRUE;
+
+        if (caja_extension_dirs)
+        {
+            gchar **dir_vector = g_strsplit (caja_extension_dirs, G_SEARCHPATH_SEPARATOR_S, 0);
+
+            for (gchar **dir = dir_vector; *dir != NULL; ++ dir)
+                load_module_dir (*dir);
+
+            g_strfreev(dir_vector);
+        }
 
         load_module_dir (CAJA_EXTENSIONDIR);
 


### PR DESCRIPTION
`CAJA_EXTENSION_DIRS` is a list of directories where caja extensions are looked for. It is needed for distributions like [NixOS](https://nixos.org/) that do not install all extensions in the same directory. In NixOS each package is installed in a self contained directory.