### PR TITLE
Reset move/copy time before beginning operation

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -4237,6 +4237,10 @@ copy_move_file (CopyMoveJob *copy_job,
 		goto out;
 	}
 
+	/* Timer was already running from g_timer_new()...
+	 * Restart now that we are actually moving or copying
+	 */
+	g_timer_start (job->time);
 
  retry:
 	error = NULL;


### PR DESCRIPTION
Queued transfers start their timer upon being queued, which negatively
affects transfer-speed calculation by including the time spent *not
transfering*.

Closes #1132
(Mirror of #1415 for master, untested)