### PR TITLE
file-operations: don't attempt to move into the source dir

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -5882,6 +5882,7 @@ caja_file_operations_copy_move (const GList *item_uris,
 {
 	GList *locations;
 	GList *p;
+	GFile *src_dir;
 	GFile *dest;
 	GtkWindow *parent_window;
 	gboolean target_is_mapping;
@@ -5918,10 +5919,9 @@ caja_file_operations_copy_move (const GList *item_uris,
 		parent_window = (GtkWindow *)gtk_widget_get_ancestor (parent_view, GTK_TYPE_WINDOW);
 	}
 
-	if (copy_action == GDK_ACTION_COPY) {
-		GFile *src_dir;
+	src_dir = g_file_get_parent (locations->data);
 
-		src_dir = g_file_get_parent (locations->data);
+	if (copy_action == GDK_ACTION_COPY) {
 		if (target_dir == NULL ||
 		    (src_dir != NULL &&
 		     g_file_equal (src_dir, dest))) {
@@ -5936,10 +5936,6 @@ caja_file_operations_copy_move (const GList *item_uris,
 						       parent_window,
 						       done_callback, done_callback_data);
 		}
-		if (src_dir) {
-			g_object_unref (src_dir);
-		}
-
 	} else if (copy_action == GDK_ACTION_MOVE) {
 		if (g_file_has_uri_scheme (dest, "trash")) {
 			MoveTrashCBData *cb_data;
@@ -5951,7 +5947,7 @@ caja_file_operations_copy_move (const GList *item_uris,
 								  parent_window,
 								  (CajaDeleteCallback) callback_for_move_to_trash,
 								  cb_data);
-		} else {
+		} else if (src_dir == NULL || !g_file_equal (src_dir, dest)) {
 			caja_file_operations_move (locations,
 						       relative_item_points,
 						       dest,
@@ -5969,6 +5965,10 @@ caja_file_operations_copy_move (const GList *item_uris,
     	g_list_free_full (locations, g_object_unref);
 	if (dest) {
 		g_object_unref (dest);
+	}
+
+	if (src_dir) {
+		g_object_unref (src_dir);
 	}
 }
 


### PR DESCRIPTION
Dragging a file in caja onto the same active tab in tab bar shows a conflict resolution dialog. This is annoying, sometimes I start dragging an item, only to realize that it doesn't need to be moved, so I drop it onto the tab, subconsciously thinking it's the safest place to do so. 