### PR TITLE
Make CajaIconData type less confusing

### DIFF
--- a/libcaja-private/caja-icon-container.h
+++ b/libcaja-private/caja-icon-container.h
@@ -45,7 +45,7 @@
 #define CAJA_ICON_CONTAINER_ICON_DATA(pointer) \
 	((CajaIconData *) (pointer))
 
-typedef struct CajaIconData CajaIconData;
+typedef void CajaIconData;
 
 typedef void (* CajaIconCallback) (CajaIconData *icon_data,
                                    gpointer callback_data);


### PR DESCRIPTION
This is actually an opaque type, and there is no definition of struct CajaIconData anywhere.  This actually doesn't change anything as the non-existent struct is equivalent to any other incomplete type, and works fine so long as the pointers are not dereferenced using that incomplete type.

However, change this to an explicit `void` to make it clear it's an opaque pointer and stop people from looking for a struct CajaIconData that is nowhere to be found.

---

Alternatively we could replace all use of `CajaIconData*` with `gpointer`, but that's a much more intrusive change.