### PR TITLE
caja-extensions: print filename when caja failed to open keys file

### DIFF
--- a/libcaja-private/caja-extensions.c
+++ b/libcaja-private/caja-extensions.c
@@ -67,7 +67,7 @@ extension_new (gchar *filename, gboolean state, gboolean python, GObject *module
     }
     else
     {
-        caja_debug_log (FALSE, CAJA_DEBUG_LOG_DOMAIN_USER, "Error loading keys from file: %s\n", error->message);
+        caja_debug_log (FALSE, CAJA_DEBUG_LOG_DOMAIN_USER, "Error loading keys from file \"%s\": %s\n", extension_filename, error->message);
         g_error_free (error);
     }
     g_free (extension_filename);


### PR DESCRIPTION
enable caja logging
```
$ cat << EOF > ~/caja-debug-log.conf
[debug log]
max lines = 1000
enable domains = async;GLog
EOF
```
restart caja
```
$ killall -9 caja
```
check caja log
```
$ kill -s SIGUSR1 $(pgrep caja) && grep "Error loading keys from file" ~/caja-debug-log.txt
0x2585090 2022/07/30 09:34:05.955040 (USER): Error loading keys from file "/usr/share/caja/extensions/libcaja-seahorse.caja-extension": El fitxer o directori no existeix
0x2585090 2022/07/30 09:34:05.967419 (USER): Error loading keys from file "/usr/share/caja/extensions/libcaja-actions-menu.caja-extension": El fitxer o directori no existeix
0x2585090 2022/07/30 09:34:05.967953 (USER): Error loading keys from file "/usr/share/caja/extensions/libcaja-actions-tracker.caja-extension": El fitxer o directori no existeix
```