### PR TITLE
eel-background: fix memory leak

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -1001,13 +1001,19 @@ void
 eel_bg_load_from_gsettings (EelBackground *self,
 			    GSettings     *settings)
 {
-    char *keyfile = g_settings_get_string (settings, MATE_BG_KEY_PICTURE_FILENAME);
+    char *picture_filename;
 
-    if (!g_file_test (keyfile, G_FILE_TEST_EXISTS) && (*keyfile != '\0'))
+    picture_filename = g_settings_get_string (settings,
+                                              MATE_BG_KEY_PICTURE_FILENAME);
+    if ((*picture_filename != '\0') &&
+        !g_file_test (picture_filename, G_FILE_TEST_EXISTS))
     {
-        *keyfile = '\0';
-        g_settings_set_string (settings, MATE_BG_KEY_PICTURE_FILENAME, keyfile);
+        *picture_filename = '\0';
+        g_settings_set_string (settings,
+                               MATE_BG_KEY_PICTURE_FILENAME,
+                               picture_filename);
     }
+    g_free (picture_filename);
 
     if (self->details->bg)
         mate_bg_load_from_gsettings (self->details->bg,


### PR DESCRIPTION
```
Direct leak of 74 byte(s) in 1 object(s) allocated from:
    #0 0x7f114a93f93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f1149627b7f in g_malloc ../glib/gmem.c:106
    #2 0x7f1149627ec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f114964a1a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x7f11496779b4 in g_variant_dup_string ../glib/gvariant.c:1537
    #5 0x7f11498d7d0d in g_settings_get_string ../gio/gsettings.c:1809
    #6 0x6b06bf in eel_bg_load_from_gsettings /home/robert/builddir.gcc/caja/eel/eel-background.c:1004
    #7 0x5bf10e in caja_connect_desktop_background_to_settings /home/robert/builddir.gcc/caja/libcaja-private/caja-directory-background.c:398
    #8 0x53706f in fm_icon_view_begin_loading /home/robert/builddir.gcc/caja/src/file-manager/fm-icon-view.c:1348
    #9 0x7f1149735f4f in g_cclosure_marshal_VOID__VOID ../gobject/gmarshal.c:117
    #10 0x7f1149732d80 in g_type_class_meta_marshal ../gobject/gclosure.c:1007
    #11 0x7f1149732264 in g_closure_invoke ../gobject/gclosure.c:810
    #12 0x7f1149752d78 in signal_emit_unlocked_R ../gobject/gsignal.c:3780
    #13 0x7f11497544ec in g_signal_emit_valist ../gobject/gsignal.c:3497
    #14 0x7f1149754cee in g_signal_emit ../gobject/gsignal.c:3553
    #15 0x50b43e in fm_directory_view_begin_loading /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:3471
    #16 0x523f76 in finish_loading /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9751
    #17 0x52453e in finish_loading_if_all_metadata_loaded /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9807
    #18 0x524a5e in metadata_for_files_in_directory_ready_callback /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9843
    #19 0x59dbf2 in merged_callback_check_done /home/robert/builddir.gcc/caja/libcaja-private/caja-desktop-directory.c:138
    #20 0x59dc91 in merged_callback_remove_directory /home/robert/builddir.gcc/caja/libcaja-private/caja-desktop-directory.c:152
    #21 0x59dee6 in directory_ready_callback /home/robert/builddir.gcc/caja/libcaja-private/caja-desktop-directory.c:178
    #22 0x5ac3e3 in ready_callback_call /home/robert/builddir.gcc/caja/libcaja-private/caja-directory-async.c:1388
    #23 0x5af569 in call_ready_callbacks_at_idle /home/robert/builddir.gcc/caja/libcaja-private/caja-directory-async.c:2031
    #24 0x7f11496196ae in g_idle_dispatch ../glib/gmain.c:5848
    #25 0x7f114961e7d6 in g_main_dispatch ../glib/gmain.c:3337
    #26 0x7f114961e61f in g_main_context_dispatch ../glib/gmain.c:4055
    #27 0x7f114961eb41 in g_main_context_iterate ../glib/gmain.c:4131
    #28 0x7f114961ebc2 in g_main_context_iteration ../glib/gmain.c:4196
    #29 0x7f11498b125f in g_application_run ../gio/gapplication.c:2560
```