### PR TITLE
cppcheck warning: Local variable 'combo_box' shadows outer argument

### DIFF
--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -357,25 +357,18 @@ icon_captions_changed_callback (GtkComboBox *combo_box,
     int i;
 
     builder = GTK_BUILDER (user_data);
-
     captions = g_ptr_array_new ();
 
     for (i = 0; icon_captions_components[i] != NULL; i++)
     {
-        GtkWidget *combo_box;
-        int active;
+        GObject *object;
         GPtrArray *column_names;
-        char *name;
+        int active;
 
-        combo_box = GTK_WIDGET (gtk_builder_get_object
-                                (builder, icon_captions_components[i]));
-        active = gtk_combo_box_get_active (GTK_COMBO_BOX (combo_box));
-
-        column_names = g_object_get_data (G_OBJECT (combo_box),
-                                          "column_names");
-
-        name = g_ptr_array_index (column_names, active);
-        g_ptr_array_add (captions, name);
+        object = gtk_builder_get_object (builder, icon_captions_components[i]);
+        column_names = g_object_get_data (object, "column_names");
+        active = gtk_combo_box_get_active (GTK_COMBO_BOX(object));
+        g_ptr_array_add (captions, g_ptr_array_index (column_names, active));
     }
     g_ptr_array_add (captions, NULL);
 


### PR DESCRIPTION
Test: Change the icon captions to show using the combo boxes and read the gsettings value from the command line:
```
$ gsettings get org.mate.caja.icon-view captions
['type', 'size', 'date_modified']
```
<img width="1346" alt="Captura de Pantalla 2021-02-06 a les 12 49 09" src="https://user-images.githubusercontent.com/10171411/107117881-a007d280-687d-11eb-9a24-02642b8bc321.png">

Test:

```
$ cppcheck --enable=all --quiet . &> cppcheck.log && grep shadowArgument cppcheck.log
src/caja-file-management-properties.c:365:20: style: Local variable 'combo_box' shadows outer argument [shadowArgument]
```