### PR TITLE
Remove dead code found by cppcheck

### DIFF
--- a/libcaja-private/caja-icon-dnd.c
+++ b/libcaja-private/caja-icon-dnd.c
@@ -620,8 +620,6 @@ caja_icon_container_selection_items_local (CajaIconContainer *container,
     /* must have at least one item */
     g_assert (items);
 
-    result = FALSE;
-
     /* get the URI associated with the container */
     container_uri_string = get_container_uri (container);
 

--- a/libcaja-private/caja-mime-application-chooser.c
+++ b/libcaja-private/caja-mime-application-chooser.c
@@ -52,7 +52,6 @@ struct _CajaMimeApplicationChooserDetails
     guint refresh_timeout;
 
     GtkWidget *label;
-    GtkWidget *entry;
     GtkWidget *treeview;
     GtkWidget *remove_button;
 

--- a/libcaja-private/caja-search-directory-file.c
+++ b/libcaja-private/caja-search-directory-file.c
@@ -39,11 +39,6 @@
 #include "caja-file-utilities.h"
 #include "caja-search-directory.h"
 
-struct CajaSearchDirectoryFileDetails
-{
-    CajaSearchDirectory *search_directory;
-};
-
 G_DEFINE_TYPE(CajaSearchDirectoryFile, caja_search_directory_file, CAJA_TYPE_FILE);
 
 static void

--- a/libcaja-private/caja-search-directory-file.h
+++ b/libcaja-private/caja-search-directory-file.h
@@ -40,12 +40,9 @@
 #define CAJA_SEARCH_DIRECTORY_FILE_GET_CLASS(obj) \
   (G_TYPE_INSTANCE_GET_CLASS ((obj), CAJA_TYPE_SEARCH_DIRECTORY_FILE, CajaSearchDirectoryFileClass))
 
-typedef struct CajaSearchDirectoryFileDetails CajaSearchDirectoryFileDetails;
-
 typedef struct
 {
     CajaFile parent_slot;
-    CajaSearchDirectoryFileDetails *details;
 } CajaSearchDirectoryFile;
 
 typedef struct

--- a/libcaja-private/caja-search-directory.c
+++ b/libcaja-private/caja-search-directory.c
@@ -49,7 +49,6 @@ struct CajaSearchDirectoryDetails
     gboolean search_finished;
 
     GList *files;
-    GHashTable *file_hash;
 
     GList *monitor_list;
     GList *callback_list;

--- a/libcaja-private/caja-search-engine-simple.c
+++ b/libcaja-private/caja-search-engine-simple.c
@@ -42,7 +42,6 @@ typedef struct
     GList *mime_types;
     GList *tags;
     char **words;
-    GList *found_list;
 
     GQueue *directories; /* GFiles */
 

--- a/libcaja-private/caja-search-engine.c
+++ b/libcaja-private/caja-search-engine.c
@@ -30,11 +30,6 @@
 #include "caja-search-engine-simple.h"
 #include "caja-search-engine-tracker.h"
 
-struct CajaSearchEngineDetails
-{
-    int none;
-};
-
 enum
 {
     HITS_ADDED,
@@ -50,30 +45,9 @@ G_DEFINE_ABSTRACT_TYPE (CajaSearchEngine,
                         caja_search_engine,
                         G_TYPE_OBJECT);
 
-static GObjectClass *parent_class = NULL;
-
-static void
-finalize (GObject *object)
-{
-    CajaSearchEngine *engine;
-
-    engine = CAJA_SEARCH_ENGINE (object);
-
-    g_free (engine->details);
-
-    EEL_CALL_PARENT (G_OBJECT_CLASS, finalize, (object));
-}
-
 static void
 caja_search_engine_class_init (CajaSearchEngineClass *class)
 {
-    GObjectClass *gobject_class;
-
-    parent_class = g_type_class_peek_parent (class);
-
-    gobject_class = G_OBJECT_CLASS (class);
-    gobject_class->finalize = finalize;
-
     signals[HITS_ADDED] =
         g_signal_new ("hits-added",
                       G_TYPE_FROM_CLASS (class),
@@ -118,7 +92,6 @@ caja_search_engine_class_init (CajaSearchEngineClass *class)
 static void
 caja_search_engine_init (CajaSearchEngine *engine)
 {
-    engine->details = g_new0 (CajaSearchEngineDetails, 1);
 }
 
 CajaSearchEngine *

--- a/libcaja-private/caja-search-engine.h
+++ b/libcaja-private/caja-search-engine.h
@@ -35,12 +35,9 @@
 #define CAJA_IS_SEARCH_ENGINE_CLASS(klass)	(G_TYPE_CHECK_CLASS_TYPE ((klass), CAJA_TYPE_SEARCH_ENGINE))
 #define CAJA_SEARCH_ENGINE_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), CAJA_TYPE_SEARCH_ENGINE, CajaSearchEngineClass))
 
-typedef struct CajaSearchEngineDetails CajaSearchEngineDetails;
-
 typedef struct CajaSearchEngine
 {
     GObject parent;
-    CajaSearchEngineDetails *details;
 } CajaSearchEngine;
 
 typedef struct

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -80,8 +80,6 @@ typedef struct
     const CajaFileSortType sort_type;
     const char *metadata_text;
     const char *action;
-    const char *menu_label;
-    const char *menu_hint;
 } SortCriterion;
 
 typedef enum
@@ -125,65 +123,47 @@ static const SortCriterion sort_criteria[] =
     {
         CAJA_FILE_SORT_BY_DISPLAY_NAME,
         "name",
-        "Sort by Name",
-        N_("by _Name"),
-        N_("Keep icons sorted by name in rows")
+        "Sort by Name"
     },
     {
         CAJA_FILE_SORT_BY_SIZE,
         "size",
-        "Sort by Size",
-        N_("by _Size"),
-        N_("Keep icons sorted by size in rows")
+        "Sort by Size"
     },
     {
         CAJA_FILE_SORT_BY_SIZE_ON_DISK,
         "size_on_disk",
-        "Sort by Size on Disk",
-        N_("by S_ize on Disk"),
-        N_("Keep icons sorted by disk usage in rows")
+        "Sort by Size on Disk"
     },
     {
         CAJA_FILE_SORT_BY_TYPE,
         "type",
-        "Sort by Type",
-        N_("by _Type"),
-        N_("Keep icons sorted by type in rows")
+        "Sort by Type"
     },
     {
         CAJA_FILE_SORT_BY_MTIME,
         "modification date",
-        "Sort by Modification Date",
-        N_("by Modification _Date"),
-        N_("Keep icons sorted by modification date in rows")
+        "Sort by Modification Date"
     },
     {
         CAJA_FILE_SORT_BY_BTIME,
         "creation date",
-        "Sort by Creation Date",
-        N_("by _Creation Date"),
-        N_("Keep icons sorted by creation date in rows")
+        "Sort by Creation Date"
     },
     {
         CAJA_FILE_SORT_BY_EMBLEMS,
         "emblems",
-        "Sort by Emblems",
-        N_("by _Emblems"),
-        N_("Keep icons sorted by emblems in rows")
+        "Sort by Emblems"
     },
     {
         CAJA_FILE_SORT_BY_TRASHED_TIME,
         "trashed",
-        "Sort by Trash Time",
-        N_("by T_rash Time"),
-        N_("Keep icons sorted by trash time in rows")
+        "Sort by Trash Time"
     },
     {
         CAJA_FILE_SORT_BY_EXTENSION,
         "extension",
-        "Sort by Extension",
-        N_("by E_xtension"),
-        N_("Keep icons sorted by reversed extension segments in rows")
+        "Sort by Extension"
     }
 };
 

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -98,7 +98,6 @@ struct _FMPropertiesWindowPrivate {
 
 	GtkLabel *name_label;
 	GtkWidget *name_field;
-	unsigned int name_row;
 	char *pending_name;
 
 	GtkLabel *directory_contents_title_field;

--- a/src/file-manager/fm-tree-model.c
+++ b/src/file-manager/fm-tree-model.c
@@ -119,12 +119,6 @@ struct FMTreeModelRoot
     TreeNode *root_node;
 };
 
-typedef struct
-{
-    CajaDirectory *directory;
-    FMTreeModel *model;
-} DoneLoadingParameters;
-
 static void fm_tree_model_tree_model_init (GtkTreeModelIface *iface);
 static void schedule_monitoring_update     (FMTreeModel *model);
 static void destroy_node_without_reporting (FMTreeModel *model,

--- a/src/file-manager/fm-tree-view.c
+++ b/src/file-manager/fm-tree-view.c
@@ -101,7 +101,6 @@ struct FMTreeViewDetails
     GtkWidget *popup_cut;
     GtkWidget *popup_copy;
     GtkWidget *popup_paste;
-    GtkWidget *popup_rename;
     GtkWidget *popup_trash;
     GtkWidget *popup_delete;
     GtkWidget *popup_properties;
@@ -113,12 +112,6 @@ struct FMTreeViewDetails
 
     guint selection_changed_timer;
 };
-
-typedef struct
-{
-    GList *uris;
-    FMTreeView *view;
-} PrependURIParameters;
 
 static GdkAtom copied_files_atom;
 


### PR DESCRIPTION
This removes various unused code, based on a [cppcheck report](https://caja.mate-desktop.dev/2022-11-23-174623-5790-cppcheck@ae663c369cf2_desktop-no-overflow/).  I carefully checked everything the best I could (not simply trusting the reports), but most of it was accurate.  Most stuff predates MATE repository so I can only guess they are leftovers from some old refactoring.