### PR TITLE
caja-dnd: wrong type field in printf format string

### DIFF
--- a/libcaja-private/caja-dnd.c
+++ b/libcaja-private/caja-dnd.c
@@ -609,7 +609,7 @@ add_one_mate_icon (const char *uri, int x, int y, int w, int h,
 
     result = (GString *) data;
 
-    g_string_append_printf (result, "%s\r%d:%d:%hu:%hu\r\n",
+    g_string_append_printf (result, "%s\r%d:%d:%d:%d\r\n",
                             uri, x, y, w, h);
 }
 


### PR DESCRIPTION
```
caja-dnd.c:613:40: warning: format specifies type 'unsigned short' but the argument has type 'int' [-Wformat]
                            uri, x, y, w, h);
                                       ^
caja-dnd.c:613:43: warning: format specifies type 'unsigned short' but the argument has type 'int' [-Wformat]
                            uri, x, y, w, h);
                                          ^
```