### PR TITLE
caja-sidebar-title: fix memory leak

### DIFF
--- a/src/caja-sidebar-title.c
+++ b/src/caja-sidebar-title.c
@@ -441,6 +441,7 @@ override_title_font (GtkWidget   *widget,
 
     css = g_strdup_printf ("label { font-family: %s; font-size: %spt; }", tempfont, tempsize);
     gtk_css_provider_load_from_data (provider, css, -1, NULL);
+    g_free (tempsize);
     g_free (css);
 
     gtk_style_context_add_provider (gtk_widget_get_style_context (widget),
@@ -459,6 +460,7 @@ update_title_font (CajaSidebarTitle *sidebar_title)
     GtkAllocation allocation;
     PangoFontDescription *title_font, *tmp_font;
     PangoLayout *layout;
+    char *title_font_str;
 
     /* Make sure theres work to do */
     if (sidebar_title->details->title_text == NULL
@@ -508,7 +510,9 @@ update_title_font (CajaSidebarTitle *sidebar_title)
     pango_font_description_set_size (title_font, max_fit_font_size * PANGO_SCALE);
     pango_font_description_set_weight (title_font, PANGO_WEIGHT_BOLD);
 
-    override_title_font (sidebar_title->details->title_label, pango_font_description_to_string (title_font));
+    title_font_str = pango_font_description_to_string (title_font);
+    override_title_font (sidebar_title->details->title_label, title_font_str);
+    g_free (title_font_str);
 
     pango_font_description_free (title_font);
 }


### PR DESCRIPTION
```
LeakSanitizer: detected memory leaks
```
```
Direct leak of 26 byte(s) in 2 object(s) allocated from:
    #0 0x7f8f74d1f93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f8f739fe4ff in g_malloc ../glib/gmem.c:106
    #2 0x7f8f739fe842 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f8f73a20d85 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x4c6c10 in override_title_font /home/robert/builddir.gcc/caja/src/caja-sidebar-title.c:432
    #5 0x4c73bf in update_title_font /home/robert/builddir.gcc/caja/src/caja-sidebar-title.c:513
    #6 0x4c7569 in update_title /home/robert/builddir.gcc/caja/src/caja-sidebar-title.c:533
    #7 0x4c81f8 in update_all /home/robert/builddir.gcc/caja/src/caja-sidebar-title.c:737
    #8 0x4c85fd in caja_sidebar_title_set_file /home/robert/builddir.gcc/caja/src/caja-sidebar-title.c:776
    #9 0x47791e in caja_information_panel_set_uri /home/robert/builddir.gcc/caja/src/caja-information-panel.c:945
    #10 0x477b1b in selection_changed_callback /home/robert/builddir.gcc/caja/src/caja-information-panel.c:1019
    #11 0x7f8f73b0e18f in g_cclosure_marshal_VOID__VOID ../gobject/gmarshal.c:117
    #12 0x7f8f73b0a465 in g_closure_invoke ../gobject/gclosure.c:830
    #13 0x7f8f73b2b0f2 in signal_emit_unlocked_R ../gobject/gsignal.c:3742
    #14 0x7f8f73b2ca0c in g_signal_emit_valist ../gobject/gsignal.c:3497
    #15 0x7f8f73b2d441 in g_signal_emit_by_name ../gobject/gsignal.c:3594
    #16 0x4d0625 in caja_window_report_selection_changed /home/robert/builddir.gcc/caja/src/caja-window-manage-views.c:124
    #17 0x693491 in caja_window_info_report_selection_changed /home/robert/builddir.gcc/caja/libcaja-private/caja-window-info.c:165
    #18 0x5070be in fm_directory_view_send_selection_change /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:2484
    #19 0x5098cb in display_selection_info_idle_callback /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:3049
    #20 0x7f8f739eff2e in g_idle_dispatch ../glib/gmain.c:5929
    #21 0x7f8f739f5136 in g_main_dispatch ../glib/gmain.c:3413
    #22 0x7f8f739f4f7f in g_main_context_dispatch ../glib/gmain.c:4131
    #23 0x7f8f739f54a1 in g_main_context_iterate ../glib/gmain.c:4207
    #24 0x7f8f739f5522 in g_main_context_iteration ../glib/gmain.c:4272
    #25 0x7f8f73c8dcee in g_application_run ../gio/gapplication.c:2569
    #26 0x47d7ba in main /home/robert/builddir.gcc/caja/src/caja-main.c:271
    #27 0x7f8f73342b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```
```
Direct leak of 13 byte(s) in 1 object(s) allocated from:
    #0 0x7f06d41dd93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f06d2ebc4ff in g_malloc ../glib/gmem.c:106
    #2 0x7f06d2ebc842 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f06d2eded85 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x4c6c10 in override_title_font /home/robert/builddir.gcc/caja/src/caja-sidebar-title.c:432
    #5 0x4c73b1 in update_title_font /home/robert/builddir.gcc/caja/src/caja-sidebar-title.c:511
    #6 0x4c88b6 in caja_sidebar_title_size_allocate /home/robert/builddir.gcc/caja/src/caja-sidebar-title.c:806
    #7 0x7f06d39c12cf in gtk_widget_size_allocate_with_baseline (/lib64/libgtk-3.so.0+0x39f2cf)
```