### PR TITLE
caja-places-sidebar: fix right-click menu height

### DIFF
--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -2892,7 +2892,7 @@ bookmarks_button_release_event_cb (GtkWidget *widget,
             return FALSE;
         }
 
-    	model = gtk_tree_view_get_model (tree_view);
+        model = gtk_tree_view_get_model (tree_view);
 
         gtk_tree_view_get_path_at_pos (tree_view, (int) event->x, (int) event->y,
                                        &path, NULL, NULL, NULL);

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -2884,15 +2884,15 @@ bookmarks_button_release_event_cb (GtkWidget *widget,
     }
 
     tree_view = GTK_TREE_VIEW (widget);
-    model = gtk_tree_view_get_model (tree_view);
 
     if (event->button == 1)
     {
-
         if (event->window != gtk_tree_view_get_bin_window (tree_view))
         {
             return FALSE;
         }
+
+    	model = gtk_tree_view_get_model (tree_view);
 
         gtk_tree_view_get_path_at_pos (tree_view, (int) event->x, (int) event->y,
                                        &path, NULL, NULL, NULL);
@@ -2903,15 +2903,6 @@ bookmarks_button_release_event_cb (GtkWidget *widget,
     }
     else if (event->button == 3)
     {
-        GtkTreeModel *model;
-        GtkTreePath *path;
-        GtkTreeView *tree_view;
-
-        tree_view = GTK_TREE_VIEW (widget);
-        g_assert (tree_view == sidebar->tree_view);
-
-        model = gtk_tree_view_get_model (tree_view);
-
         gtk_tree_view_get_path_at_pos (tree_view, (int) event->x, (int) event->y,
                                        &path, NULL, NULL, NULL);
 

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -2906,12 +2906,13 @@ bookmarks_button_release_event_cb (GtkWidget *widget,
         gtk_tree_view_get_path_at_pos (tree_view, (int) event->x, (int) event->y,
                                        &path, NULL, NULL, NULL);
 
-        gtk_tree_view_set_cursor(tree_view, path, NULL, FALSE);
-        bookmarks_popup_menu (sidebar, event);
-
         if (path != NULL)
         {
+            gtk_tree_view_set_cursor(tree_view, path, NULL, FALSE);
             gtk_tree_path_free (path);
+
+            bookmarks_popup_menu (sidebar, event);
+
             return TRUE;
         }
     }

--- a/src/caja-places-sidebar.c
+++ b/src/caja-places-sidebar.c
@@ -2901,6 +2901,29 @@ bookmarks_button_release_event_cb (GtkWidget *widget,
 
         gtk_tree_path_free (path);
     }
+    else if (event->button == 3)
+    {
+        GtkTreeModel *model;
+        GtkTreePath *path;
+        GtkTreeView *tree_view;
+
+        tree_view = GTK_TREE_VIEW (widget);
+        g_assert (tree_view == sidebar->tree_view);
+
+        model = gtk_tree_view_get_model (tree_view);
+
+        gtk_tree_view_get_path_at_pos (tree_view, (int) event->x, (int) event->y,
+                                       &path, NULL, NULL, NULL);
+
+        gtk_tree_view_set_cursor(tree_view, path, NULL, FALSE);
+        bookmarks_popup_menu (sidebar, event);
+
+        if (path != NULL)
+        {
+            gtk_tree_path_free (path);
+            return TRUE;
+        }
+    }
 
     return FALSE;
 }
@@ -3016,11 +3039,7 @@ bookmarks_button_press_event_cb (GtkWidget             *widget,
         return TRUE;
     }
 
-    if (event->button == 3)
-    {
-        bookmarks_popup_menu (sidebar, event);
-    }
-    else if (event->button == 2)
+    if (event->button == 2)
     {
         GtkTreeModel *model;
         GtkTreePath *path;


### PR DESCRIPTION
Prevents the places sidebar right-click menu from having an incorrect height when selecting an item with a different amount of menu entries. This should fix #1473 / #1442.

Note that this also changes the behavior of right-clicking on a different sidebar item when the menu is already open: Instead of only closing the menu, the menu of the new item is opened immediately. I think I prefer it this way but I don't know if this is desired.

