### PR TITLE
caja-bookmarks-window.ui: expand child widgets, sane default size

### DIFF
--- a/src/caja-bookmarks-window.ui
+++ b/src/caja-bookmarks-window.ui
@@ -28,6 +28,8 @@
     <property name="border-width">5</property>
     <property name="title" translatable="yes">Edit Bookmarks</property>
     <property name="window-position">center</property>
+    <property name="default-width">500</property>
+    <property name="default-height">300</property>
     <property name="type-hint">normal</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
@@ -129,12 +131,14 @@
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">&lt;b&gt;_Bookmarks&lt;/b&gt;</property>
-                    <property name="use-markup">True</property>
+                    <property name="label" translatable="yes">_Bookmarks</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">bookmark_tree_view</property>
                     <property name="xalign">0</property>
                     <property name="yalign">0.5</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -154,11 +158,14 @@
                         <property name="can-focus">True</property>
                         <property name="headers-visible">False</property>
                         <property name="reorderable">True</property>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                       </object>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
+                    <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
@@ -186,11 +193,13 @@
                       <object class="GtkLabel" id="bookmark_name_label">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">&lt;b&gt;_Name&lt;/b&gt;</property>
-                        <property name="use-markup">True</property>
+                        <property name="label" translatable="yes">_Name</property>
                         <property name="use-underline">True</property>
                         <property name="xalign">0</property>
                         <property name="yalign">0.5</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -229,11 +238,13 @@
                       <object class="GtkLabel" id="bookmark_location_label">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">&lt;b&gt;_Location&lt;/b&gt;</property>
-                        <property name="use-markup">True</property>
+                        <property name="label" translatable="yes">_Location</property>
                         <property name="use-underline">True</property>
                         <property name="xalign">0</property>
                         <property name="yalign">0.5</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
                       </object>
                       <packing>
                         <property name="expand">False</property>


### PR DESCRIPTION
use attribute "bold" instead of markup