### PR TITLE
fix gfile sort and symlink warnings w glib 2.76 or later

### DIFF
--- a/libcaja-private/caja-directory-async.c
+++ b/libcaja-private/caja-directory-async.c
@@ -3807,7 +3807,7 @@ static gboolean is_trusted_system_desktop_file (GFile *file)
         return FALSE;
     }
 
-    target = g_file_info_get_symlink_target (info);
+    target = g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_STANDARD_SYMLINK_TARGET);
     if (!target) {
         goto done;
     }

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -2396,7 +2396,7 @@ update_info_internal (CajaFile *file,
 	}
 	file->details->size_on_disk = size_on_disk;
 
-	sort_order = g_file_info_get_sort_order (info);
+	sort_order = g_file_info_get_attribute_int32 (info, G_FILE_ATTRIBUTE_STANDARD_SORT_ORDER);
 	if (file->details->sort_order != sort_order) {
 		changed = TRUE;
 	}
@@ -2451,7 +2451,8 @@ update_info_internal (CajaFile *file,
 		file->details->thumbnailing_failed = (thumbnailing_failed != FALSE);
 	}
 
-	symlink_name = g_file_info_get_symlink_target (info);
+	symlink_name = g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_STANDARD_SYMLINK_TARGET);
+
 	if (eel_strcmp (file->details->symlink_name, symlink_name) != 0) {
 		changed = TRUE;
 		g_free (file->details->symlink_name);


### PR DESCRIPTION
*Use code borrowed from Nemo