### PR TITLE
Navigation windows:  Save the state of the extra pane

### DIFF
--- a/libcaja-private/caja-global-preferences.h
+++ b/libcaja-private/caja-global-preferences.h
@@ -106,6 +106,7 @@ typedef enum
 #define CAJA_PREFERENCES_ALWAYS_USE_LOCATION_ENTRY			"always-use-location-entry"
 
 /* Which views should be displayed for new windows */
+#define CAJA_WINDOW_STATE_START_WITH_EXTRA_PANE		 		"start-with-extra-pane"
 #define CAJA_WINDOW_STATE_START_WITH_LOCATION_BAR			"start-with-location-bar"
 #define CAJA_WINDOW_STATE_START_WITH_STATUS_BAR				"start-with-status-bar"
 #define CAJA_WINDOW_STATE_START_WITH_SIDEBAR		 		"start-with-sidebar"
@@ -113,6 +114,7 @@ typedef enum
 #define CAJA_WINDOW_STATE_SIDE_PANE_VIEW                    "side-pane-view"
 #define CAJA_WINDOW_STATE_GEOMETRY 	"geometry"
 #define CAJA_WINDOW_STATE_MAXIMIZED        "maximized"
+#define CAJA_WINDOW_STATE_EXTRA_PANE_POSITION  					"extra-pane-position"
 #define CAJA_WINDOW_STATE_SIDEBAR_WIDTH  					"sidebar-width"
 
 /* Sorting order */

--- a/libcaja-private/org.mate.caja.gschema.xml
+++ b/libcaja-private/org.mate.caja.gschema.xml
@@ -438,10 +438,20 @@
       <summary>Whether the navigation window should be maximized.</summary>
       <description>Whether the navigation window should be maximized by default.</description>
     </key>
+    <key name="extra-pane-position" type="i">
+      <default>-1</default>
+      <summary>Default position of the extra pane</summary>
+      <description>The default position (in pixels) of the extra pane in new windows, relative to the left side (or right side in right-to-left mode) of the navigation window.  A greater value here will allocate more space for the primary pane and less space for the extra pane.  A value of -1 here will split the window evenly in half between the two panes.</description>
+    </key>
     <key name="sidebar-width" type="i">
       <default>148</default>
       <summary>Width of the side pane</summary>
       <description>The default width of the side pane in new windows.</description>
+    </key>
+    <key name="start-with-extra-pane" type="b">
+      <default>true</default>
+      <summary>Show extra pane by default in new windows</summary>
+      <description>If set to true, newly opened windows will have the extra pane visible.</description>
     </key>
     <key name="start-with-toolbar" type="b">
       <default>true</default>

--- a/src/caja-window-private.h
+++ b/src/caja-window-private.h
@@ -99,6 +99,9 @@ struct _CajaNavigationWindowPrivate
 
     GtkSizeGroup *header_size_group;
 
+    /* Extra Pane */
+    int extra_pane_width;
+
     /* Side Pane */
     int side_pane_width;
     CajaSidebar *current_side_panel;


### PR DESCRIPTION
**Requested by @tatanka on the Ubuntu MATE Community:**
https://ubuntu-mate.community/t/feature-request-caja/24937

Already, the presence and position of the sidebar in navigation windows is recorded, and all future navigation windows will open up by default with the user's chosen sidebar preferences.  This commit gives that same flexibility to the extra pane:  If the user likes the extra pane, when they open it, Caja will record to open the extra pane by default; and it will also record the position of the handle of the extra pane, so that if the user likes the primary pane to take up 40% of the navigation area and the extra pane 60%, then Caja will open up the panes to that position by default.