### PR TITLE
caja-file-operations: fixes the operations timer handling

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -5232,6 +5232,8 @@ move_job (GIOSchedulerJob *io_job,
 		goto aborted;
 	}
 
+	g_timer_start (job->common.time);
+
 	memset (&transfer_info, 0, sizeof (transfer_info));
 	move_files (job,
 		    fallbacks,

--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -1873,7 +1873,7 @@ trash_files (CommonJob *job, GList *files, guint *files_skipped)
 	for (l = files;
 	     l != NULL && !job_aborted (job);
 	     l = l->next) {
-        caja_progress_info_get_ready (job->progress);
+        caja_progress_info_get_ready (job->progress, job->time);
 
 		file = l->data;
 
@@ -3598,7 +3598,7 @@ copy_move_directory (CopyMoveJob *copy_job,
 		nextinfo = g_file_enumerator_next_file (enumerator, job->cancellable, skip_error?NULL:&error);
 		while (!job_aborted (job) &&
 		       (info = nextinfo) != NULL) {
-			caja_progress_info_get_ready (job->progress);
+			caja_progress_info_get_ready (job->progress, job->time);
 
 			nextinfo = g_file_enumerator_next_file (enumerator, job->cancellable, skip_error?NULL:&error);
 			src_file = g_file_get_child (src,
@@ -4564,7 +4564,7 @@ copy_files (CopyMoveJob *job,
 	for (l = job->files;
 	     l != NULL && !job_aborted (common);
 	     l = l->next) {
-		caja_progress_info_get_ready (common->progress);
+		caja_progress_info_get_ready (common->progress, common->time);
 
 		src = l->data;
 
@@ -4880,7 +4880,7 @@ move_file_prepare (CopyMoveJob *move_job,
 	}
 
  retry:
-    caja_progress_info_get_ready (job->progress);
+	caja_progress_info_get_ready (job->progress, job->time);
 
 	flags = G_FILE_COPY_NOFOLLOW_SYMLINKS | G_FILE_COPY_NO_FALLBACK_FOR_MOVE;
 	if (overwrite) {
@@ -5056,7 +5056,7 @@ move_files_prepare (CopyMoveJob *job,
 
 	total = left = g_list_length (job->files);
 
-	caja_progress_info_get_ready (common->progress);
+	caja_progress_info_get_ready (common->progress, common->time);
 	report_move_progress (job, total, left);
 
 	i = 0;
@@ -5120,7 +5120,7 @@ move_files (CopyMoveJob *job,
 	for (l = fallbacks;
 	     l != NULL && !job_aborted (common);
 	     l = l->next) {
-		caja_progress_info_get_ready (common->progress);
+		caja_progress_info_get_ready (common->progress, common->time);
 
 		fallback = l->data;
 		src = fallback->file;
@@ -5543,7 +5543,7 @@ link_job (GIOSchedulerJob *io_job,
 	for (l = job->files;
 	     l != NULL && !job_aborted (common);
 	     l = l->next) {
-        caja_progress_info_get_ready (common->progress);
+        caja_progress_info_get_ready (common->progress, common->time);
 
 		src = l->data;
 
@@ -5685,7 +5685,7 @@ set_permissions_file (SetPermissionsJob *job,
 
 	caja_progress_info_pulse_progress (common->progress);
 
-	caja_progress_info_get_ready (common->progress);
+	caja_progress_info_get_ready (common->progress, common->time);
 
 	free_info = FALSE;
 	if (info == NULL) {
@@ -6049,7 +6049,7 @@ create_job (GIOSchedulerJob *io_job,
 	count = 1;
 
  retry:
-    caja_progress_info_get_ready (common->progress);
+	caja_progress_info_get_ready (common->progress, common->time);
 
 	error = NULL;
 	if (job->make_dir) {
@@ -6379,7 +6379,7 @@ delete_trash_file (CommonJob *job,
 		   gboolean del_file,
 		   gboolean del_children)
 {
-	caja_progress_info_get_ready (job->progress);
+	caja_progress_info_get_ready (job->progress, job->time);
 
 	if (job_aborted (job)) {
 		return;
@@ -6528,7 +6528,7 @@ mark_desktop_file_trusted (CommonJob *common,
 	GFileInfo *info;
 
  retry:
-    caja_progress_info_get_ready (common->progress);
+	caja_progress_info_get_ready (common->progress, common->time);
 
 	error = NULL;
 	if (!g_file_load_contents (file,

--- a/libcaja-private/caja-progress-info.c
+++ b/libcaja-private/caja-progress-info.c
@@ -707,7 +707,7 @@ widget_state_notify_paused_callback (ProgressWidgetData *data)
 }
 
 void
-caja_progress_info_get_ready (CajaProgressInfo *info)
+caja_progress_info_get_ready (CajaProgressInfo *info, GTimer *time)
 {
     if (info->waiting) {
         G_LOCK (progress_info);
@@ -717,8 +717,10 @@ caja_progress_info_get_ready (CajaProgressInfo *info)
             g_source_set_callback (source, (GSourceFunc)widget_state_notify_paused_callback, info->widget, NULL);
             g_source_attach (source, NULL);
 
+            g_timer_stop (time);
             while (info->waiting)
                 g_cond_wait (&info->waiting_c, &G_LOCK_NAME(progress_info));
+            g_timer_continue (time);
         }
         G_UNLOCK (progress_info);
     }

--- a/libcaja-private/caja-progress-info.h
+++ b/libcaja-private/caja-progress-info.h
@@ -51,7 +51,7 @@ GType caja_progress_info_get_type (void) G_GNUC_CONST;
  */
 
 CajaProgressInfo *caja_progress_info_new (gboolean should_start, gboolean can_pause);
-void caja_progress_info_get_ready (CajaProgressInfo *info);
+void caja_progress_info_get_ready (CajaProgressInfo *info, GTimer *time);
 void caja_progress_info_disable_pause (CajaProgressInfo *info);
 
 GList *       caja_get_all_progress_info (void);


### PR DESCRIPTION
Essentially fixes the bug that for queued file operations the wrong transfer rate is shown.

To reproduce the issue/check the fix, start a (larger) file copy/move operation and then start a second one, while the first one is still running.

Fixes #1420 and #1623.