### PR TITLE
Updating the link of caja

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -5,4 +5,4 @@ The Caja source tree is available from MATE git
 (https://github.com/mate-desktop/caja) and
 in releases on the MATE FTP site (https://pub.mate-desktop.org/).
 
-See also https://wiki.mate-desktop.org/applications:caja .
+See also https://wiki.mate-desktop.org/#!pages/applications-caja.md .


### PR DESCRIPTION
Updating the link of caja.
The old link generated a 404 error.