### PR TITLE
Fix unknown filesystem on home icon dnd

### DIFF
--- a/libcaja-private/caja-file-utilities.c
+++ b/libcaja-private/caja-file-utilities.c
@@ -1299,6 +1299,42 @@ caja_restore_files_from_trash (GList *files,
     caja_file_list_unref (unhandled_files);
 }
 
+char *
+caja_get_filesystem_id_by_location (GFile *location, gboolean follow)
+{
+    GFileInfo *info;
+    GFileQueryInfoFlags flags;
+    char *filesystem_id = NULL;
+
+    if (follow) {
+        flags = G_FILE_QUERY_INFO_NONE;
+    } else {
+        flags = G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS;
+    }
+
+    info = g_file_query_info (location, G_FILE_ATTRIBUTE_ID_FILESYSTEM, flags, NULL, NULL);
+    if (info) {
+        if (g_file_info_has_attribute (info, G_FILE_ATTRIBUTE_ID_FILESYSTEM)) {
+            filesystem_id = g_strdup (
+                g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_ID_FILESYSTEM));
+        }
+        g_object_unref (info);
+    }
+    return filesystem_id;
+}
+
+char *
+caja_get_filesystem_id_by_uri (const char *uri, gboolean follow)
+{
+    GFile *location;
+    char *filesystem_id;
+
+    location = g_file_new_for_uri (uri);
+    filesystem_id = caja_get_filesystem_id_by_location (location, follow);
+    g_object_unref (location);
+    return filesystem_id;
+}
+
 #if !defined (CAJA_OMIT_SELF_CHECK)
 
 void

--- a/libcaja-private/caja-file-utilities.h
+++ b/libcaja-private/caja-file-utilities.h
@@ -94,5 +94,7 @@ GHashTable * caja_trashed_files_get_original_directories (GList *files,
         GList **unhandled_files);
 void caja_restore_files_from_trash (GList *files,
                                     GtkWindow *parent_window);
+char * caja_get_filesystem_id_by_location (GFile *location, gboolean follow);
+char * caja_get_filesystem_id_by_uri (const char *uri, gboolean follow);
 
 #endif /* CAJA_FILE_UTILITIES_H */


### PR DESCRIPTION
When files are dropped on the user home icon, it's file system data can be unavailable. This happens if the home folder has not been browsed before. Therefore, caja copies the files to the home folder even if home and desktop share the same file system.

On caja-dnd.c:458, the function caja_file_get_existing_by_uri returns a null target_file, causing check_same_fs to get a wrong result. The function with caja_file_get_by_uri returns a CajaFile, but with no filesystem_id. 