### PR TITLE
Fix file conflict dialog crashes

### DIFF
--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -672,6 +672,39 @@ caja_file_conflict_dialog_init (CajaFileConflictDialog *fcd)
 }
 
 static void
+do_dispose (GObject *self)
+{
+    CajaFileConflictDialogPrivate *details =
+        CAJA_FILE_CONFLICT_DIALOG (self)->details;
+
+    if (details->handle != NULL)
+    {
+        caja_file_list_cancel_call_when_ready (details->handle);
+        details->handle = NULL;
+    }
+
+    if (details->src_handler_id)
+    {
+        g_signal_handler_disconnect (details->source, details->src_handler_id);
+        caja_file_monitor_remove (details->source, self);
+        details->src_handler_id = 0;
+    }
+
+    if (details->dest_handler_id)
+    {
+        g_signal_handler_disconnect (details->destination, details->dest_handler_id);
+        caja_file_monitor_remove (details->destination, self);
+        details->dest_handler_id = 0;
+    }
+
+    g_clear_pointer (&details->source, caja_file_unref);
+    g_clear_pointer (&details->destination, caja_file_unref);
+    g_clear_pointer (&details->dest_dir, caja_file_unref);
+
+    G_OBJECT_CLASS (caja_file_conflict_dialog_parent_class)->dispose (self);
+}
+
+static void
 do_finalize (GObject *self)
 {
     CajaFileConflictDialogPrivate *details =
@@ -679,33 +712,13 @@ do_finalize (GObject *self)
 
     g_free (details->conflict_name);
 
-    if (details->handle != NULL)
-    {
-        caja_file_list_cancel_call_when_ready (details->handle);
-    }
-
-    if (details->src_handler_id)
-    {
-        g_signal_handler_disconnect (details->source, details->src_handler_id);
-        caja_file_monitor_remove (details->source, self);
-    }
-
-    if (details->dest_handler_id)
-    {
-        g_signal_handler_disconnect (details->destination, details->dest_handler_id);
-        caja_file_monitor_remove (details->destination, self);
-    }
-
-    caja_file_unref (details->source);
-    caja_file_unref (details->destination);
-    caja_file_unref (details->dest_dir);
-
     G_OBJECT_CLASS (caja_file_conflict_dialog_parent_class)->finalize (self);
 }
 
 static void
 caja_file_conflict_dialog_class_init (CajaFileConflictDialogClass *klass)
 {
+    G_OBJECT_CLASS (klass)->dispose = do_dispose;
     G_OBJECT_CLASS (klass)->finalize = do_finalize;
 }
 

--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -68,27 +68,18 @@ G_DEFINE_TYPE_WITH_PRIVATE (CajaFileConflictDialog,
                             GTK_TYPE_DIALOG);
 
 static void
-file_icons_changed (CajaFile *file,
-                    CajaFileConflictDialog *fcd)
+file_icons_changed (CajaFile  *file,
+                    GtkWidget *widget)
 {
     cairo_surface_t *surface;
 
-    surface = caja_file_get_icon_surface (fcd->details->destination,
+    surface = caja_file_get_icon_surface (file,
                                           CAJA_ICON_SIZE_LARGE,
                                           FALSE,
-                                          gtk_widget_get_scale_factor (fcd->details->dest_image),
+                                          gtk_widget_get_scale_factor (widget),
                                           CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
 
-    gtk_image_set_from_surface (GTK_IMAGE (fcd->details->dest_image), surface);
-    cairo_surface_destroy (surface);
-
-    surface = caja_file_get_icon_surface (fcd->details->source,
-                                          CAJA_ICON_SIZE_LARGE,
-                                          FALSE,
-                                          gtk_widget_get_scale_factor (fcd->details->src_image),
-                                          CAJA_FILE_ICON_FLAGS_USE_THUMBNAILS);
-
-    gtk_image_set_from_surface (GTK_IMAGE (fcd->details->src_image), surface);
+    gtk_image_set_from_surface (GTK_IMAGE (widget), surface);
     cairo_surface_destroy (surface);
 }
 
@@ -371,9 +362,11 @@ file_list_ready_cb (GList *files,
     caja_file_monitor_add (dest, fcd, CAJA_FILE_ATTRIBUTES_FOR_ICON);
 
     details->src_handler_id = g_signal_connect (src, "changed",
-                              G_CALLBACK (file_icons_changed), fcd);
+                                                G_CALLBACK (file_icons_changed),
+                                                fcd->details->src_image);
     details->dest_handler_id = g_signal_connect (dest, "changed",
-                               G_CALLBACK (file_icons_changed), fcd);
+                                                 G_CALLBACK (file_icons_changed),
+                                                 fcd->details->dest_image);
 }
 
 static void

--- a/libcaja-private/caja-file-conflict-dialog.c
+++ b/libcaja-private/caja-file-conflict-dialog.c
@@ -46,8 +46,6 @@ struct _CajaFileConflictDialogPrivate
 
     gchar *conflict_name;
     CajaFileListHandle *handle;
-    gulong src_handler_id;
-    gulong dest_handler_id;
 
     /* UI objects */
     GtkWidget *titles_vbox;
@@ -361,12 +359,12 @@ file_list_ready_cb (GList *files,
     caja_file_monitor_add (src, fcd, CAJA_FILE_ATTRIBUTES_FOR_ICON);
     caja_file_monitor_add (dest, fcd, CAJA_FILE_ATTRIBUTES_FOR_ICON);
 
-    details->src_handler_id = g_signal_connect (src, "changed",
-                                                G_CALLBACK (file_icons_changed),
-                                                fcd->details->src_image);
-    details->dest_handler_id = g_signal_connect (dest, "changed",
-                                                 G_CALLBACK (file_icons_changed),
-                                                 fcd->details->dest_image);
+    g_signal_connect_object (src, "changed",
+                             G_CALLBACK (file_icons_changed),
+                             fcd->details->src_image, 0);
+    g_signal_connect_object (dest, "changed",
+                             G_CALLBACK (file_icons_changed),
+                             fcd->details->dest_image, 0);
 }
 
 static void
@@ -682,19 +680,12 @@ do_dispose (GObject *self)
         caja_file_list_cancel_call_when_ready (details->handle);
         details->handle = NULL;
     }
-
-    if (details->src_handler_id)
+    else
     {
-        g_signal_handler_disconnect (details->source, details->src_handler_id);
-        caja_file_monitor_remove (details->source, self);
-        details->src_handler_id = 0;
-    }
-
-    if (details->dest_handler_id)
-    {
-        g_signal_handler_disconnect (details->destination, details->dest_handler_id);
-        caja_file_monitor_remove (details->destination, self);
-        details->dest_handler_id = 0;
+        if (details->source)
+            caja_file_monitor_remove (details->source, self);
+        if (details->destination)
+            caja_file_monitor_remove (details->destination, self);
     }
 
     g_clear_pointer (&details->source, caja_file_unref);


### PR DESCRIPTION
Fix #1630.

This contains 3 separate but fairly closely related changes (see each commit for details):

1) Fix reference to objects by releasing them in `dispose()` as we ought to instead of waiting for `finalize()`.  This is the real fix, and is the right thing to do in the GObject world: no object is supposed to hold a reference to any other object after `dispose()`.
2) Simplification of the icon update code, which optimizes it as well and allows for improving safety in 3 -- thanks @rbuj
3) thanks to 2, make use of `g_signal_connect_object()` to improve safety of the handler by making sure all parameters are valid at signal dispatch time.

1 alone is enough of a fix, but 2 is a nice improvement of the code, and 3 makes things safer.  Actually, 2+3 alone are also a fix for #1630, although not as thorough.