### PR TITLE
fm-properties: Don't show notebook arrows

### DIFF
--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -5196,7 +5196,6 @@ create_properties_window (StartupData *startup_data)
 	/* Create the notebook tabs. */
 	window->details->notebook = GTK_NOTEBOOK (gtk_notebook_new ());
 
-        gtk_notebook_set_scrollable (GTK_NOTEBOOK (window->details->notebook), TRUE);
         gtk_widget_add_events (GTK_WIDGET (window->details->notebook), GDK_SCROLL_MASK);
         g_signal_connect (window->details->notebook,
                           "scroll-event",


### PR DESCRIPTION
fixes https://github.com/mate-desktop/caja/issues/1412

Unwanted arrows won't be shown and notebook-tabs mouse-scrolling works like before.