### PR TITLE
Confirm undo if deleting

### DIFF
--- a/libcaja-private/caja-undostack-manager.c
+++ b/libcaja-private/caja-undostack-manager.c
@@ -265,7 +265,6 @@ caja_undostack_manager_init (CajaUndoStackManager * self)
   priv->index = 0;
   priv->dispose_has_run = FALSE;
   priv->undo_redo_flag = FALSE;
-  priv->confirm_delete = FALSE;
 }
 
 static void
@@ -319,9 +318,6 @@ caja_undostack_manager_set_property (GObject * object, guint prop_id,
         g_mutex_unlock (&priv->mutex);
         do_menu_update (manager);
       }
-      break;
-    case PROP_CONFIRM_DELETE:
-      priv->confirm_delete = g_value_get_boolean (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -423,7 +419,7 @@ caja_undostack_manager_redo (CajaUndoStackManager * manager,
         uris = construct_gfile_list (action->sources, action->src_dir);
         caja_file_operations_copy (uris, NULL,
             action->dest_dir, NULL, undo_redo_done_transfer_callback, action);
-    	g_list_free_full (uris, g_object_unref);
+        g_list_free_full (uris, g_object_unref);
         break;
       }
       case CAJA_UNDOSTACK_CREATEFILEFROMTEMPLATE:
@@ -614,25 +610,11 @@ caja_undostack_manager_undo (CajaUndoStackManager * manager,
           uris = construct_gfile_list (action->destinations, action->dest_dir);
           uris = g_list_reverse (uris); // Deleting must be done in reverse
         }
-        if (priv->confirm_delete) {
-          caja_file_operations_delete (uris, NULL,
-              undo_redo_done_delete_callback, action);
-    	  g_list_free_full (uris, g_object_unref);
-        } else {
-          /* We skip the confirmation message
-           */
-          GList *f;
-          for (f = uris; f != NULL; f = f->next) {
-            char *name;
-            name = g_file_get_uri (f->data);
-            g_free (name);
-            g_file_delete (f->data, NULL, NULL);
-            g_object_unref (f->data);
-          }
-          g_list_free (uris);
-          /* Here we must do what's necessary for the callback */
-          undo_redo_done_transfer_callback (NULL, action);
-        }
+
+        caja_file_operations_delete (uris, NULL,
+            undo_redo_done_delete_callback, action);
+    	g_list_free_full (uris, g_object_unref);
+ 
         break;
       case CAJA_UNDOSTACK_RESTOREFROMTRASH:
         uris = construct_gfile_list (action->destinations, action->dest_dir);


### PR DESCRIPTION
Fix https://github.com/mate-desktop/caja/issues/1106
Remove data loss threat from https://github.com/mate-desktop/caja/issues/1353 by preventing silent deletion of files in all cases except where user has turned off  "Ask before emptying trash or deleting files"

Use the general case  `caja_file_operations_delete` when undo operations involve deleting a file in all cases, as this respects "Ask before emptying trash or deleting files". Remove the direct use of `g_file_delete` and now unused variable `priv->confirm_delete` which was not being properly read or set for some reason. This is also shorter, simpler code and in the (default) case of " Ask before emptying trash or deleting files" being turned on is the intended codepath anyway.

Note that if the user cancels deletion of a file/files/directory/directories the job is still removed from the undo stack, the next previous job will now be next item that can be undone if "undo" is invoked again.