### PR TITLE
caja-bookmark: Fix build warning -Wlogical-not-parentheses

### DIFF
--- a/libcaja-private/caja-bookmark.c
+++ b/libcaja-private/caja-bookmark.c
@@ -330,7 +330,7 @@ caja_bookmark_icon_is_different (CajaBookmark *bookmark,
         return TRUE;
     }
 
-    return !g_icon_equal (bookmark->details->icon, new_icon) != 0;
+    return !g_icon_equal (bookmark->details->icon, new_icon);
 }
 
 /**


### PR DESCRIPTION
```
git submodule init
git submodule update --recursive --remote
CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make
```
```
caja-bookmark.c:333:12: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
    return !g_icon_equal (bookmark->details->icon, new_icon) != 0;
           ^                                                 ~~
caja-bookmark.c:333:12: note: add parentheses after the '!' to evaluate the comparison first
    return !g_icon_equal (bookmark->details->icon, new_icon) != 0;
           ^
            (                                                    )
caja-bookmark.c:333:12: note: add parentheses around left hand side expression to silence this warning
    return !g_icon_equal (bookmark->details->icon, new_icon) != 0;
           ^
           (                                                )
```