### PR TITLE
Fix implicit conversion changes signedness: 'gboolean' to 'guint'

### DIFF
--- a/eel/eel-canvas-rect-ellipse.c
+++ b/eel/eel-canvas-rect-ellipse.c
@@ -204,7 +204,7 @@ eel_canvas_re_set_fill (EelCanvasRE *re, gboolean fill_set)
 {
     if (re->fill_set != fill_set)
     {
-        re->fill_set = fill_set;
+        re->fill_set = (fill_set != FALSE);
         eel_canvas_item_request_update (EEL_CANVAS_ITEM (re));
     }
 }
@@ -214,7 +214,7 @@ eel_canvas_re_set_outline (EelCanvasRE *re, gboolean outline_set)
 {
     if (re->outline_set != outline_set)
     {
-        re->outline_set = outline_set;
+        re->outline_set = (outline_set != FALSE);
         eel_canvas_item_request_update (EEL_CANVAS_ITEM (re));
     }
 }

--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -764,7 +764,7 @@ eel_editable_label_set_draw_outline (EelEditableLabel *label,
 
     if (label->draw_outline != draw_outline)
     {
-        label->draw_outline = draw_outline;
+        label->draw_outline = (draw_outline != FALSE);
 
         gtk_widget_queue_draw (GTK_WIDGET (label));
     }
@@ -790,7 +790,7 @@ eel_editable_label_set_line_wrap (EelEditableLabel *label,
 
     if (label->wrap != wrap)
     {
-        label->wrap = wrap;
+        label->wrap = (wrap != FALSE);
         g_object_notify (G_OBJECT (label), "wrap");
 
         gtk_widget_queue_resize (GTK_WIDGET (label));
@@ -1000,7 +1000,7 @@ eel_editable_label_ensure_layout (EelEditableLabel *label,
         {
             label->layout = gtk_widget_create_pango_layout (widget, label->text);
         }
-        label->layout_includes_preedit = include_preedit;
+        label->layout_includes_preedit = (include_preedit != FALSE);
 
         if (label->font_desc != NULL)
             pango_layout_set_font_description (label->layout, label->font_desc);

--- a/libcaja-private/caja-desktop-icon-file.c
+++ b/libcaja-private/caja-desktop-icon-file.c
@@ -205,8 +205,8 @@ update_info_from_link (CajaDesktopIconFile *icon_file)
     file->details->mount = mount;
     if (mount)
     {
-        file->details->can_unmount = g_mount_can_unmount (mount);
-        file->details->can_eject = g_mount_can_eject (mount);
+        file->details->can_unmount = (g_mount_can_unmount (mount) != FALSE);
+        file->details->can_eject = (g_mount_can_eject (mount) != FALSE);
     }
 
     file->details->file_info_is_up_to_date = TRUE;

--- a/libcaja-private/caja-directory-async.c
+++ b/libcaja-private/caja-directory-async.c
@@ -871,7 +871,7 @@ set_file_unconfirmed (CajaFile *file, gboolean unconfirmed)
     {
         return;
     }
-    file->details->unconfirmed = unconfirmed;
+    file->details->unconfirmed = (unconfirmed != FALSE);
 
     directory = file->details->directory;
     if (unconfirmed)
@@ -3521,7 +3521,7 @@ top_left_read_callback (GObject *source_object,
     {
         file_details->top_left_text = caja_extract_top_left_text (file_contents, state->large, file_size);
         file_details->got_top_left_text = TRUE;
-        file_details->got_large_top_left_text = state->large;
+        file_details->got_large_top_left_text = (state->large != FALSE);
         g_free (file_contents);
     }
     else
@@ -3902,9 +3902,9 @@ link_info_done (CajaDirectory *directory,
     {
         file->details->custom_icon = g_strdup (icon);
     }
-    file->details->is_launcher = is_launcher;
-    file->details->is_foreign_link = is_foreign;
-    file->details->is_trusted_link = is_trusted;
+    file->details->is_launcher = (is_launcher != FALSE);
+    file->details->is_foreign_link = (is_foreign != FALSE);
+    file->details->is_trusted_link = (is_trusted != FALSE);
 
     caja_directory_async_state_changed (directory);
 }
@@ -4111,7 +4111,7 @@ thumbnail_done (CajaDirectory *directory,
                 gboolean tried_original)
 {
     file->details->thumbnail_is_up_to_date = TRUE;
-    file->details->thumbnail_tried_original  = tried_original;
+    file->details->thumbnail_tried_original = (tried_original != FALSE);
     if (file->details->thumbnail)
     {
         g_object_unref (file->details->thumbnail);
@@ -4667,7 +4667,7 @@ got_filesystem_info (FilesystemInfoState *state, GFileInfo *info)
         file->details->filesystem_use_preview =
             g_file_info_get_attribute_uint32 (info, G_FILE_ATTRIBUTE_FILESYSTEM_USE_PREVIEW);
         file->details->filesystem_readonly =
-            g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_FILESYSTEM_READONLY);
+            (g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_FILESYSTEM_READONLY) != FALSE);
     }
 
     caja_directory_async_state_changed (directory);

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -257,7 +257,7 @@ caja_file_set_display_name (CajaFile *file,
 		}
 	}
 
-	file->details->got_custom_display_name = custom;
+	file->details->got_custom_display_name = (custom != FALSE);
 	return changed;
 }
 
@@ -2188,7 +2188,7 @@ update_info_internal (CajaFile *file,
 	if (file->details->is_symlink != is_symlink) {
 		changed = TRUE;
 	}
-	file->details->is_symlink = is_symlink;
+	file->details->is_symlink = (is_symlink != FALSE);
 
 	is_hidden = g_file_info_get_is_hidden (info);
 	is_backup = g_file_info_get_is_backup (info);
@@ -2196,14 +2196,14 @@ update_info_internal (CajaFile *file,
 	    file->details->is_backup != is_backup) {
 		changed = TRUE;
 	}
-	file->details->is_hidden = is_hidden;
-	file->details->is_backup = is_backup;
+	file->details->is_hidden = (is_hidden != FALSE);
+	file->details->is_backup = (is_backup != FALSE);
 
 	is_mountpoint = g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT);
 	if (file->details->is_mountpoint != is_mountpoint) {
 		changed = TRUE;
 	}
-	file->details->is_mountpoint = is_mountpoint;
+	file->details->is_mountpoint = (is_mountpoint != FALSE);
 
 	has_permissions = g_file_info_has_attribute (info, G_FILE_ATTRIBUTE_UNIX_MODE);
 	permissions = g_file_info_get_attribute_uint32 (info, G_FILE_ATTRIBUTE_UNIX_MODE);;
@@ -2211,7 +2211,7 @@ update_info_internal (CajaFile *file,
 	    file->details->permissions != permissions) {
 		changed = TRUE;
 	}
-	file->details->has_permissions = has_permissions;
+	file->details->has_permissions = (has_permissions != FALSE);
 	file->details->permissions = permissions;
 
 	/* We default to TRUE for this if we can't know */
@@ -2308,21 +2308,21 @@ update_info_internal (CajaFile *file,
 		changed = TRUE;
 	}
 
-	file->details->can_read = can_read;
-	file->details->can_write = can_write;
-	file->details->can_execute = can_execute;
-	file->details->can_delete = can_delete;
-	file->details->can_trash = can_trash;
-	file->details->can_rename = can_rename;
-	file->details->can_mount = can_mount;
-	file->details->can_unmount = can_unmount;
-	file->details->can_eject = can_eject;
-	file->details->can_start = can_start;
-	file->details->can_start_degraded = can_start_degraded;
-	file->details->can_stop = can_stop;
+	file->details->can_read = (can_read != FALSE);
+	file->details->can_write = (can_write != FALSE);
+	file->details->can_execute = (can_execute != FALSE);
+	file->details->can_delete = (can_delete != FALSE);
+	file->details->can_trash = (can_trash != FALSE);
+	file->details->can_rename = (can_rename != FALSE);
+	file->details->can_mount = (can_mount != FALSE);
+	file->details->can_unmount = (can_unmount != FALSE);
+	file->details->can_eject = (can_eject != FALSE);
+	file->details->can_start = (can_start != FALSE);
+	file->details->can_start_degraded = (can_start_degraded != FALSE);
+	file->details->can_stop = (can_stop != FALSE);
 	file->details->start_stop_type = start_stop_type;
-	file->details->can_poll_for_media = can_poll_for_media;
-	file->details->is_media_check_automatic = is_media_check_automatic;
+	file->details->can_poll_for_media = (can_poll_for_media != FALSE);
+	file->details->is_media_check_automatic = (is_media_check_automatic != FALSE);
 
 	free_owner = FALSE;
 	owner = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_OWNER_USER);
@@ -2448,7 +2448,7 @@ update_info_internal (CajaFile *file,
 	thumbnailing_failed =  g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_THUMBNAILING_FAILED);
 	if (file->details->thumbnailing_failed != thumbnailing_failed) {
 		changed = TRUE;
-		file->details->thumbnailing_failed = thumbnailing_failed;
+		file->details->thumbnailing_failed = (thumbnailing_failed != FALSE);
 	}
 
 	symlink_name = g_file_info_get_symlink_target (info);
@@ -7987,7 +7987,7 @@ caja_file_set_has_open_window (CajaFile *file,
 	has_open_window = (has_open_window != FALSE);
 
 	if (file->details->has_open_window != has_open_window) {
-		file->details->has_open_window = has_open_window;
+		file->details->has_open_window = (has_open_window != FALSE);
 		caja_file_changed (file);
 	}
 }
@@ -8006,7 +8006,7 @@ caja_file_set_is_thumbnailing (CajaFile *file,
 {
 	g_return_if_fail (CAJA_IS_FILE (file));
 
-	file->details->is_thumbnailing = is_thumbnailing;
+	file->details->is_thumbnailing = (is_thumbnailing != FALSE);
 }
 
 /**

--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -420,7 +420,7 @@ caja_icon_canvas_item_set_property (GObject        *object,
         {
             return;
         }
-        details->is_highlighted_for_selection = g_value_get_boolean (value);
+        details->is_highlighted_for_selection = (g_value_get_boolean (value) != FALSE);
         caja_icon_canvas_item_invalidate_label_size (item);
 
         atk_object_notify_state_change (accessible, ATK_STATE_SELECTED,
@@ -432,7 +432,7 @@ caja_icon_canvas_item_set_property (GObject        *object,
         {
             return;
         }
-        details->is_highlighted_as_keyboard_focus = g_value_get_boolean (value);
+        details->is_highlighted_as_keyboard_focus = (g_value_get_boolean (value) != FALSE);
         atk_object_notify_state_change (accessible, ATK_STATE_FOCUSED,
                                         details->is_highlighted_as_keyboard_focus);
         break;
@@ -442,7 +442,7 @@ caja_icon_canvas_item_set_property (GObject        *object,
         {
             return;
         }
-        details->is_highlighted_for_drop = g_value_get_boolean (value);
+        details->is_highlighted_for_drop = (g_value_get_boolean (value) != FALSE);
         break;
 
     case PROP_HIGHLIGHTED_FOR_CLIPBOARD:
@@ -450,7 +450,7 @@ caja_icon_canvas_item_set_property (GObject        *object,
         {
             return;
         }
-        details->is_highlighted_for_clipboard = g_value_get_boolean (value);
+        details->is_highlighted_for_clipboard = (g_value_get_boolean (value) != FALSE);
         break;
 
     default:
@@ -1431,7 +1431,7 @@ caja_icon_canvas_item_set_is_visible (CajaIconCanvasItem       *item,
     if (item->details->is_visible == visible)
         return;
 
-    item->details->is_visible = visible;
+    item->details->is_visible = (visible != FALSE);
 
     if (!visible)
     {
@@ -1827,7 +1827,7 @@ map_surface (CajaIconCanvasItem *icon_item)
         icon_item->details->rendered_is_highlighted_for_selection = icon_item->details->is_highlighted_for_selection;
         icon_item->details->rendered_is_highlighted_for_drop = icon_item->details->is_highlighted_for_drop;
         icon_item->details->rendered_is_highlighted_for_clipboard = icon_item->details->is_highlighted_for_clipboard;
-        icon_item->details->rendered_is_focused = gtk_widget_has_focus (GTK_WIDGET (EEL_CANVAS_ITEM (icon_item)->canvas));
+        icon_item->details->rendered_is_focused = (gtk_widget_has_focus (GTK_WIDGET (EEL_CANVAS_ITEM (icon_item)->canvas)) != FALSE);
     }
 
     cairo_surface_reference (icon_item->details->rendered_surface);
@@ -2128,10 +2128,10 @@ caja_icon_canvas_item_event (EelCanvasItem *item, GdkEvent *event)
              * should be separate. The "unpreview" signal
              * does not have a return value.
              */
-            icon_item->details->is_active = caja_icon_container_emit_preview_signal
-                                            (CAJA_ICON_CONTAINER (item->canvas),
-                                             CAJA_ICON_CANVAS_ITEM (item)->user_data,
-                                             TRUE);
+            icon_item->details->is_active =
+                (caja_icon_container_emit_preview_signal (CAJA_ICON_CONTAINER (item->canvas),
+                                                          CAJA_ICON_CANVAS_ITEM (item)->user_data,
+                                                          TRUE) != FALSE);
         }
         return TRUE;
 
@@ -2583,7 +2583,7 @@ caja_icon_canvas_item_set_show_stretch_handles (CajaIconCanvasItem *item,
         return;
     }
 
-    item->details->show_stretch_handles = show_stretch_handles;
+    item->details->show_stretch_handles = (show_stretch_handles != FALSE);
     eel_canvas_item_request_update (EEL_CANVAS_ITEM (item));
 }
 
@@ -2691,7 +2691,7 @@ caja_icon_canvas_item_set_renaming (CajaIconCanvasItem *item, gboolean state)
         return;
     }
 
-    item->details->is_renaming = state;
+    item->details->is_renaming = (state != FALSE);
     eel_canvas_item_request_update (EEL_CANVAS_ITEM (item));
 }
 
@@ -2744,7 +2744,7 @@ caja_icon_canvas_item_set_entire_text (CajaIconCanvasItem       *item,
 					   gboolean                      entire_text)
 {
 	if (item->details->entire_text != entire_text) {
-		item->details->entire_text = entire_text;
+		item->details->entire_text = (entire_text != FALSE);
 
 		caja_icon_canvas_item_invalidate_label_size (item);
 		eel_canvas_item_request_update (EEL_CANVAS_ITEM (item));

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -7852,7 +7852,7 @@ caja_icon_container_add (CajaIconContainer *container,
      * if the previous icon position is free. If the position
      * is occupied, another position near the last one will
      */
-    icon->has_lazy_position = is_old_or_unknown_icon_data (container, data);
+    icon->has_lazy_position = (is_old_or_unknown_icon_data (container, data) != FALSE);
     icon->scale = 1.0;
     icon->item = CAJA_ICON_CANVAS_ITEM
                  (eel_canvas_item_new (EEL_CANVAS_GROUP (EEL_CANVAS (container)->root),
@@ -10153,7 +10153,7 @@ caja_icon_container_get_store_layout_timestamps (CajaIconContainer *container)
 
 void
 caja_icon_container_set_store_layout_timestamps (CajaIconContainer *container,
-        gboolean               store_layout_timestamps)
+                                                 gboolean           store_layout_timestamps)
 {
-    container->details->store_layout_timestamps = store_layout_timestamps;
+    container->details->store_layout_timestamps = (store_layout_timestamps != FALSE);
 }

--- a/src/caja-pathbar.c
+++ b/src/caja-pathbar.c
@@ -1941,7 +1941,7 @@ make_directory_button (CajaPathBar  *path_bar,
                               button_data);
     }
 
-    button_data->file_is_hidden = file_is_hidden;
+    button_data->file_is_hidden = (file_is_hidden != FALSE);
 
     gtk_container_add (GTK_CONTAINER (button_data->button), child);
     gtk_widget_show_all (button_data->button);

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -1296,11 +1296,11 @@ sort_column_changed_callback (GtkTreeSortable *sortable,
         if (sort_attr == default_sort_attr)
         {
             /* use value from preferences */
-            reversed = g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_DEFAULT_SORT_IN_REVERSE_ORDER);
+            reversed = (g_settings_get_boolean (caja_preferences, CAJA_PREFERENCES_DEFAULT_SORT_IN_REVERSE_ORDER) != FALSE);
         }
         else
         {
-            reversed = caja_file_is_date_sort_attribute_q (sort_attr);
+            reversed = (caja_file_is_date_sort_attribute_q (sort_attr) != FALSE);
         }
 
         if (reversed)

--- a/src/file-manager/fm-tree-model.c
+++ b/src/file-manager/fm-tree-model.c
@@ -1101,7 +1101,7 @@ set_done_loading (FMTreeModel *model, TreeNode *node, gboolean done_loading)
 
     had_dummy = tree_node_has_dummy_child (node);
 
-    node->done_loading = done_loading;
+    node->done_loading = (done_loading != FALSE);
 
     if (tree_node_has_dummy_child (node))
     {


### PR DESCRIPTION
```
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
```
eel-canvas-rect-ellipse.c:207:24: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'unsigned int' [-Wsign-conversion]
eel-canvas-rect-ellipse.c:217:27: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'unsigned int' [-Wsign-conversion]
eel-editable-label.c:767:31: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
eel-editable-label.c:793:23: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
eel-editable-label.c:1003:42: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-desktop-icon-file.c:208:38: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-desktop-icon-file.c:209:36: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-directory-async.c:874:34: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-directory-async.c:3524:56: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-directory-async.c:3905:34: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-directory-async.c:3906:38: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-directory-async.c:3907:38: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-directory-async.c:4114:48: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-directory-async.c:4670:13: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:260:43: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2191:30: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2199:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2200:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2206:33: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2214:35: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2311:28: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2312:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2313:31: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2314:30: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2315:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2316:30: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2317:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2318:31: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2319:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2320:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2321:38: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2322:28: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2324:38: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2325:44: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:2451:40: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:7990:36: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-file.c:8009:35: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:423:49: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:435:53: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:445:44: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:453:49: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:1434:33: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:1830:51: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:2131:45: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:2586:43: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:2694:34: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-canvas-item.c:2747:32: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-container.c:7855:31: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
caja-icon-container.c:10158:51: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'eel_boolean_bit' (aka 'unsigned int') [-Wsign-conversion]
fm-list-view.c:1299:24: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'GtkSortType' [-Wsign-conversion]
fm-list-view.c:1303:24: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'GtkSortType' [-Wsign-conversion]
fm-tree-model.c:1104:26: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
caja-pathbar.c:1944:35: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
```