### PR TITLE
icon view: Fix positioning overflowing icons on the desktop

### DIFF
--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -7687,19 +7687,6 @@ assign_icon_position (CajaIconContainer *container,
 }
 
 static void
-finish_adding_icon (CajaIconContainer *container,
-                    CajaIcon *icon)
-{
-    caja_icon_container_update_icon (container, icon);
-    eel_canvas_item_show (EEL_CANVAS_ITEM (icon->item));
-
-    g_signal_connect_object (icon->item, "event",
-                             G_CALLBACK (item_event_callback), container, 0);
-
-    g_signal_emit (container, signals[ICON_ADDED], 0, icon->data);
-}
-
-static void
 finish_adding_new_icons (CajaIconContainer *container)
 {
     GList *p, *new_icons, *no_position_icons, *semi_position_icons;
@@ -7717,6 +7704,7 @@ finish_adding_new_icons (CajaIconContainer *container)
     for (p = new_icons; p != NULL; p = p->next)
     {
         icon = p->data;
+        caja_icon_container_update_icon (container, icon);
         if (icon->has_lazy_position)
         {
             assign_icon_position (container, icon);
@@ -7727,7 +7715,12 @@ finish_adding_new_icons (CajaIconContainer *container)
             no_position_icons = g_list_prepend (no_position_icons, icon);
         }
 
-        finish_adding_icon (container, icon);
+        eel_canvas_item_show (EEL_CANVAS_ITEM (icon->item));
+
+        g_signal_connect_object (icon->item, "event",
+                                 G_CALLBACK (item_event_callback), container, 0);
+
+        g_signal_emit (container, signals[ICON_ADDED], 0, icon->data);
     }
     g_list_free (new_icons);
 


### PR DESCRIPTION
Properly update the icon data before placing the icon, because positioning might depend on full icon contents on the desktop, whereas updating contents don't care about position.

When an icon position overflows the desktop area, it is clamped to stay in the visible area, but this computation depends on accurate icon and label sizes, which is only available when the icon is fully loaded.

Fix the code to first load the contents and then position instead of the other way around, which was actually trivial.

Note that visible positions were most often correct anyway for two reasons:

1. Most of the time icons do not overflow, as they are positioned on the final desktop size anyway.  It however can easily happen reducing monitor resolution or increasing desktop view zoom. (see also #1676)
2. A second layout pass happens most of the time (I'm not yet sure why and when though), but not when an update is triggered before the previous one terminated (e.g. quickly hitting F5 twice).