### PR TITLE
caja-bookmark: 'caja_bookmark_get_uri (CajaBookmark *)' may return NULL

### DIFF
--- a/libcaja-private/caja-bookmark.c
+++ b/libcaja-private/caja-bookmark.c
@@ -274,11 +274,13 @@ char *
 caja_bookmark_get_uri (CajaBookmark *bookmark)
 {
     GFile *file;
-    char *uri;
+    char *uri = NULL;
 
-    file = caja_bookmark_get_location (bookmark);
-    uri = g_file_get_uri (file);
-    g_object_unref (file);
+    if ((file = caja_bookmark_get_location (bookmark)) != NULL)
+    {
+        uri = g_file_get_uri (file);
+        g_object_unref (file);
+    }
     return uri;
 }
 

--- a/src/caja-bookmarks-sidebar.c
+++ b/src/caja-bookmarks-sidebar.c
@@ -328,10 +328,7 @@ loading_uri_callback (CajaWindowInfo       *window,
             gtk_tree_model_get (model, &iter,
                                 BOOKMARKS_SIDEBAR_COLUMN_BOOKMARK, &bookmark,
                                 -1);
-
-            uri = caja_bookmark_get_uri (bookmark);
-
-            if (uri != NULL)
+            if (bookmark && ((uri = caja_bookmark_get_uri (bookmark)) != NULL))
             {
                 if (strcmp (uri, location) == 0)
                 {


### PR DESCRIPTION
When the uri is changed, caja automatically checks whether the uri exists in the sidebar to select it. It always checks in  places, bookmarks, ... . If the bookmarks list is empty, then some critical error messages are obtained such as:
```
GLib-GIO-CRITICAL **: 08:40:56.086: g_file_get_uri: assertion 'G_IS_FILE (file)' failed
```
When the bookmarks list is empty, the variable bookmark is NULL:
https://github.com/mate-desktop/caja/blob/141440bf89af9df9b64f77ac3a1c0fc63b768989/src/caja-bookmarks-sidebar.c#L332-L343