### PR TITLE
Properly initialize IconKey::scale

### DIFF
--- a/libcaja-private/caja-icon-info.c
+++ b/libcaja-private/caja-icon-info.c
@@ -307,6 +307,7 @@ icon_key_new (GIcon *icon,
 
     key = g_slice_new (IconKey);
     key->icon = g_object_ref (icon);
+    key->scale = scale;
     key->size = size;
 
     return key;


### PR DESCRIPTION
This value is used to look up icons in the cache, but somehow was not properly initialized.  It was introduced in cfd502157420406aa56a6b5319f0bd8dc90df8e4 but lost in refactoring in 6c423bc27d2803f3259bcca9f518a1c22b2b5fd1.

Might or might not be related to #1630.