### PR TITLE
caja-directory.c: Fix memory leak.

### DIFF
--- a/libcaja-private/caja-directory.c
+++ b/libcaja-private/caja-directory.c
@@ -923,7 +923,6 @@ caja_directory_notify_files_added (GList *files)
              * If it was renamed this could be ignored, but
              * queue a change just in case */
             caja_file_changed (file);
-            caja_file_unref (file);
         }
         else
         {
@@ -931,6 +930,7 @@ caja_directory_notify_files_added (GList *files)
                                      directory,
                                      g_object_ref (location));
         }
+        caja_file_unref (file);
         caja_directory_unref (directory);
     }
 


### PR DESCRIPTION
When creating a new file (using a template, for instance), file->
details->is_added could potentially be FALSE, and cause this file to
not be finalized along with other files if the view directory is
destroyed.

This can cause issues when re-entering that directory, with the file
being in an undefined state, and could prevent the view from fully
loading the location (this is identical behavior to that described
in https://github.com/mate-desktop/python-caja/pull/64.

To reproduce:
- Create an svg file and save in ~/Templates.
- Right-click, Create document-> svg file, name it whatever.
- Navigate out of the folder.
- Modify the file in a visible manner.
- Re-enter the folder, note that it never finishes loading.

Ref:
https://github.com/linuxmint/nemo/issues/2736