### PR TITLE
wayland desktop: suppress spatial window warning

### DIFF
--- a/src/caja-spatial-window.c
+++ b/src/caja-spatial-window.c
@@ -313,6 +313,7 @@ caja_spatial_window_show (GtkWidget *widget)
     CajaWindow *window;
     CajaWindowSlot *slot;
     GFile *location;
+    GdkDisplay *display;
 
     window = CAJA_WINDOW (widget);
     slot = caja_window_get_active_slot (window);
@@ -325,7 +326,17 @@ caja_spatial_window_show (GtkWidget *widget)
     }
 
     location = caja_window_slot_get_location (slot);
-    g_return_if_fail (location != NULL);
+    display = gtk_widget_get_display (widget);
+
+    if (GDK_IS_X11_DISPLAY (display))
+        g_return_if_fail (location != NULL);
+
+    /*Return silently if this is a wayland desktop
+     *as the location isn't ready yet on first rendering
+     *but contents show fine, presumably from an update
+     */
+    else if (location == NULL)
+        return;
 
     while (location != NULL) {
         CajaFile *file;


### PR DESCRIPTION
*When under wayland, silence `caja_spatial_window_show: assertion 'location != NULL' failed` warning
*The startup sequence is not the same with wlroots and the location isn't ready yet 
*Using gtk_widget_show instead of gtk_widget_realize in caja-desktop-window.c generates this warning