### PR TITLE
No longer need to check the locale.h header as it's part of C90

### DIFF
--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -30,9 +30,7 @@
 #include <config.h>
 #include <dlfcn.h>
 #include <signal.h>
-#ifdef HAVE_LOCALE_H
 #include <locale.h>
-#endif
 #ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif


### PR DESCRIPTION
```
# There is no longer any need to check for headers that are part of
# ISO C90 (as amended): assert.h, ctype.h, errno.h, float.h, iso646.h,
# limits.h, locale.h, math.h, setjmp.h, signal.h, stdarg.h, stddef.h,
# stdio.h, stdlib.h, string.h, time.h, wchar.h, wctype.h.
```
https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4#n358