### PR TITLE
Fix crash while browsing Windows Network

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -2534,7 +2534,8 @@ update_info_internal (CajaFile *file,
 				(file->details->directory, file);
 
 			g_clear_pointer (&file->details->name, g_ref_string_release);
-			if (eel_strcmp (file->details->display_name, name) == 0) {
+			if (file->details->display_name &&
+			    strcmp (file->details->display_name, name) == 0) {
 				file->details->name = g_ref_string_acquire (file->details->display_name);
 			} else {
 				file->details->name = g_ref_string_new (name);
@@ -4099,7 +4100,7 @@ caja_file_peek_display_name (CajaFile *file)
 		}
 	}
 
-	return file->details->display_name;
+	return file->details->display_name ? file->details->display_name : "";
 }
 
 char *


### PR DESCRIPTION
This commit fixes two problems that each cause a crash while browsing the Windows Network if a computer on the network has an empty name. See #689 for more detail about how the problem happens. It sounds pretty weird for a computer to have an empty name, but it's definitely possible -- [nmbd used to have a bug](https://bugzilla.samba.org/show_bug.cgi?id=10896) that caused the autogenerated NetBIOS name to be empty if the computer's hostname was too long.

Both of these changes are basically just bringing in small fixes that have already been in Nautilus for years.