### PR TITLE
Wayland desktop: do not attempt to take over background image/color handling from the compositor

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -449,6 +449,15 @@ init_fade (EelBackground *self)
         return;
     }
 
+    GdkDisplay *display = gdk_screen_get_display (gdk_screen_get_default());
+
+    /*do not attempt to manage desktop background on wayland
+     *as the compositor handles this
+     */
+
+    if (!(GDK_IS_X11_DISPLAY (display)))
+        return;
+
     mate_background_preferences = g_settings_new ("org.mate.background");
     do_fade = g_settings_get_boolean (mate_background_preferences,
                                       MATE_BG_KEY_BACKGROUND_FADE);

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -42,6 +42,7 @@
 #include <eel/eel-glib-extensions.h>
 #include <eel/eel-gtk-extensions.h>
 #include <eel/eel-vfs-extensions.h>
+#include <eel/eel-stock-dialogs.h>
 
 #include <libcaja-private/caja-desktop-icon-file.h>
 #include <libcaja-private/caja-directory-background.h>
@@ -708,11 +709,14 @@ action_change_background_callback (GtkAction *action,
 {
     g_assert (FM_DIRECTORY_VIEW (data));
 
-    caja_launch_application_from_command (gtk_widget_get_screen (GTK_WIDGET (data)),
-                                          _("Background"),
-                                          "mate-appearance-properties",
-                                          FALSE,
-                                          "--show-page=background", NULL);
+    if (GDK_IS_X11_DISPLAY (gdk_screen_get_display (gdk_screen_get_default())))
+        caja_launch_application_from_command (gtk_widget_get_screen (GTK_WIDGET (data)),
+                                              _("Background"),
+                                              "mate-appearance-properties",
+                                              FALSE,
+                                              "--show-page=background", NULL);
+    else
+    eel_show_error_dialog (_("Caja cannot change the desktop background in Wayland."), ("Image and color backgrounds on the wayland desktop are managed by the compositor. The background can be changed from the compositor's configuration utility"), NULL);
 }
 
 static void


### PR DESCRIPTION
Do not attempt to draw the background in wayland, as it starts but reverts to the compositor's background image in about a second. This seems to be the compositor taking over. We have no root window to draw the background on in wayland. In wayland, the compositor normally manages the desktop background, drawing it on the screen without even defining it as a window.

Also, connect the right-click menu item "Change Desktop Background" to a useful error dialog telling users to change the background in the compositor's background manager.

No change in desktop icon rendering, this affects the background only.