### PR TITLE
caja-file-operations: overlapping comparisons always evaluate to true

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -4045,7 +4045,7 @@ do_run_conflict_dialog (gpointer _data)
 	if (response == CONFLICT_RESPONSE_RENAME) {
 		data->resp_data->new_name =
 			caja_file_conflict_dialog_get_new_name (CAJA_FILE_CONFLICT_DIALOG (dialog));
-	} else if (response != GTK_RESPONSE_CANCEL ||
+	} else if (response != GTK_RESPONSE_CANCEL &&
 		   response != GTK_RESPONSE_NONE) {
 		   data->resp_data->apply_to_all =
 			   caja_file_conflict_dialog_get_apply_to_all


### PR DESCRIPTION
```
caja-file-operations.c:4048:45: warning: overlapping comparisons always evaluate to true [-Wtautological-overlap-compare]
        } else if (response != GTK_RESPONSE_CANCEL ||
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```