### PR TITLE
Fix handling of invalid x-special/mate-icon-list drops

### DIFF
--- a/libcaja-private/caja-dnd.c
+++ b/libcaja-private/caja-dnd.c
@@ -204,7 +204,7 @@ caja_drag_build_selection_list (GtkSelectionData *data)
         if (*p == '\n' || *p == '\0')
         {
             result = g_list_prepend (result, item);
-            if (p == 0)
+            if (*p != '\n')
             {
                 g_warning ("Invalid x-special/mate-icon-list data received: "
                            "missing newline character.");


### PR DESCRIPTION
`p` actually could never be `0` (because of the NULL check on the `memchr()` call), but the intended behavior is `*p == '\0'`: the containing condition checks for either a truncated data (`*p == '\0'`) or no geometry information (`*p == '\n'`).

I replaced the check to be `*p != '\n'` instead of `*p == '\0'` to make this more robust as the actual issue is anything but a newline, the fact it can only be a NUL otherwise is incidental to the enclosing check, but not really relevant at this level.  This is also in line with the actual error message.

Found by cppcheck: https://caja.mate-desktop.dev/2022-11-23-174623-5790-cppcheck@ae663c369cf2_desktop-no-overflow/16.html#line-204

----

Normally you won't see any change in any case, unless you manage to drop invalid data somehow.