### PR TITLE
build: Use PACKAGE_URL variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,11 @@ dnl Interface break is not allowed.
 m4_define(caja_extension_current,  5)
 m4_define(caja_extension_revision, 0)
 
-AC_INIT([caja], [1.25.2], [https://mate-desktop.org])
+AC_INIT([caja],
+        [1.25.2],
+        [https://github.com/mate-desktop/caja/issues],
+        [caja],
+        [https://mate-desktop.org])
 
 dnl ---------------------------------------------------------------------------
 
@@ -273,6 +277,7 @@ Makefile
 mate-submodules/Makefile
 mate-submodules/libegg/Makefile
 data/Makefile
+data/caja.appdata.xml.in
 data/icons/Makefile
 data/patterns/Makefile
 docs/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -53,13 +53,14 @@ cajadata_DATA = \
 
 # app data file
 appdatadir = $(datadir)/metainfo
-appdata_in_files = caja.appdata.xml.in
+appdata_in_in_files = caja.appdata.xml.in.in
+appdata_in_files = $(appdata_in_in_files:.appdata.xml.in.in=.appdata.xml.in)
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 $(appdata_DATA): $(appdata_in_files)
 	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
 EXTRA_DIST = \
-	$(appdata_in_files) \
+	$(appdata_in_in_files) \
 	$(cajadata_DATA) \
 	$(cajadata_in_files) \
 	$(desktop_in_in_files) \
@@ -69,6 +70,7 @@ EXTRA_DIST = \
 	$(NULL)
 
 DISTCLEANFILES = \
+	$(appdata_in_files) \
 	$(desktop_in_files) \
 	$(NULL)
 

--- a/data/caja.appdata.xml.in.in
+++ b/data/caja.appdata.xml.in.in
@@ -35,7 +35,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">https://mate-desktop.org</url>
+ <url type="homepage">@PACKAGE_URL@</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,7 +1,7 @@
 # List of source files containing translatable strings.
 # Please keep this file sorted alphabetically.
 data/browser.xml.in
-data/caja.appdata.xml.in
+data/caja.appdata.xml.in.in
 data/caja-autorun-software.desktop.in.in
 data/caja-browser.desktop.in.in
 data/caja-computer.desktop.in.in

--- a/src/caja-window-menus.c
+++ b/src/caja-window-menus.c
@@ -585,7 +585,7 @@ action_about_caja_callback (GtkAction *action,
                            "documenters", documenters,
                            "translator-credits", _("translator-credits"),
                            "logo-icon-name", "system-file-manager",
-                           "website", "https://mate-desktop.org",
+                           "website", PACKAGE_URL,
                            "website-label", _("Website"),
                            NULL);
 


### PR DESCRIPTION
Test:
```
$ grep PACKAGE_URL config.h
#define PACKAGE_URL "https://mate-desktop.org"
$ grep homepage data/caja.appdata.xml
  <url type="homepage">https://mate-desktop.org</url>
```

- Set all [AC_INIT](https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Initializing-configure.html) fields including optional ones (configure.ac):
```
Macro: AC_INIT (package, version, [bug-report], [tarname], [url])
```
