### PR TITLE
Fix build warning -Wmissing-field-initializers

### DIFF
--- a/eel/eel-accessibility.c
+++ b/eel/eel-accessibility.c
@@ -218,11 +218,16 @@ eel_accessible_text_get_type (void)
     {
         const GTypeInfo tinfo =
         {
-            sizeof (AtkTextIface),
-            (GBaseInitFunc) NULL,
-            (GBaseFinalizeFunc) NULL,
-            (GClassInitFunc) NULL,
-            (GClassFinalizeFunc) NULL
+            sizeof (AtkTextIface),     /* class_size */
+            NULL,                      /* base_init */
+            NULL,                      /* base_finalize */
+            NULL,                      /* class_init */
+            NULL,                      /* class_finalize */
+            NULL,                      /* class_data */
+            0,                         /* instance_size */
+            0,                         /* n_preallocs */
+            NULL,                      /* instance_init */
+            NULL                       /* value_table */
         };
 
         type = g_type_register_static (

--- a/eel/eel-canvas-rect-ellipse.c
+++ b/eel/eel-canvas-rect-ellipse.c
@@ -101,7 +101,8 @@ eel_canvas_re_get_type (void)
             NULL,           /* class_data */
             sizeof (EelCanvasRE),
             0,              /* n_preallocs */
-            (GInstanceInitFunc) eel_canvas_re_init
+            (GInstanceInitFunc) eel_canvas_re_init,
+            NULL            /* value_table */
         };
 
         re_type = g_type_register_static (eel_canvas_item_get_type (),
@@ -465,7 +466,8 @@ eel_canvas_rect_get_type (void)
             NULL,           /* class_data */
             sizeof (EelCanvasRect),
             0,              /* n_preallocs */
-            (GInstanceInitFunc) eel_canvas_rect_init
+            (GInstanceInitFunc) eel_canvas_rect_init,
+            NULL            /* value_table */
         };
 
         rect_type = g_type_register_static (eel_canvas_re_get_type (),

--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -137,7 +137,8 @@ eel_canvas_item_get_type (void)
             NULL,           /* class_data */
             sizeof (EelCanvasItem),
             0,              /* n_preallocs */
-            (GInstanceInitFunc) eel_canvas_item_init
+            (GInstanceInitFunc) eel_canvas_item_init,
+            NULL            /* value_table */
         };
 
         canvas_item_type = g_type_register_static (G_TYPE_INITIALLY_UNOWNED,
@@ -1255,8 +1256,8 @@ eel_canvas_group_get_type (void)
             NULL,           /* class_data */
             sizeof (EelCanvasGroup),
             0,              /* n_preallocs */
-            (GInstanceInitFunc) eel_canvas_group_init
-
+            (GInstanceInitFunc) eel_canvas_group_init,
+            NULL            /* value_table */
         };
 
         group_type = g_type_register_static (eel_canvas_item_get_type (),
@@ -1851,7 +1852,8 @@ eel_canvas_get_type (void)
             NULL,           /* class_data */
             sizeof (EelCanvas),
             0,              /* n_preallocs */
-            (GInstanceInitFunc) eel_canvas_init
+            (GInstanceInitFunc) eel_canvas_init,
+            NULL            /* value_table */
         };
 
         canvas_type = g_type_register_static (gtk_layout_get_type (),

--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -2303,7 +2303,8 @@ eel_labeled_image_button_get_type (void)
             NULL, /* class_data */
             sizeof (GtkButton),
             0, /* n_preallocs */
-            (GInstanceInitFunc) NULL
+            (GInstanceInitFunc) NULL,
+            NULL /* value_table */
         };
 
         type = g_type_register_static
@@ -2331,7 +2332,8 @@ eel_labeled_image_check_button_get_type (void)
             NULL, /* class_data */
             sizeof (GtkCheckButton),
             0, /* n_preallocs */
-            (GInstanceInitFunc) NULL
+            (GInstanceInitFunc) NULL,
+            NULL /* value_table */
         };
 
         type = g_type_register_static
@@ -2359,7 +2361,8 @@ eel_labeled_image_toggle_button_get_type (void)
             NULL, /* class_data */
             sizeof (GtkToggleButton),
             0, /* n_preallocs */
-            (GInstanceInitFunc) NULL
+            (GInstanceInitFunc) NULL,
+            NULL /* value_table */
         };
 
         type = g_type_register_static
@@ -2387,7 +2390,8 @@ eel_labeled_image_radio_button_get_type (void)
             NULL, /* class_data */
             sizeof (GtkRadioButton),
             0, /* n_preallocs */
-            (GInstanceInitFunc) NULL
+            (GInstanceInitFunc) NULL,
+            NULL /* value_table */
         };
 
         type = g_type_register_static

--- a/libcaja-extension/caja-column-provider.c
+++ b/libcaja-extension/caja-column-provider.c
@@ -57,6 +57,7 @@ caja_column_provider_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-extension/caja-configurable.c
+++ b/libcaja-extension/caja-configurable.c
@@ -57,6 +57,7 @@ caja_configurable_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-extension/caja-file-info.c
+++ b/libcaja-extension/caja-file-info.c
@@ -96,6 +96,7 @@ caja_file_info_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-extension/caja-info-provider.c
+++ b/libcaja-extension/caja-info-provider.c
@@ -59,6 +59,7 @@ caja_info_provider_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-extension/caja-location-widget-provider.c
+++ b/libcaja-extension/caja-location-widget-provider.c
@@ -57,6 +57,7 @@ caja_location_widget_provider_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-extension/caja-menu-item.c
+++ b/libcaja-extension/caja-menu-item.c
@@ -337,7 +337,8 @@ caja_menu_item_get_type (void)
             NULL,
             sizeof (CajaMenuItem),
             0,
-            (GInstanceInitFunc)caja_menu_item_instance_init
+            (GInstanceInitFunc)caja_menu_item_instance_init,
+            NULL
         };
 
         type = g_type_register_static

--- a/libcaja-extension/caja-menu-provider.c
+++ b/libcaja-extension/caja-menu-provider.c
@@ -71,6 +71,7 @@ caja_menu_provider_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-extension/caja-property-page-provider.c
+++ b/libcaja-extension/caja-property-page-provider.c
@@ -58,6 +58,7 @@ caja_property_page_provider_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-extension/caja-property-page.c
+++ b/libcaja-extension/caja-property-page.c
@@ -239,7 +239,8 @@ caja_property_page_get_type (void)
             NULL,
             sizeof (CajaPropertyPage),
             0,
-            (GInstanceInitFunc)caja_property_page_instance_init
+            (GInstanceInitFunc)caja_property_page_instance_init,
+            NULL
         };
 
         type = g_type_register_static

--- a/libcaja-extension/caja-widget-view-provider.c
+++ b/libcaja-extension/caja-widget-view-provider.c
@@ -55,6 +55,7 @@ caja_widget_view_provider_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-private/caja-query.c
+++ b/libcaja-private/caja-query.c
@@ -332,7 +332,7 @@ static GMarkupParser parser =
 static CajaQuery *
 caja_query_parse_xml (char *xml, gsize xml_len)
 {
-    ParserInfo info = { NULL };
+    ParserInfo info = { NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE };
     GMarkupParseContext *ctx;
 
     info.query = caja_query_new ();

--- a/libcaja-private/caja-sidebar-provider.c
+++ b/libcaja-private/caja-sidebar-provider.c
@@ -47,6 +47,7 @@ caja_sidebar_provider_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-private/caja-sidebar.c
+++ b/libcaja-private/caja-sidebar.c
@@ -72,6 +72,7 @@ caja_sidebar_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-private/caja-view.c
+++ b/libcaja-private/caja-view.c
@@ -80,6 +80,7 @@ caja_view_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-private/caja-window-info.c
+++ b/libcaja-private/caja-window-info.c
@@ -112,6 +112,7 @@ caja_window_info_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/libcaja-private/caja-window-slot-info.c
+++ b/libcaja-private/caja-window-slot-info.c
@@ -78,6 +78,7 @@ caja_window_slot_info_get_type (void)
             NULL,
             0,
             0,
+            NULL,
             NULL
         };
 

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -1945,8 +1945,7 @@ caja_application_local_command_line (GApplication *application,
         { "select", 's', 0, G_OPTION_ARG_NONE, &select_uris,
           N_("Select specified URI in parent folder."), NULL },
         { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &remaining, NULL,  N_("[URI...]") },
-
-        { NULL }
+        { NULL, '\0', 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
     };
     GOptionContext *context;
     GError *error = NULL;


### PR DESCRIPTION
```
git submodule init
git submodule update --recursive --remote
CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make
```

```
eel-accessibility.c:226:9: warning: missing field 'class_data' initializer [-Wmissing-field-initializers]
eel-canvas.c:141:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
eel-canvas.c:1260:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
eel-canvas.c:1855:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
eel-canvas-rect-ellipse.c:105:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
eel-canvas-rect-ellipse.c:469:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
eel-labeled-image.c:2307:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
eel-labeled-image.c:2335:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
eel-labeled-image.c:2363:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
eel-labeled-image.c:2391:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-column-provider.c:61:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-widget-view-provider.c:59:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-file-info.c:100:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-info-provider.c:63:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-location-widget-provider.c:61:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-menu-item.c:341:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-menu-provider.c:75:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-property-page-provider.c:62:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-property-page.c:243:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-configurable.c:61:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-sidebar-provider.c:51:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-sidebar.c:76:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-query.c:335:30: warning: missing field 'in_text' initializer [-Wmissing-field-initializers]
caja-view.c:84:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-window-info.c:116:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-window-slot-info.c:82:9: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
caja-application.c:1949:16: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
```