### PR TITLE
Fix build warning -Wbad-function-cast

### DIFF
--- a/eel/eel-canvas-rect-ellipse.c
+++ b/eel/eel-canvas-rect-ellipse.c
@@ -735,7 +735,12 @@ eel_canvas_rect_update (EelCanvasItem *item, double i2w_dx, double i2w_dy, gint 
         if (re->width_pixels)
             width_pixels = (int) re->width;
         else
-            width_pixels = (int) floor (re->width * re->item.canvas->pixels_per_unit + 0.5);
+        {
+            double pixels;
+
+            pixels = floor (re->width * re->item.canvas->pixels_per_unit + 0.5);
+            width_pixels = (int) pixels;
+        }
 
         width_lt = width_pixels / 2;
         width_rb = (width_pixels + 1) / 2;

--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -2286,10 +2286,12 @@ scroll_to (EelCanvas *canvas, int cx, int cy)
     int scroll_width, scroll_height;
     int right_limit, bottom_limit;
     int old_zoom_xofs, old_zoom_yofs;
-    int changed_x = FALSE, changed_y = FALSE;
+    gboolean changed_x;
+    gboolean changed_y;
     int canvas_width, canvas_height;
     GtkAllocation allocation;
     GtkAdjustment *vadjustment, *hadjustment;
+    gdouble adjustment_value;
     guint width, height;
 
     gtk_widget_get_allocation (GTK_WIDGET (canvas), &allocation);
@@ -2373,22 +2375,25 @@ scroll_to (EelCanvas *canvas, int cx, int cy)
     hadjustment = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (canvas));
     vadjustment = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (canvas));
 
-    if (((int) gtk_adjustment_get_value (hadjustment)) != cx)
-    {
-        gtk_adjustment_set_value (hadjustment, cx);
-        changed_x = TRUE;
-    }
+    adjustment_value = gtk_adjustment_get_value (hadjustment);
+    changed_x = ((int) adjustment_value) != cx;
+    if (changed_x)
+        gtk_adjustment_set_value (hadjustment,
+                                  (gdouble) cx);
 
-    if (((int) gtk_adjustment_get_value (vadjustment)) != cy)
-    {
-        gtk_adjustment_set_value (vadjustment, cy);
-        changed_y = TRUE;
-    }
+    adjustment_value = gtk_adjustment_get_value (vadjustment);
+    changed_y = ((int) adjustment_value) != cy;
+    if (changed_y)
+        gtk_adjustment_set_value (vadjustment,
+                                  (gdouble) cy);
 
     gtk_layout_get_size (&canvas->layout, &width, &height);
-    if ((scroll_width != (int) width )|| (scroll_height != (int) height))
+    if ((scroll_width  != (int) width) ||
+        (scroll_height != (int) height))
     {
-        gtk_layout_set_size (GTK_LAYOUT (canvas), scroll_width, scroll_height);
+        gtk_layout_set_size (GTK_LAYOUT (canvas),
+                             (guint) scroll_width,
+                             (guint) scroll_height);
     }
 
     /* Signal GtkLayout that it should do a redraw. */

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -7968,6 +7968,7 @@ caja_icon_container_set_zoom_level (CajaIconContainer *container, int new_level)
     CajaIconContainerDetails *details;
     int pinned_level;
     double pixels_per_unit;
+    guint icon_size;
 
     details = container->details;
 
@@ -7990,8 +7991,8 @@ caja_icon_container_set_zoom_level (CajaIconContainer *container, int new_level)
 
     details->zoom_level = pinned_level;
 
-    pixels_per_unit = (double) caja_get_icon_size_for_zoom_level (pinned_level)
-                      / CAJA_ICON_SIZE_STANDARD;
+    icon_size = caja_get_icon_size_for_zoom_level (pinned_level);
+    pixels_per_unit = ((double) icon_size) / ((double) CAJA_ICON_SIZE_STANDARD);
     eel_canvas_set_pixels_per_unit (EEL_CANVAS (container), pixels_per_unit);
 
     invalidate_labels (container);

--- a/libcaja-private/caja-icon-info.c
+++ b/libcaja-private/caja-icon-info.c
@@ -682,7 +682,10 @@ caja_get_icon_size_for_zoom_level (CajaZoomLevel zoom_level)
 float
 caja_get_relative_icon_size_for_zoom_level (CajaZoomLevel zoom_level)
 {
-    return (float)caja_get_icon_size_for_zoom_level (zoom_level) / CAJA_ICON_SIZE_STANDARD;
+    guint icon_size;
+
+    icon_size = caja_get_icon_size_for_zoom_level (zoom_level);
+    return ((float) icon_size) / ((float) CAJA_ICON_SIZE_STANDARD);
 }
 
 guint

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -5675,14 +5675,17 @@ update_preview_callback (GtkFileChooser *icon_chooser,
 
 		if (gdk_pixbuf_get_width (pixbuf) > PREVIEW_IMAGE_WIDTH) {
 			double scale;
+			gint   height;
+			gint   width;
 
-			scale = (double)gdk_pixbuf_get_height (pixbuf) /
-				gdk_pixbuf_get_width (pixbuf);
+			height = gdk_pixbuf_get_height (pixbuf);
+			width = gdk_pixbuf_get_width (pixbuf);
+			scale = ((double) height) / ((double) width);
 
 			scaled_pixbuf = gdk_pixbuf_scale_simple
 				(pixbuf,
 				 PREVIEW_IMAGE_WIDTH,
-				 scale * PREVIEW_IMAGE_WIDTH,
+				 (int) (scale * (double) PREVIEW_IMAGE_WIDTH),
 				 GDK_INTERP_HYPER);
 			g_object_unref (pixbuf);
 			pixbuf = scaled_pixbuf;

--- a/test/test-eel-pixbuf-scale.c
+++ b/test/test-eel-pixbuf-scale.c
@@ -11,6 +11,8 @@ main (int argc, char* argv[])
 	GdkPixbuf *pixbuf, *scaled;
 	GError *error;
 	gint64 t1, t2;
+	int width;
+	int height;
 
 	test_init (&argc, &argv);
 
@@ -27,9 +29,11 @@ main (int argc, char* argv[])
 		exit (1);
 	}
 
+	width = gdk_pixbuf_get_width (pixbuf);
+        height = gdk_pixbuf_get_height (pixbuf);
 	printf ("scale factors: %f, %f\n",
-		(double)gdk_pixbuf_get_width(pixbuf)/DEST_WIDTH,
-		(double)gdk_pixbuf_get_height(pixbuf)/DEST_HEIGHT);
+		((double) width)  / ((double) DEST_WIDTH),
+		((double) height) / ((double) DEST_HEIGHT));
 
 	t1 = g_get_monotonic_time ();
 	scaled = eel_gdk_pixbuf_scale_down (pixbuf, DEST_WIDTH, DEST_HEIGHT);


### PR DESCRIPTION
```
eel-canvas.c:2376:16: warning: cast from function call of type 'gdouble' (aka 'double') to non-matching type 'int' [-Wbad-function-cast]
    if (((int) gtk_adjustment_get_value (hadjustment)) != cx)
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
eel-canvas.c:2382:16: warning: cast from function call of type 'gdouble' (aka 'double') to non-matching type 'int' [-Wbad-function-cast]
    if (((int) gtk_adjustment_get_value (vadjustment)) != cy)
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
eel-canvas-rect-ellipse.c:738:34: warning: cast from function call of type 'double' to non-matching type 'int' [-Wbad-function-cast]
            width_pixels = (int) floor (re->width * re->item.canvas->pixels_per_unit + 0.5);
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
caja-icon-container.c:7993:32: warning: cast from function call of type 'guint' (aka 'unsigned int') to non-matching type 'double' [-Wbad-function-cast]
    pixels_per_unit = (double) caja_get_icon_size_for_zoom_level (pinned_level)
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
caja-icon-info.c:685:19: warning: cast from function call of type 'guint' (aka 'unsigned int') to non-matching type 'float' [-Wbad-function-cast]
    return (float)caja_get_icon_size_for_zoom_level (zoom_level) / CAJA_ICON_SIZE_STANDARD;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
fm-properties-window.c:5679:20: warning: cast from function call of type 'int' to non-matching type 'double' [-Wbad-function-cast]
                        scale = (double)gdk_pixbuf_get_height (pixbuf) /
                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
test-eel-pixbuf-scale.c:31:11: warning: cast from function call of type 'int' to non-matching type 'double' [-Wbad-function-cast]
                (double)gdk_pixbuf_get_width(pixbuf)/DEST_WIDTH,
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
test-eel-pixbuf-scale.c:32:11: warning: cast from function call of type 'int' to non-matching type 'double' [-Wbad-function-cast]
                (double)gdk_pixbuf_get_height(pixbuf)/DEST_HEIGHT);
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```