### PR TITLE
Fix desktop file validation warning

### DIFF
--- a/data/caja-browser.desktop.in.in
+++ b/data/caja-browser.desktop.in.in
@@ -9,7 +9,7 @@ Icon=system-file-manager
 Terminal=false
 StartupNotify=false
 Type=Application
-Categories=GTK;System;Utility;Core;
+Categories=GTK;System;Core;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=files;browser;manager;MATE;
 OnlyShowIn=MATE;


### PR DESCRIPTION
```
$ find -type f -name *.desktop -exec desktop-file-validate {} \;
./data/caja-browser.desktop: hint: value "GTK;System;Utility;Core;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
```
https://specifications.freedesktop.org/menu-spec/latest/apa.html