### PR TITLE
build: underline package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -296,7 +296,10 @@ AC_OUTPUT
 dnl ==========================================================================
 
 echo "
-caja-$VERSION:
+Configure summary:
+
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
 
     prefix:                       ${prefix}
     source code location:         ${srcdir}


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr
<cut>
Configure summary:

    caja 1.25.1
    ===========

    prefix:                       /usr
    source code location:         .
    compiler:                     gcc
    compiler flags:               -g -O2
    warning flags:                -Wall -Wmissing-prototypes
    xmp support:                  yes
    PackageKit support:           yes
    Self check:                   yes

    caja-extension documentation: no
    caja-extension introspection: yes

Now type `make' to compile caja
```