### PR TITLE
fm-directory-view: Display an error message when a link could not be created

### DIFF
--- a/libcaja-private/caja-link.c
+++ b/libcaja-private/caja-link.c
@@ -197,7 +197,8 @@ caja_link_local_create (const char     *directory_uri,
                         const char     *target_uri,
                         const GdkPoint *point,
                         int             screen,
-                        gboolean        unique_filename)
+                        gboolean        unique_filename,
+                        GError        **error)
 {
     char *real_directory_uri;
     char *contents;
@@ -274,7 +275,7 @@ caja_link_local_create (const char     *directory_uri,
                                   contents, strlen (contents),
                                   NULL, FALSE,
                                   G_FILE_CREATE_NONE,
-                                  NULL, NULL, NULL))
+                                  NULL, NULL, error))
     {
         g_free (contents);
         g_object_unref (file);

--- a/libcaja-private/caja-link.h
+++ b/libcaja-private/caja-link.h
@@ -34,7 +34,8 @@ gboolean         caja_link_local_create                      (const char        
         const char        *target_uri,
         const GdkPoint    *point,
         int                screen,
-        gboolean           unique_filename);
+        gboolean           unique_filename,
+        GError           **error);
 gboolean         caja_link_local_set_text                    (const char        *uri,
         const char        *text);
 gboolean         caja_link_local_set_icon                    (const char        *uri,

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -10732,6 +10732,8 @@ fm_directory_view_handle_netscape_url_drop (FMDirectoryView  *view,
 			GdkScreen *screen;
 			int screen_num;
 			char *link_display_name;
+			GError *error = NULL;
+			gboolean success;
 
 			link_display_name = g_strdup_printf (_("Link to %s"), link_name);
 
@@ -10745,14 +10747,27 @@ fm_directory_view_handle_netscape_url_drop (FMDirectoryView  *view,
 			screen = gtk_widget_get_screen (GTK_WIDGET (view));
 			screen_num = gdk_x11_screen_get_screen_number (screen);
 
-			caja_link_local_create (target_uri != NULL ? target_uri : container_uri,
-						    link_name,
-						    link_display_name,
-						    "mate-fs-bookmark",
-						    url,
-						    &point,
-						    screen_num,
-						    TRUE);
+			success = caja_link_local_create (target_uri != NULL ? target_uri : container_uri,
+			                                  link_name,
+			                                  link_display_name,
+			                                  "mate-fs-bookmark",
+			                                  url,
+			                                  &point,
+			                                  screen_num,
+			                                  TRUE,
+			                                  &error);
+			if (!success) {
+				if (error) {
+					eel_show_error_dialog (_("Link Creation Failed"),
+					                       error->message, NULL);
+					g_error_free (error);
+				} else {
+					gchar *error_message = g_strdup_printf (_("Cannot create the link to %s"), url);
+					eel_show_error_dialog (_("Link Creation Failed"),
+					                       error_message, NULL);
+					g_free (error_message);
+				}
+			}
 
 			g_free (link_display_name);
 		}


### PR DESCRIPTION
closes #1446

test:
- create the file test.html
```
$ cat <<EOF > test.html
<!DOCTYPE html>
<html>
<head>
  <title>Remarks on the Quantum-Gravity effects of "Bean Pole" diversification in Mononucleosis patients in Developing Countries under Economic Conditions Prevalent during the Second half of the Twentieth Century, and Related Papers: a Summary - Remarks on the Quantum-Gravity effects of "Bean Pole" diversification in Mononucleosis patients in Developing Countries under Economic Conditions Prevalent during the Second half of the Twentieth Century, and Related Papers: a Summary</title>
</head>
<body>
</body>
</html>
EOF
```
- open test.html using FF
```
$ firefox test.html 
```
- drag-n-drop the document icon from FF location bar to desktop

![Screenshot at 2020-08-31 13-03-02](https://user-images.githubusercontent.com/10171411/91713612-61614400-eb8a-11ea-919a-cdf8286ea9a5.png)
