### PR TITLE
caja-file-operations: invalid conversion specifier

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -635,7 +635,7 @@ parse_previous_duplicate_name (const char *name,
 			}
 			*name_base = extract_string_until (name, tag);
 			/* Translators: opening parentheses of the "th copy)" string */
-			if (sscanf (tag, _(" (%'d"), count) == 1) {
+			if (sscanf (tag, _(" (%d"), count) == 1) {
 				if (*count < 1 || *count > 1000000) {
 					/* keep the count within a reasonable range */
 					*count = 0;


### PR DESCRIPTION
```
caja-file-operations.c:638:27: warning: invalid conversion specifier ''' [-Wformat-invalid-specifier]
                        if (sscanf (tag, _(" (%'d"), count) == 1) {
                                            ~~~^
```