### PR TITLE
Enable showing in Budgie Desktop and XFCE

### DIFF
--- a/data/caja-browser.desktop.in.in
+++ b/data/caja-browser.desktop.in.in
@@ -12,4 +12,4 @@ Type=Application
 Categories=GTK;System;Core;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=files;browser;manager;MATE;
-OnlyShowIn=MATE;
+OnlyShowIn=Budgie;MATE;XFCE;


### PR DESCRIPTION
This PR enables the displaying of Caja (as a file manager) for use in Budgie Desktop and XFCE. Prior to this commit, it would only be able accessible in MATE or with downstreams like Fedora patching in the support. The addition of these is important as file managers such as Nautilus adopt libadwaita and begin to directly come into conflict with user theming choices.