### PR TITLE
wayland: initial support for showing the desktop

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -40,6 +40,7 @@ requires:
     - libgirepository1.0-dev
     - libglib2.0-dev
     - libgtk-3-dev
+    - libgtk-layer-shell-dev
     - libmate-desktop-dev
     - libnotify-dev
     - libpango1.0-dev
@@ -62,6 +63,8 @@ requires:
     - cppcheck-htmlreport
     - git
     - gcc
+    - gtk3-devel
+    - gtk-layer-shell-devel
     - make
     - redhat-rpm-config
     - dbus-glib-devel
@@ -95,6 +98,7 @@ requires:
     - libgirepository1.0-dev
     - libglib2.0-dev
     - libgtk-3-dev
+    - libgtk-layer-shell-dev
     - libmate-desktop-dev
     - libnotify-dev
     - libpango1.0-dev

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.60)
 
 dnl ===========================================================================
 
-m4_define(gdkpixbuf_minver,           2.36.5)
+m4_define(gdkpixbuf_minver,            2.36.5)
 m4_define(glib_minver,                 2.58.1)
 m4_define(gio_minver,                  2.50.0)
 m4_define(mate_desktop_minver,         1.17.3)
@@ -13,6 +13,7 @@ m4_define(exif_minver,                 0.6.14)
 m4_define(exempi_minver,               1.99.5)
 m4_define(gail_minver,                 3.0.0)
 m4_define(notify_minver,               0.7.0)
+m4_define(gtk-layer-shell_minver,      0.8.0)
 
 
 dnl 1. If the library code has changed at all since last release, then increment revision.
@@ -177,7 +178,33 @@ if test "x$enable_xmp" != "xno"; then
     AC_SUBST(EXEMPI_LIBS)
 fi
 
-dnl ==========================================================================
+dnl **************************************************************************
+dnl Whether or not to build with wayland support and check for gtk-layer-shell
+dnl **************************************************************************
+
+
+AC_ARG_ENABLE(wayland,
+              [AS_HELP_STRING([--enable-wayland],
+                              [Explicitly enable or disable Wayland support
+                              (default is to enable only if Wayland client development library is detected)])],
+              [enable_wayland=$enableval],
+              [enable_wayland=auto])
+
+# Check if we have gtk-layer-shell installed, and thus should build with Wayland support
+have_wayland=no
+if test "x$enable_wayland" != "xno"; then
+  PKG_CHECK_MODULES(WAYLAND, gtk-layer-shell-0 >= gtk-layer-shell_minver wayland-client, have_wayland=yes, [
+        if test "x$enable_wayland" = "xyes"; then
+          AC_MSG_ERROR([Wayland enabled but GTK Layer Shell library not found])
+        fi
+    ])
+fi
+
+AM_CONDITIONAL(ENABLE_WAYLAND, [test "x$have_wayland" = "xyes"])
+
+if test "x$have_wayland" = "xyes"; then
+  AC_DEFINE(HAVE_WAYLAND, 1, [Have the Wayland development library])
+fi
 
 dnl ****************************
 dnl *** Check for libselinux ***
@@ -240,7 +267,7 @@ AC_SUBST(LIBCAJA_EXTENSION_LIBS)
 
 dnl core caja
 PKG_CHECK_MODULES(GMODULE, gmodule-2.0, [GMODULE_ADD="gmodule-2.0"],[GMODULE_ADD=""])
-CORE_MODULES="glib-2.0 $GMODULE_ADD mate-desktop-2.0 gthread-2.0 gio-2.0 gio-unix-2.0 gail-3.0 libxml-2.0 $EXTRA_CORE_MODULES gtk+-3.0 x11"
+CORE_MODULES="glib-2.0 $GMODULE_ADD mate-desktop-2.0 gthread-2.0 gio-2.0 gio-unix-2.0 gail-3.0 libxml-2.0 gtk+-3.0 x11"
 CORE_CFLAGS="`$PKG_CONFIG --cflags $CORE_MODULES`"
 AC_SUBST(CORE_CFLAGS)
 CORE_LIBS="`$PKG_CONFIG --libs $CORE_MODULES`"
@@ -323,6 +350,7 @@ Configure summary:
     PackageKit support:           $msg_packagekit
     Native Language support:      $USE_NLS
     Self check:                   $msg_self_check
+    Wayland support:              ${have_wayland}
 
     caja-extension documentation: ${enable_gtk_doc}
     caja-extension introspection: ${found_introspection}

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ m4_define(exif_minver,                 0.6.14)
 m4_define(exempi_minver,               1.99.5)
 m4_define(gail_minver,                 3.0.0)
 m4_define(notify_minver,               0.7.0)
-m4_define(gtk-layer-shell_minver,      0.8.0)
+m4_define(gtk_layer_shell_minver,      0.8.0)
 
 
 dnl 1. If the library code has changed at all since last release, then increment revision.
@@ -192,13 +192,11 @@ AC_ARG_ENABLE(wayland,
 
 # Check if we have gtk-layer-shell installed, and thus should build with Wayland support
 have_wayland=no
-if test "x$enable_wayland" != "xno"; then
-  PKG_CHECK_MODULES(WAYLAND, gtk-layer-shell-0 >= gtk-layer-shell_minver wayland-client, have_wayland=yes, [
-        if test "x$enable_wayland" = "xyes"; then
-          AC_MSG_ERROR([Wayland enabled but GTK Layer Shell library not found])
-        fi
-    ])
-fi
+m4_define([WAYLAND_DEPS], [gtk-layer-shell-0 >= gtk_layer_shell_minver wayland-client])
+AS_IF([test "x$enable_wayland" = "xyes"],
+      [PKG_CHECK_MODULES([WAYLAND], [WAYLAND_DEPS], [have_wayland=yes])],
+      [test "x$enable_wayland" != "xno"],
+      [PKG_CHECK_MODULES([WAYLAND], [WAYLAND_DEPS], [have_wayland=yes], [have_wayland=no])])
 
 AM_CONDITIONAL(ENABLE_WAYLAND, [test "x$have_wayland" = "xyes"])
 

--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -1028,7 +1028,6 @@ eel_editable_label_ensure_layout (EelEditableLabel *label,
             else
             {
                 gint wrap_width;
-                gint scale;
 
                 pango_layout_set_width (label->layout, -1);
                 pango_layout_get_extents (label->layout, NULL, &logical_rect);
@@ -1039,7 +1038,6 @@ eel_editable_label_ensure_layout (EelEditableLabel *label,
                 longest_paragraph = width;
 
                 wrap_width = get_label_wrap_width (label);
-                scale = gtk_widget_get_scale_factor (widget);
                 width = MIN (width, wrap_width);
                 width = MIN (width,
                 PANGO_SCALE * (gdk_screen_width () + 1) / 2);

--- a/eel/eel-gtk-extensions.c
+++ b/eel/eel-gtk-extensions.c
@@ -93,23 +93,27 @@ sanity_check_window_position (int *left, int *top)
      * that it might be obscured by the panel.
      *
      */
-    root_window = gdk_screen_get_root_window (gdk_screen_get_default());
     display = gdk_display_get_default ();
-    gdk_monitor_get_workarea(gdk_display_get_monitor_at_window (display, root_window), &workarea);
-    *top = CLAMP (*top, 0, workarea.height - MINIMUM_ON_SCREEN_HEIGHT);
+    /*This is x11 only, there is no root window in wayland*/
+    if (GDK_IS_X11_DISPLAY (display))
+    {
+        root_window = gdk_screen_get_root_window (gdk_screen_get_default());
+        gdk_monitor_get_workarea(gdk_display_get_monitor_at_window (display, root_window), &workarea);
+        *top = CLAMP (*top, 0, workarea.height - MINIMUM_ON_SCREEN_HEIGHT);
 
-    /* FIXME bugzilla.eazel.com 669:
-     * If window has negative left coordinate, set_uposition sends it
-     * somewhere else entirely. Not sure what level contains this bug (XWindows?).
-     * Hacked around by pinning the left edge to zero, which just means you
-     * can't set a window to be partly off the left of the screen using
-     * this routine.
-     */
-    /* Make sure the left edge of the window isn't off the right edge of
-     * the screen, or so close to the right edge that it might be
-     * obscured by the panel.
-     */
-    *left = CLAMP (*left, 0, workarea.width - MINIMUM_ON_SCREEN_WIDTH);
+        /* FIXME bugzilla.eazel.com 669:
+         * If window has negative left coordinate, set_uposition sends it
+         * somewhere else entirely. Not sure what level contains this bug (XWindows?).
+         * Hacked around by pinning the left edge to zero, which just means you
+         * can't set a window to be partly off the left of the screen using
+         * this routine.
+         */
+        /* Make sure the left edge of the window isn't off the right edge of
+         * the screen, or so close to the right edge that it might be
+         * obscured by the panel.
+         */
+        *left = CLAMP (*left, 0, workarea.width - MINIMUM_ON_SCREEN_WIDTH);
+    }
 }
 
 static void

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,6 +38,11 @@ LDADD = \
     -lnotify
 	$(NULL)
 
+if ENABLE_WAYLAND
+LDADD += \
+	$(WAYLAND_LIBS)
+endif
+
 dbus_freedesktop_built_sources =			\
 	caja-freedesktop-generated.c		\
 	caja-freedesktop-generated.h

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -634,19 +634,15 @@ selection_get_cb (GtkWidget          *widget,
 static GtkWidget *
 get_desktop_manager_selection (GdkDisplay *display)
 {
-	/*FIXME: for Wayland we need a new desktop canvas anyway
-    *so when that is ready we will need to add a wayland code
-    *path here to support it
-    */
-    if  (GDK_IS_X11_DISPLAY (display)){
-        char selection_name[32];
-        GdkAtom selection_atom;
-        Window selection_owner;
-        GtkWidget *selection_widget;
+    char selection_name[32];
+    GdkAtom selection_atom;
+    Window selection_owner;
+    GtkWidget *selection_widget;
 
-        g_snprintf (selection_name, sizeof (selection_name), "_NET_DESKTOP_MANAGER_S0");
-        selection_atom = gdk_atom_intern (selection_name, FALSE);
-
+    g_snprintf (selection_name, sizeof (selection_name), "_NET_DESKTOP_MANAGER_S0");
+    selection_atom = gdk_atom_intern (selection_name, FALSE);
+    if (GDK_IS_X11_DISPLAY (display))
+    {
         selection_owner = XGetSelectionOwner (GDK_DISPLAY_XDISPLAY (display),
                                           gdk_x11_atom_to_xatom_for_display (display,
                                                   selection_atom));
@@ -654,24 +650,31 @@ get_desktop_manager_selection (GdkDisplay *display)
         {
         return NULL;
         }
+    }
+    selection_widget = gtk_invisible_new_for_screen (gdk_display_get_default_screen (display));
+    /* We need this for gdk_x11_get_server_time() */
+    gtk_widget_add_events (selection_widget, GDK_PROPERTY_CHANGE_MASK);
 
-        selection_widget = gtk_invisible_new_for_screen (gdk_display_get_default_screen (display));
-        /* We need this for gdk_x11_get_server_time() */
-        gtk_widget_add_events (selection_widget, GDK_PROPERTY_CHANGE_MASK);
-
+    if (GDK_IS_X11_DISPLAY (display))
+    {
         if (gtk_selection_owner_set_for_display (display,
             selection_widget,
             selection_atom,
             gdk_x11_get_server_time (gtk_widget_get_window (selection_widget))))
         {
-
             g_signal_connect (selection_widget, "selection_get",
-                          G_CALLBACK (selection_get_cb), NULL);
+                              G_CALLBACK (selection_get_cb), NULL);
             return selection_widget;
         }
-
-        gtk_widget_destroy (selection_widget);
     }
+    else
+    {
+        g_signal_connect (selection_widget, "selection_get",
+                          G_CALLBACK (selection_get_cb), NULL);
+        return selection_widget;
+    }
+
+    gtk_widget_destroy (selection_widget);
 
     return NULL;
 }

--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -171,8 +171,8 @@ caja_desktop_window_screen_size_changed (GdkScreen             *screen,
         /*No root window or primary monitor in wayland unless compositors add it back*/
         GdkRectangle geometry = {0};
         GdkMonitor *monitor;
-        monitor = gdk_display_get_monitor(display, 0);
-        gdk_monitor_get_geometry(monitor,&geometry);
+        monitor = gdk_display_get_monitor (display, 0);
+        gdk_monitor_get_geometry (monitor, &geometry);
         width_request = geometry.width;
         height_request = geometry.height;
     }
@@ -207,8 +207,8 @@ caja_desktop_window_new (CajaApplication *application,
         */
         GdkRectangle geometry = {0};
         GdkMonitor *monitor;
-        monitor = gdk_display_get_monitor(display, 0);
-        gdk_monitor_get_geometry(monitor,&geometry);
+        monitor = gdk_display_get_monitor (display, 0);
+        gdk_monitor_get_geometry (monitor, &geometry);
         width_request = geometry.width;
         height_request = geometry.height;
     }
@@ -380,10 +380,10 @@ realize (GtkWidget *widget)
     /* This is the new way to set up the desktop window in x11 but not for wayland */
     display = gtk_widget_get_display (widget);
     if (GDK_IS_X11_DISPLAY (display))
-        {
-            set_wmspec_desktop_hint (gtk_widget_get_window (widget));
-            set_desktop_window_id (window, gtk_widget_get_window (widget));
-        }
+    {
+        set_wmspec_desktop_hint (gtk_widget_get_window (widget));
+        set_desktop_window_id (window, gtk_widget_get_window (widget));
+    }
 
     details->size_changed_id =
         g_signal_connect (gtk_window_get_screen (GTK_WINDOW (window)), "size_changed",

--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -29,7 +29,10 @@
 #include <gtk/gtk.h>
 #include <gio/gio.h>
 #include <glib/gi18n.h>
-
+#ifdef HAVE_WAYLAND
+#include <gdk/gdkwayland.h>
+#include <gtk-layer-shell/gtk-layer-shell.h>
+#endif
 #include <eel/eel-background.h>
 #include <eel/eel-vfs-extensions.h>
 
@@ -156,9 +159,23 @@ caja_desktop_window_screen_size_changed (GdkScreen             *screen,
 {
     int width_request, height_request;
 
-    GdkWindow *root_window;
-    root_window = gdk_screen_get_root_window (screen);
-    gdk_window_get_geometry (root_window, NULL, NULL, &width_request, &height_request);
+    GdkDisplay *display = gdk_screen_get_display (screen);
+    if (GDK_IS_X11_DISPLAY (display))
+    {
+        GdkWindow *root_window;
+        root_window = gdk_screen_get_root_window (screen);
+        gdk_window_get_geometry (root_window, NULL, NULL, &width_request, &height_request);
+    }
+    else
+    {
+        /*No root window or primary monitor in wayland unless compositors add it back*/
+        GdkRectangle geometry = {0};
+        GdkMonitor *monitor;
+        monitor = gdk_display_get_monitor(display, 0);
+        gdk_monitor_get_geometry(monitor,&geometry);
+        width_request = geometry.width;
+        height_request = geometry.height;
+    }
 
     g_object_set (window,
                   "width_request", width_request,
@@ -174,10 +191,27 @@ caja_desktop_window_new (CajaApplication *application,
     int width_request, height_request;
     int scale;
 
-    scale = gdk_window_get_scale_factor (gdk_screen_get_root_window (screen));
-
-    width_request = WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) / scale;
-    height_request = HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) / scale;
+    GdkDisplay *display = gdk_screen_get_display (screen);
+    if (GDK_IS_X11_DISPLAY (display))
+    {
+        scale = gdk_window_get_scale_factor (gdk_screen_get_root_window (screen));
+        width_request = WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) / scale;
+        height_request = HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) / scale;
+    }
+    else
+    {
+        /*FIXME: There is no primary monitor in wayland itself
+        *compositors can implement this but as this is written
+        *only a few wayland compositors allow setting a primary monitor
+        *and they all do it differently. For now, use the first monitor
+        */
+        GdkRectangle geometry = {0};
+        GdkMonitor *monitor;
+        monitor = gdk_display_get_monitor(display, 0);
+        gdk_monitor_get_geometry(monitor,&geometry);
+        width_request = geometry.width;
+        height_request = geometry.height;
+    }
 
     window = CAJA_DESKTOP_WINDOW
              (gtk_widget_new (caja_desktop_window_get_type(),
@@ -191,11 +225,47 @@ caja_desktop_window_new (CajaApplication *application,
     /* will cause the desktop window to open at the wrong size in gtk 3.20 */
     gtk_window_set_default_size (GTK_WINDOW (window), -1, -1);
 
+    /*For wayland only
+     *Code taken from gtk-layer-shell simple-example.c
+     */
+#ifdef HAVE_WAYLAND
+    if (GDK_IS_WAYLAND_DISPLAY (display))
+    {
+        GtkWindow *gtkwin;
+        gtkwin = (GTK_WINDOW(window));
+
+        /* Before the window is first realized, set it up to be a layer surface */
+        gtk_layer_init_for_window (gtkwin);
+
+        /* Order below normal windows */
+        gtk_layer_set_layer (gtkwin, GTK_LAYER_SHELL_LAYER_BOTTOM);
+
+        gtk_layer_set_namespace (gtkwin, "desktop");
+
+        /*Anchor the desktop to all four corners
+         *This is much simpler than on x11 and
+         *should always render the desktop across
+         *all of the screen
+         */
+        gtk_layer_set_anchor (gtkwin, GTK_LAYER_SHELL_EDGE_TOP, TRUE);
+        gtk_layer_set_anchor (gtkwin, GTK_LAYER_SHELL_EDGE_BOTTOM, TRUE);
+        gtk_layer_set_anchor (gtkwin, GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
+        gtk_layer_set_anchor (gtkwin, GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
+
+        /*Enable keyboard use on the desktop*/
+        gtk_layer_set_keyboard_mode (gtkwin, GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
+    }
+#endif
     /* Special sawmill setting*/
     GdkWindow *gdkwin;
-    gtk_widget_realize (GTK_WIDGET (window));
+    if ((GDK_IS_X11_DISPLAY (display)))
+        gtk_widget_realize (GTK_WIDGET (window));
+    else
+        gtk_widget_show (GTK_WIDGET (window));
+
     gdkwin = gtk_widget_get_window (GTK_WIDGET (window));
-    if (gdk_window_ensure_native (gdkwin)) {
+    if ((GDK_IS_X11_DISPLAY (display)) && (gdk_window_ensure_native (gdkwin)))
+    {
         Display *disp = GDK_DISPLAY_XDISPLAY (gdk_window_get_display (gdkwin));
         XClassHint *xch = XAllocClassHint ();
         xch->res_name = "desktop_window";
@@ -230,15 +300,21 @@ unrealize (GtkWidget *widget)
     CajaDesktopWindow *window;
     CajaDesktopWindowPrivate *details;
     GdkWindow *root_window;
+    GdkDisplay *display;
 
     window = CAJA_DESKTOP_WINDOW (widget);
     details = window->details;
+    display = gtk_widget_get_display (widget);
 
-    root_window = gdk_screen_get_root_window (
+    /*Avoid root window on wayland-it's not supposed to work*/
+    if (GDK_IS_X11_DISPLAY (display))
+    {
+        root_window = gdk_screen_get_root_window (
                       gtk_window_get_screen (GTK_WINDOW (window)));
 
-    gdk_property_delete (root_window,
-                         gdk_atom_intern ("CAJA_DESKTOP_WINDOW_ID", TRUE));
+        gdk_property_delete (root_window,
+                             gdk_atom_intern ("CAJA_DESKTOP_WINDOW_ID", TRUE));
+    }
 
     if (details->size_changed_id != 0) {
         g_signal_handler_disconnect (gtk_window_get_screen (GTK_WINDOW (window)),
@@ -249,6 +325,7 @@ unrealize (GtkWidget *widget)
     GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->unrealize (widget);
 }
 
+/*This should only be reached in x11*/
 static void
 set_wmspec_desktop_hint (GdkWindow *window)
 {
@@ -262,18 +339,18 @@ set_wmspec_desktop_hint (GdkWindow *window)
                          GDK_PROP_MODE_REPLACE, (guchar *) &atom, 1);
 }
 
+/*This should only be reached in x11*/
 static void
 set_desktop_window_id (CajaDesktopWindow *window,
                        GdkWindow             *gdkwindow)
 {
-    /* Tuck the desktop windows xid in the root to indicate we own the desktop.
+    /* Tuck the desktop windows xid in the root to indicate we own the desktop in on x11
      */
     Window window_xid;
     GdkWindow *root_window;
 
     root_window = gdk_screen_get_root_window (
                       gtk_window_get_screen (GTK_WINDOW (window)));
-
     window_xid = GDK_WINDOW_XID (gdkwindow);
 
     gdk_property_change (root_window,
@@ -289,17 +366,24 @@ realize (GtkWidget *widget)
     CajaDesktopWindowPrivate *details;
     window = CAJA_DESKTOP_WINDOW (widget);
     details = window->details;
+    GdkDisplay *display;
 
     /* Make sure we get keyboard events */
-    gtk_widget_set_events (widget, gtk_widget_get_events (widget)
-                           | GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK);
-    /* Do the work of realizing. */
+    display = gtk_widget_get_display (widget);
+    if (GDK_IS_X11_DISPLAY (display))
+        gtk_widget_set_events (widget, gtk_widget_get_events (widget)
+                               | GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK);
+
+    /*Do the work of realizing. */
     GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->realize (widget);
 
-    /* This is the new way to set up the desktop window */
-    set_wmspec_desktop_hint (gtk_widget_get_window (widget));
-
-    set_desktop_window_id (window, gtk_widget_get_window (widget));
+    /* This is the new way to set up the desktop window in x11 but not for wayland */
+    display = gtk_widget_get_display (widget);
+    if (GDK_IS_X11_DISPLAY (display))
+        {
+            set_wmspec_desktop_hint (gtk_widget_get_window (widget));
+            set_desktop_window_id (window, gtk_widget_get_window (widget));
+        }
 
     details->size_changed_id =
         g_signal_connect (gtk_window_get_screen (GTK_WINDOW (window)), "size_changed",
@@ -311,7 +395,6 @@ draw (GtkWidget *widget,
       cairo_t   *cr)
 {
     eel_background_draw (widget, cr);
-
     return GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->draw (widget, cr);
 }
 
@@ -332,7 +415,8 @@ caja_desktop_window_class_init (CajaDesktopWindowClass *klass)
     wclass->realize = realize;
     wclass->unrealize = unrealize;
     wclass->map = map;
-    wclass->draw = draw;
+    if (GDK_IS_X11_DISPLAY (gdk_display_get_default()))
+        wclass->draw = draw;
 
     gtk_widget_class_set_accessible_type (wclass, CAJA_TYPE_DESKTOP_WINDOW_ACCESSIBLE);
 

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -136,8 +136,8 @@ icon_container_set_workarea (CajaIconContainer *icon_container,
         scale = 1; /*wayland handles this for us*/
         GdkRectangle geometry = {0};
         GdkMonitor *monitor;
-        monitor = gdk_display_get_monitor(display, 0);
-        gdk_monitor_get_geometry(monitor,&geometry);
+        monitor = gdk_display_get_monitor (display, 0);
+        gdk_monitor_get_geometry (monitor, &geometry);
         screen_width = geometry.width;
         screen_height = geometry.height;
     }
@@ -434,8 +434,8 @@ realized_callback (GtkWidget *widget, FMDesktopIconView *desktop_icon_view)
         /*No real root window or primary monitor in wayland unless compositors add it back*/
         GdkRectangle geometry = {0};
         GdkMonitor *monitor;
-        monitor = gdk_display_get_monitor(display, 0);
-        gdk_monitor_get_geometry(monitor,&geometry);
+        monitor = gdk_display_get_monitor (display, 0);
+        gdk_monitor_get_geometry (monitor, &geometry);
         allocation.width = geometry.width;
         allocation.height = geometry.height;
     }


### PR DESCRIPTION
*Uses gtk-layer-shell to keep the desktop always on the bottom *Uses gtk-layer-shell to keep the desktop on all workpaces *Depends on two changes in mate-desktop package
*We can later make wayland support optional here due to new dependency on gtk-layer-shell

*Depends on https://github.com/mate-desktop/mate-desktop/pull/558
