### PR TITLE
directory: Include hidden files in properties window totals

### DIFF
--- a/libcaja-private/caja-directory-async.c
+++ b/libcaja-private/caja-directory-async.c
@@ -2823,11 +2823,6 @@ deep_count_one (DeepCountState *state,
     CajaFile *file;
     gboolean is_seen_inode;
 
-    if (should_skip_file (NULL, info))
-    {
-        return;
-    }
-
     is_seen_inode = seen_inode (state, info);
     if (!is_seen_inode)
     {


### PR DESCRIPTION
This change will make the directory properties info always count "hidden" dotfiles in the count and size.
based on https://gitlab.gnome.org/GNOME/nautilus/-/merge_requests/821/diffs

fixes #527, fixes #738