### PR TITLE
Add native support for using a bulk renaming tool.

### DIFF
--- a/libcaja-private/caja-global-preferences.h
+++ b/libcaja-private/caja-global-preferences.h
@@ -209,6 +209,9 @@ typedef enum
 #define CAJA_PREFERENCES_LOCKDOWN_COMMAND_LINE         "disable-command-line"
 #define CAJA_PREFERENCES_DISABLED_EXTENSIONS           "disabled-extensions"
 
+/* bulk rename utility */
+#define CAJA_PREFERENCES_BULK_RENAME_TOOL              "bulk-rename-tool"
+
 void caja_global_preferences_init                      (void);
 char *caja_global_preferences_get_default_folder_viewer_preference_as_iid (void);
 

--- a/libcaja-private/org.mate.caja.gschema.xml
+++ b/libcaja-private/org.mate.caja.gschema.xml
@@ -269,6 +269,11 @@
       <summary>Whether to show desktop notifications</summary>
       <description>If set to true, Caja will show desktop notifications.</description>
     </key>
+    <key type="ay" name="bulk-rename-tool">
+      <default>[]</default>
+      <summary>Bulk rename utility</summary>
+      <description>If set, Nautilus will append URIs of selected files and treat the result as a command line for bulk renaming. Bulk rename applications can register themselves in this key by setting the key to a space-separated string of their executable name and any command line options. If the executable name is not set to a full path, it will be searched for in the search path.</description>
+    </key>
   </schema>
 
   <schema id="org.mate.caja.icon-view" path="/org/mate/caja/icon-view/" gettext-domain="caja">


### PR DESCRIPTION
This allows the normal method of renaming a file launch a bulk
renamer if one is configured and multiple files are selected.

Ported from nemo.