### PR TITLE
warning: missing initializer for a field of ‘GtkActionEntry’

### DIFF
--- a/src/caja-navigation-window-menus.c
+++ b/src/caja-navigation-window-menus.c
@@ -824,9 +824,15 @@ action_tab_change_action_activate_callback (GtkAction *action, gpointer user_dat
 
 static const GtkActionEntry navigation_entries[] =
 {
-    /* name, icon name, label */ { "Go", NULL, N_("_Go") },
-    /* name, icon name, label */ { "Bookmarks", NULL, N_("_Bookmarks") },
-    /* name, icon name, label */ { "Tabs", NULL, N_("_Tabs") },
+    /* name, icon name, label */ { "Go", NULL, N_("_Go"),
+        NULL, NULL, NULL
+    },
+    /* name, icon name, label */ { "Bookmarks", NULL, N_("_Bookmarks"),
+        NULL, NULL, NULL
+    },
+    /* name, icon name, label */ { "Tabs", NULL, N_("_Tabs"),
+        NULL, NULL, NULL
+    },
     /* name, icon name, label */ { "New Window", "window-new", N_("New _Window"),
         "<control>N", N_("Open another Caja window for the displayed location"),
         G_CALLBACK (action_new_window_callback)

--- a/src/caja-spatial-window.c
+++ b/src/caja-spatial-window.c
@@ -921,7 +921,9 @@ action_search_callback (GtkAction *action,
 
 static const GtkActionEntry spatial_entries[] =
 {
-    /* name, icon name, label */ { SPATIAL_ACTION_PLACES, NULL, N_("_Places") },
+    /* name, icon name, label */ { SPATIAL_ACTION_PLACES, NULL, N_("_Places"),
+        NULL, NULL, NULL
+    },
     /* name, icon name, label */ {
         SPATIAL_ACTION_GO_TO_LOCATION, NULL, N_("Open _Location..."),
         "<control>L", N_("Specify a location to open"),

--- a/src/caja-window-menus.c
+++ b/src/caja-window-menus.c
@@ -846,10 +846,14 @@ caja_window_initialize_trash_icon_monitor (CajaWindow *window)
 
 static const GtkActionEntry main_entries[] =
 {
-    /* name, icon name, label */ { "File", NULL, N_("_File") },
-    /* name, icon name, label */ { "Edit", NULL, N_("_Edit") },
-    /* name, icon name, label */ { "View", NULL, N_("_View") },
-    /* name, icon name, label */ { "Help", NULL, N_("_Help") },
+    /* name, icon name, label */ { "File", NULL, N_("_File"),
+                                   NULL, NULL, NULL },
+    /* name, icon name, label */ { "Edit", NULL, N_("_Edit"),
+                                   NULL, NULL, NULL },
+    /* name, icon name, label */ { "View", NULL, N_("_View"),
+                                   NULL, NULL, NULL },
+    /* name, icon name, label */ { "Help", NULL, N_("_Help"),
+                                   NULL, NULL, NULL },
     /* name, icon name */        { "Close", "window-close",
         /* label, accelerator */       N_("_Close"), "<control>W",
         /* tooltip */                  N_("Close this folder"),

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -7386,9 +7386,10 @@ fm_directory_view_init_show_backup_files (FMDirectoryView *view)
 }
 
 static const GtkActionEntry directory_view_entries[] = {
-  /* name, icon name, label */ { "New Documents", "document-new", N_("Create _Document") },
+  /* name, icon name, label */ { "New Documents", "document-new", N_("Create _Document"),
+                                 NULL, NULL, NULL },
   /* name, icon name, label */ { "Open With", NULL, N_("Open Wit_h"),
-                                 NULL, N_("Choose a program with which to open the selected item") },
+                                 NULL, N_("Choose a program with which to open the selected item"), NULL },
   /* name, icon name */        { "Properties", "document-properties",
   /* label, accelerator */       N_("_Properties"), "<alt>Return",
   /* tooltip */                  N_("View or modify the properties of each selected item"),
@@ -7401,7 +7402,7 @@ static const GtkActionEntry directory_view_entries[] = {
   /* label, accelerator */       N_("Create _Folder"), "<control><shift>N",
   /* tooltip */                  N_("Create a new empty folder inside this folder"),
                                  G_CALLBACK (action_new_folder_callback) },
-  /* name, icon name, label */ { "No Templates", NULL, N_("No templates installed") },
+  /* name, icon name, label */ { "No Templates", NULL, N_("No templates installed"), NULL, NULL, NULL },
   /* name, icon name */        { "New Empty File", NULL,
   /* Translators: this is used to indicate that a file doesn't contain anything */
   /* label, accelerator */       N_("_Empty File"), NULL,
@@ -7465,8 +7466,10 @@ static const GtkActionEntry directory_view_entries[] = {
   /* label, accelerator */       N_("_Paste Into Folder"), "",
   /* tooltip */                  N_("Move or copy files previously selected by a Cut or Copy command into the selected folder"),
                                  G_CALLBACK (action_paste_files_into_callback) },
-  /* name, icon name, label */ { "CopyToMenu", NULL, N_("Cop_y to") },
-  /* name, icon name, label */ { "MoveToMenu", NULL, N_("M_ove to") },
+  /* name, icon name, label */ { "CopyToMenu", NULL, N_("Cop_y to"),
+                                 NULL, NULL, NULL },
+  /* name, icon name, label */ { "MoveToMenu", NULL, N_("M_ove to"),
+                                 NULL, NULL, NULL },
   /* name, icon name */        { "Select All", NULL,
   /* label, accelerator */       N_("Select _All"), "<control>A",
   /* tooltip */                  N_("Select all items in this window"),
@@ -7507,14 +7510,14 @@ static const GtkActionEntry directory_view_entries[] = {
   /* label, accelerator */       N_("_Restore"), NULL,
 				 NULL,
                                  G_CALLBACK (action_restore_from_trash_callback) },
-  /* name, icon name */		  { FM_ACTION_UNDO, "edit-undo",
-  /* label, accelerator */		 N_("_Undo"), "<control>Z",
-  /* tooltip */ 				 	 N_("Undo the last action"),
-								 G_CALLBACK (action_undo_callback) },
-  /* name, icon name */		  { FM_ACTION_REDO, "edit-redo",
-  /* label, accelerator */	     N_("_Redo"), "<control>Y",
-  /* tooltip */     			 	 N_("Redo the last undone action"),
-								 G_CALLBACK (action_redo_callback) },
+  /* name, icon name */        { FM_ACTION_UNDO, "edit-undo",
+  /* label, accelerator */       N_("_Undo"), "<control>Z",
+  /* tooltip */                  N_("Undo the last action"),
+                                 G_CALLBACK (action_undo_callback) },
+  /* name, icon name */        { FM_ACTION_REDO, "edit-redo",
+  /* label, accelerator */       N_("_Redo"), "<control>Y",
+  /* tooltip */                  N_("Redo the last undone action"),
+                                 G_CALLBACK (action_redo_callback) },
 
   /*
    * multiview-TODO: decide whether "Reset to Defaults" should

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -1706,22 +1706,20 @@ fm_icon_view_start_renaming_file (FMDirectoryView *view,
 
 static const GtkActionEntry icon_view_entries[] =
 {
-    /* name, stock id, label */  { "Arrange Items", NULL, N_("Arran_ge Items") },
+    /* name, stock id, label */  { "Arrange Items", NULL, N_("Arran_ge Items"),
+                                   NULL, NULL, NULL },
     /* name, stock id */         { "Stretch", NULL,
-        /* label, accelerator */       N_("Resize Icon..."), NULL,
-        /* tooltip */                  N_("Make the selected icon resizable"),
-        G_CALLBACK (action_stretch_callback)
-    },
+    /* label, accelerator */       N_("Resize Icon..."), NULL,
+    /* tooltip */                  N_("Make the selected icon resizable"),
+                                   G_CALLBACK (action_stretch_callback) },
     /* name, stock id */         { "Unstretch", NULL,
-        /* label, accelerator */       N_("Restore Icons' Original Si_zes"), NULL,
-        /* tooltip */                  N_("Restore each selected icon to its original size"),
-        G_CALLBACK (action_unstretch_callback)
-    },
+    /* label, accelerator */       N_("Restore Icons' Original Si_zes"), NULL,
+    /* tooltip */                  N_("Restore each selected icon to its original size"),
+                                   G_CALLBACK (action_unstretch_callback) },
     /* name, stock id */         { "Clean Up", NULL,
-        /* label, accelerator */       N_("_Organize by Name"), NULL,
-        /* tooltip */                  N_("Reposition icons to better fit in the window and avoid overlapping"),
-        G_CALLBACK (action_clean_up_callback)
-    },
+    /* label, accelerator */       N_("_Organize by Name"), NULL,
+    /* tooltip */                  N_("Reposition icons to better fit in the window and avoid overlapping"),
+                                   G_CALLBACK (action_clean_up_callback) },
 };
 
 static const GtkToggleActionEntry icon_view_toggle_entries[] =


### PR DESCRIPTION
```
fm-directory-view.c:7389:32: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
fm-directory-view.c:7391:34: warning: missing initializer for field ‘callback’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
fm-directory-view.c:7404:32: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
fm-directory-view.c:7468:32: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
fm-directory-view.c:7469:32: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
fm-icon-view.c:1709:34: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
caja-navigation-window-menus.c:827:34: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
caja-navigation-window-menus.c:828:34: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
caja-navigation-window-menus.c:829:34: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
caja-window-menus.c:849:34: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
caja-window-menus.c:850:34: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
caja-window-menus.c:851:34: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
caja-window-menus.c:852:34: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
caja-spatial-window.c:924:34: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘const struct _GtkActionEntry’} [-Wmissing-field-initializers]
```