### PR TITLE
Remove trailing spaces/tabs

### DIFF
--- a/libcaja-private/caja-undostack-manager.c
+++ b/libcaja-private/caja-undostack-manager.c
@@ -605,7 +605,7 @@ caja_undostack_manager_undo (CajaUndoStackManager * manager,
         caja_file_operations_delete (uris, NULL,
             undo_redo_done_delete_callback, action);
     	g_list_free_full (uris, g_object_unref);
- 
+
         break;
       case CAJA_UNDOSTACK_RESTOREFROMTRASH:
         uris = construct_gfile_list (action->destinations, action->dest_dir);

--- a/src/caja-navigation-window-menus.c
+++ b/src/caja-navigation-window-menus.c
@@ -608,7 +608,7 @@ action_new_window_callback (GtkAction *action,
 {
     CajaWindow *current_window;
 
-    current_window = CAJA_WINDOW (user_data);   
+    current_window = CAJA_WINDOW (user_data);
     caja_window_new_window (current_window);
 }
 

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -320,7 +320,7 @@ caja_window_new_window (CajaWindow *window)
     current_slot = window->details->active_pane->active_slot;
     location = caja_window_slot_get_location (current_slot);
 
-    if (location != NULL) 
+    if (location != NULL)
     {
         CajaWindow *new_window;
         CajaWindowSlot *new_slot;

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -3347,7 +3347,7 @@ create_basic_page (FMPropertiesWindow *window)
 	{
 		append_blank_row (grid);
 	}
-	
+
 	if (should_show_accessed_date (window))
 	{
 		append_title_value_pair (window, grid, _("Accessed:"),
@@ -3355,7 +3355,7 @@ create_basic_page (FMPropertiesWindow *window)
 					 INCONSISTENT_STATE_STRING,
 					 FALSE);
 	}
-	
+
 	if (should_show_modified_date (window))
 	{
 		append_title_value_pair (window, grid, _("Modified:"),


### PR DESCRIPTION
```
find . \( -name '*.h' -o -name '*.c' \) -exec sed -i 's/[[:space:]]*$//' {} \;
find . \( -name '*.h' -o -name '*.c' \) -exec sed -i 's/\t*$//' {} \;
```