### PR TITLE
Remove the use of the gettimeofday function

### DIFF
--- a/test/test-eel-pixbuf-scale.c
+++ b/test/test-eel-pixbuf-scale.c
@@ -1,5 +1,3 @@
-#include <sys/time.h>
-
 #include <eel/eel-gdk-pixbuf-extensions.h>
 
 #include "test.h"
@@ -14,7 +12,7 @@ main (int argc, char* argv[])
 {
 	GdkPixbuf *pixbuf, *scaled;
 	GError *error;
-	struct timeval t1, t2;
+	gint64 t1, t2;
 	int i;
 
 	test_init (&argc, &argv);
@@ -36,35 +34,35 @@ main (int argc, char* argv[])
 		(double)gdk_pixbuf_get_width(pixbuf)/DEST_WIDTH,
 		(double)gdk_pixbuf_get_height(pixbuf)/DEST_HEIGHT);
 
-	gettimeofday(&t1, NULL);
+	t1 = g_get_monotonic_time ();
 	for (i = 0; i < N_SCALES; i++) {
 		scaled = eel_gdk_pixbuf_scale_down (pixbuf, DEST_WIDTH, DEST_HEIGHT);
 		g_object_unref (scaled);
 	}
-	gettimeofday(&t2, NULL);
-	g_print ("Time for eel_gdk_pixbuf_scale_down: %ld msecs\n",
-		 (t2.tv_sec - t1.tv_sec) * 1000 + (t2.tv_usec - t1.tv_usec) / 1000);
+	t2 = g_get_monotonic_time ();
+	g_print ("Time for eel_gdk_pixbuf_scale_down: %" G_GINT64_FORMAT " msecs\n",
+		 (t2 - t1) / G_TIME_SPAN_MILLISECOND);
 
 
 
-	gettimeofday(&t1, NULL);
+	t1 = g_get_monotonic_time ();
 	for (i = 0; i < N_SCALES; i++) {
 		scaled = gdk_pixbuf_scale_simple (pixbuf, DEST_WIDTH, DEST_HEIGHT, GDK_INTERP_NEAREST);
 		g_object_unref (scaled);
 	}
-	gettimeofday(&t2, NULL);
-	g_print ("Time for INTERP_NEAREST: %ld msecs\n",
-		 (t2.tv_sec - t1.tv_sec) * 1000 + (t2.tv_usec - t1.tv_usec) / 1000);
+	t2 = g_get_monotonic_time ();
+	g_print ("Time for INTERP_NEAREST: %" G_GINT64_FORMAT " msecs\n",
+		 (t2 - t1) / G_TIME_SPAN_MILLISECOND);
 
 
-	gettimeofday(&t1, NULL);
+	t1 = g_get_monotonic_time ();
 	for (i = 0; i < N_SCALES; i++) {
 		scaled = gdk_pixbuf_scale_simple (pixbuf, DEST_WIDTH, DEST_HEIGHT, GDK_INTERP_BILINEAR);
 		g_object_unref (scaled);
 	}
-	gettimeofday(&t2, NULL);
-	g_print ("Time for INTERP_BILINEAR: %ld msecs\n",
-		 (t2.tv_sec - t1.tv_sec) * 1000 + (t2.tv_usec - t1.tv_usec) / 1000);
+	t2 = g_get_monotonic_time ();
+	g_print ("Time for INTERP_BILINEAR: %" G_GINT64_FORMAT " msecs\n",
+		 (t2 - t1) / G_TIME_SPAN_MILLISECOND);
 
 	scaled = eel_gdk_pixbuf_scale_down (pixbuf, DEST_WIDTH, DEST_HEIGHT);
 	gdk_pixbuf_save (scaled, "eel_scaled.png", "png", NULL, NULL);

--- a/test/test-eel-pixbuf-scale.c
+++ b/test/test-eel-pixbuf-scale.c
@@ -2,8 +2,6 @@
 
 #include "test.h"
 
-#define N_SCALES 100
-
 #define DEST_WIDTH 32
 #define DEST_HEIGHT 32
 
@@ -13,7 +11,6 @@ main (int argc, char* argv[])
 	GdkPixbuf *pixbuf, *scaled;
 	GError *error;
 	gint64 t1, t2;
-	int i;
 
 	test_init (&argc, &argv);
 
@@ -35,34 +32,22 @@ main (int argc, char* argv[])
 		(double)gdk_pixbuf_get_height(pixbuf)/DEST_HEIGHT);
 
 	t1 = g_get_monotonic_time ();
-	for (i = 0; i < N_SCALES; i++) {
-		scaled = eel_gdk_pixbuf_scale_down (pixbuf, DEST_WIDTH, DEST_HEIGHT);
-		g_object_unref (scaled);
-	}
+	scaled = eel_gdk_pixbuf_scale_down (pixbuf, DEST_WIDTH, DEST_HEIGHT);
 	t2 = g_get_monotonic_time ();
-	g_print ("Time for eel_gdk_pixbuf_scale_down: %" G_GINT64_FORMAT " msecs\n",
-		 (t2 - t1) / G_TIME_SPAN_MILLISECOND);
-
-
+	g_object_unref (scaled);
+	g_print ("Time for eel_gdk_pixbuf_scale_down: %" G_GINT64_FORMAT " usecs\n",  t2 - t1);
 
 	t1 = g_get_monotonic_time ();
-	for (i = 0; i < N_SCALES; i++) {
-		scaled = gdk_pixbuf_scale_simple (pixbuf, DEST_WIDTH, DEST_HEIGHT, GDK_INTERP_NEAREST);
-		g_object_unref (scaled);
-	}
+	scaled = gdk_pixbuf_scale_simple (pixbuf, DEST_WIDTH, DEST_HEIGHT, GDK_INTERP_NEAREST);
 	t2 = g_get_monotonic_time ();
-	g_print ("Time for INTERP_NEAREST: %" G_GINT64_FORMAT " msecs\n",
-		 (t2 - t1) / G_TIME_SPAN_MILLISECOND);
-
+	g_object_unref (scaled);
+	g_print ("Time for INTERP_NEAREST: %" G_GINT64_FORMAT " usecs\n", t2 - t1);
 
 	t1 = g_get_monotonic_time ();
-	for (i = 0; i < N_SCALES; i++) {
-		scaled = gdk_pixbuf_scale_simple (pixbuf, DEST_WIDTH, DEST_HEIGHT, GDK_INTERP_BILINEAR);
-		g_object_unref (scaled);
-	}
+	scaled = gdk_pixbuf_scale_simple (pixbuf, DEST_WIDTH, DEST_HEIGHT, GDK_INTERP_BILINEAR);
 	t2 = g_get_monotonic_time ();
-	g_print ("Time for INTERP_BILINEAR: %" G_GINT64_FORMAT " msecs\n",
-		 (t2 - t1) / G_TIME_SPAN_MILLISECOND);
+	g_object_unref (scaled);
+	g_print ("Time for INTERP_BILINEAR: %" G_GINT64_FORMAT " usecs\n", t2 - t1);
 
 	scaled = eel_gdk_pixbuf_scale_down (pixbuf, DEST_WIDTH, DEST_HEIGHT);
 	gdk_pixbuf_save (scaled, "eel_scaled.png", "png", NULL, NULL);


### PR DESCRIPTION
Test 1 : see ~/caja-debug-log.txt
```
#!/bin/bash
cat << EOF > ~/caja-debug-log.conf
[debug log]
max lines = 1000
enable domains = async;GLog
EOF

# To write the debug log to disk immediately, send a SIGUSR1 to Caja:
# kill -s SIGUSR1 $(pgrep caja)

# To see Caja log:
# cat ~/caja-debug-log.txt
```
Test 2 : call ./test/test-eel-pixbuf-scale FILENAME
```
./test/test-eel-pixbuf-scale /usr/share/pixmaps/fedora-logo.png
```