### PR TITLE
fix building with libxml 2.12.0

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+#include <libxml/parser.h>
 #include <libxml/xmlsave.h>
 #include <glib/gstdio.h>
 #include <glib/gi18n.h>


### PR DESCRIPTION
```
caja-application.c:1557:11: error: implicit declaration of function ‘xmlReadMemory’; did you mean ‘xmlInitMemory’? [-Werror=implicit-function-declaration]
1557 |     doc = xmlReadMemory (data, strlen (data), NULL, "UTF-8", 0);
|           ^~~~~~~~~~~~~
|           xmlInitMemory
caja-application.c:1557:9: warning: assignment to ‘xmlDocPtr’ {aka ‘struct _xmlDoc *’} from ‘int’ makes pointerfrom integer without a cast [-Wint-conversion]
1557 |     doc = xmlReadMemory (data, strlen (data), NULL, "UTF-8", 0);
|         ^
```
Building caja with commit from PR for fedora-rawhide at koji buildserver works fine.
https://src.fedoraproject.org/rpms/caja/blob/rawhide/f/caja_0001-fix-building-with-libxml-2.12.0.patch
https://koji.fedoraproject.org/koji/taskinfo?taskID=109410799