### PR TITLE
Remove warning -Wtype-limits

### DIFF
--- a/libcaja-private/caja-icon-info.h
+++ b/libcaja-private/caja-icon-info.h
@@ -13,7 +13,7 @@ extern "C" {
 
     /* Names for Caja's different zoom levels, from tiniest items to largest items */
     typedef enum {
-        CAJA_ZOOM_LEVEL_SMALLEST,
+        CAJA_ZOOM_LEVEL_SMALLEST = 0,
         CAJA_ZOOM_LEVEL_SMALLER,
         CAJA_ZOOM_LEVEL_SMALL,
         CAJA_ZOOM_LEVEL_STANDARD,

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -1229,7 +1229,7 @@ get_default_zoom_level (FMIconView *icon_view)
                                       (int *) &default_compact_zoom_level);
     }
 
-    return CLAMP (DEFAULT_ZOOM_LEVEL(icon_view), CAJA_ZOOM_LEVEL_SMALLEST, CAJA_ZOOM_LEVEL_LARGEST);
+    return MIN (DEFAULT_ZOOM_LEVEL(icon_view), CAJA_ZOOM_LEVEL_LARGEST);
 }
 
 static void


### PR DESCRIPTION
```
caja.make.log:/usr/include/glib-2.0/glib/gmacros.h:813:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
caja.make.log-  813 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
caja.make.log-      |                                                               ^
```