### PR TITLE
[1.20] Reset move/copy time before beginning operation

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -4196,6 +4196,10 @@ copy_move_file (CopyMoveJob *copy_job,
 		goto out;
 	}
 
+	/* Timer was already running from g_timer_new()...
+	 * Restart now that we are actually moving or copying
+	 */
+	g_timer_start( job->time );
 
  retry:
 	error = NULL;


### PR DESCRIPTION
Tested on v1.20.3-13-g01b11be, can apply on latest as well but I'm unable to test.

Closes #1132 