### PR TITLE
eel-editable-label: Consecutive break/return statements are unnecessary

### DIFF
--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -2792,7 +2792,6 @@ eel_editable_label_move_cursor (EelEditableLabel    *label,
         case GTK_MOVEMENT_DISPLAY_LINES:
             new_pos = eel_editable_label_move_line (label, new_pos, count);
             break;
-            break;
         case GTK_MOVEMENT_PARAGRAPHS:
         case GTK_MOVEMENT_PAGES:
             break;

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -3278,8 +3278,8 @@ rightmost_in_top_row (CajaIconContainer *container,
     {
         return TRUE;
     }
-    return compare_icons_vertical (container, best_so_far, candidate) > 0;
-    return compare_icons_horizontal (container, best_so_far, candidate) < 0;
+    return ((compare_icons_vertical (container, best_so_far, candidate) > 0) &&
+            (compare_icons_horizontal (container, best_so_far, candidate) < 0));
 }
 
 static gboolean


### PR DESCRIPTION
reported by cppcheck