### PR TITLE
fm-directory-view: fix memory leak

### DIFF
--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -4730,6 +4730,7 @@ reset_open_with_menu (FMDirectoryView *view, GList *selection)
 	GtkUIManager *ui_manager;
 	GtkAction *action;
 	GAppInfo *default_app;
+	char *uri;
 
 	/* Clear any previous inserted items in the applications and viewers placeholders */
 
@@ -4811,11 +4812,14 @@ reset_open_with_menu (FMDirectoryView *view, GList *selection)
 	}
 
 	/* Show open parent folder action if we are in search mode */
-	if (eel_uri_is_search (fm_directory_view_get_uri (view)) && g_list_length (selection) == 1)
+	uri = fm_directory_view_get_uri (view);
+	if (eel_uri_is_search (uri) && g_list_length (selection) == 1)
 		add_parent_folder_to_open_menu (view,
 					       selection,
 					       FM_DIRECTORY_VIEW_MENU_PATH_OPEN,
 					       FM_DIRECTORY_VIEW_POPUP_PATH_OPEN);
+
+	g_free (uri);
 
 	open_with_chooser_visible = other_applications_visible &&
 				    g_list_length (selection) == 1;


### PR DESCRIPTION
```
LeakSanitizer: detected memory leaks

Direct leak of 13 byte(s) in 1 object(s) allocated from:
    #0 0x7f7d6c7da93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f7d6b4b94ff in g_malloc ../glib/gmem.c:106
    #2 0x7f7d6b4b9842 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f7d6b4dc436 in g_strconcat ../glib/gstrfuncs.c:629
    #4 0x7f7d6b481d65 in g_escape_file_uri ../glib/gconvert.c:1510
    #5 0x7f7d6b481c98 in g_filename_to_uri ../glib/gconvert.c:1835
    #6 0x7f7d6b7c4aa4 in g_local_file_get_uri ../gio/glocalfile.c:284
    #7 0x7f7d6b688495 in g_file_get_uri ../gio/gfile.c:645
    #8 0x5c0f08 in caja_directory_get_uri /home/robert/builddir.gcc/caja/libcaja-private/caja-directory.c:442
    #9 0x52800e in fm_directory_view_get_uri /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:10307
    #10 0x5113dd in reset_open_with_menu /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:4814
    #11 0x520893 in real_update_menus /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9111
    #12 0x54dc63 in fm_list_view_update_menus /home/robert/builddir.gcc/caja/src/file-manager/fm-list-view.c:2701
    #13 0x527bae in fm_directory_view_update_menus /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:10267
    #14 0x54e828 in fm_list_view_set_zoom_level /home/robert/builddir.gcc/caja/src/file-manager/fm-list-view.c:2821
    #15 0x54a6b6 in set_zoom_level_from_metadata_and_preferences /home/robert/builddir.gcc/caja/src/file-manager/fm-list-view.c:2036
    #16 0x54a774 in fm_list_view_begin_loading /home/robert/builddir.gcc/caja/src/file-manager/fm-list-view.c:2052
    #17 0x7f7d6b5c918f in g_cclosure_marshal_VOID__VOID ../gobject/gmarshal.c:117
    #18 0x7f7d6b5c5fc0 in g_type_class_meta_marshal ../gobject/gclosure.c:1031
    #19 0x7f7d6b5c5465 in g_closure_invoke ../gobject/gclosure.c:830
    #20 0x7f7d6b5e6298 in signal_emit_unlocked_R ../gobject/gsignal.c:3781
    #21 0x7f7d6b5e7a0c in g_signal_emit_valist ../gobject/gsignal.c:3497
    #22 0x7f7d6b5e820e in g_signal_emit ../gobject/gsignal.c:3553
    #23 0x50b45b in fm_directory_view_begin_loading /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:3471
    #24 0x523f93 in finish_loading /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9751
    #25 0x52455b in finish_loading_if_all_metadata_loaded /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9807
    #26 0x524a7b in metadata_for_files_in_directory_ready_callback /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9843
    #27 0x5ac400 in ready_callback_call /home/robert/builddir.gcc/caja/libcaja-private/caja-directory-async.c:1388
    #28 0x5af586 in call_ready_callbacks_at_idle /home/robert/builddir.gcc/caja/libcaja-private/caja-directory-async.c:2031
    #29 0x7f7d6b4aaf2e in g_idle_dispatch ../glib/gmain.c:5929
```