### PR TITLE
Fix -Wmissing-prototypes build warnings

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -3660,7 +3660,7 @@ caja_file_is_hidden_file (CajaFile *file)
 	return file->details->is_hidden;
 }
 
-gboolean
+static gboolean
 caja_file_is_backup_file (CajaFile *file)
 {
 	return file->details->is_backup;

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -119,7 +119,7 @@ struct _CajaApplicationPrivate {
 
 G_DEFINE_TYPE_WITH_PRIVATE (CajaApplication, caja_application, GTK_TYPE_APPLICATION);
 
-GList *
+static GList *
 caja_application_get_spatial_window_list (void)
 {
     return caja_application_spatial_window_list;
@@ -210,7 +210,7 @@ caja_application_smclient_initialize (CajaApplication *self)
     /* TODO: Should connect to quit_requested and block logout on active transfer? */
 }
 
-void
+static void
 caja_application_smclient_startup (CajaApplication *self)
 {
     g_assert (self->smclient == NULL);
@@ -726,7 +726,7 @@ caja_application_create_desktop_windows (CajaApplication *application)
     }
 }
 
-void
+static void
 caja_application_open_desktop (CajaApplication *application)
 {
     if (caja_application_desktop_windows == NULL)

--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -42,6 +42,8 @@
 
 /* Tell screen readers that this is a desktop window */
 
+static GType caja_desktop_window_accessible_get_type (void);
+
 G_DEFINE_TYPE (CajaDesktopWindowAccessible, caja_desktop_window_accessible,
                GTK_TYPE_WINDOW_ACCESSIBLE);
 

--- a/src/caja-query-editor.c
+++ b/src/caja-query-editor.c
@@ -485,7 +485,7 @@ tags_row_free_data (CajaQueryEditorRow *row)
 {
 }
 
-gchar *
+static gchar *
 xattr_tags_list_to_str (const GList *tags)
 {
     gchar *result = NULL;


### PR DESCRIPTION
Fixes the build warnings:

```
caja-file.c:3664:1: warning: no previous prototype for function 'caja_file_is_backup_file' [-Wmissing-prototypes]
caja-application.c:123:1: warning: no previous prototype for function 'caja_application_get_spatial_window_list' [-Wmissing-prototypes]
caja-application.c:214:1: warning: no previous prototype for function 'caja_application_smclient_startup' [-Wmissing-prototypes]
caja-application.c:730:1: warning: no previous prototype for function 'caja_application_open_desktop' [-Wmissing-prototypes]
caja-desktop-window.c:45:1: warning: no previous prototype for function 'caja_desktop_window_accessible_get_type' [-Wmissing-prototypes]
caja-query-editor.c:489:1: warning: no previous prototype for function 'xattr_tags_list_to_str' [-Wmissing-prototypes]
```