### PR TITLE
Duplicate tabs using the scroll wheel

### DIFF
--- a/src/caja-window-manage-views.c
+++ b/src/caja-window-manage-views.c
@@ -2394,11 +2394,3 @@ caja_window_slot_reload (CajaWindowSlot *slot)
     g_list_free_full (selection, g_object_unref);
 }
 
-void
-caja_window_reload (CajaWindow *window)
-{
-    g_assert (CAJA_IS_WINDOW (window));
-
-    caja_window_slot_reload (window->details->active_pane->active_slot);
-}
-

--- a/src/caja-window-menus.c
+++ b/src/caja-window-menus.c
@@ -366,7 +366,7 @@ static void
 action_reload_callback (GtkAction *action,
                         gpointer user_data)
 {
-    caja_window_reload (CAJA_WINDOW (user_data));
+    caja_window_reload (CAJA_WINDOW (user_data), should_open_in_new_tab ());
 }
 
 static void

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -272,11 +272,10 @@ caja_window_go_up_signal (CajaWindow *window, gboolean close_behind)
     return TRUE;
 }
 
-static gboolean
+static void
 caja_window_reload_signal (CajaWindow *window)
 {
     caja_window_reload (window, FALSE);
-    return TRUE;
 }
 
 void
@@ -487,7 +486,6 @@ void
 caja_window_reload (CajaWindow *window, gboolean new_tab)
 {
     CajaWindowSlot *slot;
-    GList *selection;
 
     g_assert (CAJA_IS_WINDOW (window));
 
@@ -502,7 +500,7 @@ caja_window_reload (CajaWindow *window, gboolean new_tab)
     }
     else
     {
-        caja_window_slot_reload (window->details->active_pane->active_slot);
+        caja_window_slot_reload (slot);
     }
 }
 

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -272,6 +272,13 @@ caja_window_go_up_signal (CajaWindow *window, gboolean close_behind)
     return TRUE;
 }
 
+static gboolean
+caja_window_reload_signal (CajaWindow *window)
+{
+    caja_window_reload (window, FALSE);
+    return TRUE;
+}
+
 void
 caja_window_new_tab (CajaWindow *window)
 {
@@ -473,6 +480,29 @@ caja_window_sync_allow_stop (CajaWindow *window,
 
         EEL_CALL_METHOD (CAJA_WINDOW_CLASS, window,
                          sync_allow_stop, (window, slot));
+    }
+}
+
+void
+caja_window_reload (CajaWindow *window, gboolean new_tab)
+{
+    CajaWindowSlot *slot;
+    GList *selection;
+
+    g_assert (CAJA_IS_WINDOW (window));
+
+    slot = window->details->active_pane->active_slot;
+
+    if (new_tab && slot->location != NULL)
+    {
+        caja_window_slot_open_location_full (slot, slot->location,
+                                             CAJA_WINDOW_OPEN_ACCORDING_TO_MODE,
+                                             CAJA_WINDOW_OPEN_FLAG_NEW_TAB,
+                                             NULL, NULL, NULL);
+    }
+    else
+    {
+        caja_window_slot_reload (window->details->active_pane->active_slot);
     }
 }
 
@@ -2220,6 +2250,6 @@ caja_window_class_init (CajaWindowClass *class)
                                   "prompt-for-location", 1,
                                   G_TYPE_STRING, "/");
 
-    class->reload = caja_window_reload;
+    class->reload = caja_window_reload_signal;
     class->go_up = caja_window_go_up_signal;
 }

--- a/src/caja-window.h
+++ b/src/caja-window.h
@@ -156,8 +156,8 @@ void             caja_window_prompt_for_location  (CajaWindow    *window,
         const char        *initial);
 void             caja_window_display_error        (CajaWindow    *window,
         const char        *error_msg);
-void		 caja_window_reload		      (CajaWindow	 *window);
-
+void             caja_window_reload               (CajaWindow    *window,
+        gboolean           new_tab);
 void             caja_window_allow_reload         (CajaWindow    *window,
         gboolean           allow);
 void             caja_window_allow_up             (CajaWindow    *window,


### PR DESCRIPTION
This has been a minor annoyance of mine, along with the notebook tab scroll removed from GTK3, because why make stuff convenient for the end user... Now we can have both!