### PR TITLE
caja-file-operations: fix estimate for queued copy

### DIFF
--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -3079,8 +3079,8 @@ report_copy_progress (CopyMoveJob *copy_job,
 		transfer_rate = transfer_info->num_bytes / elapsed;
 	}
 
-	if (elapsed < SECONDS_NEEDED_FOR_RELIABLE_TRANSFER_RATE &&
-	    transfer_rate > 0) {
+	if (elapsed < SECONDS_NEEDED_FOR_RELIABLE_TRANSFER_RATE ||
+	    transfer_rate <= 0) {
 		char *s;
 		/* Translators: %S will expand to a size like "2 bytes" or "3 MB", so something like "4 kb of 4 MB" */
 		s = f (_("%S of %S"), transfer_info->num_bytes, total_size);

--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -1495,7 +1495,7 @@ report_delete_progress (CommonJob *job,
 			TransferInfo *transfer_info)
 {
 	int files_left;
-	double elapsed;
+	double elapsed, transfer_rate;
 	gint64 now;
 	char *files_left_s;
 
@@ -1522,15 +1522,19 @@ report_delete_progress (CommonJob *job,
 					    f (_("Deleting files")));
 
 	elapsed = g_timer_elapsed (job->time, NULL);
-	if (elapsed < SECONDS_NEEDED_FOR_RELIABLE_TRANSFER_RATE) {
+	transfer_rate = 0;
+	if (elapsed > 0) {
+		transfer_rate = transfer_info->num_files / elapsed;
+	}
+
+	if (elapsed < SECONDS_NEEDED_FOR_RELIABLE_TRANSFER_RATE ||
+		transfer_rate <= 0) {
 
 		caja_progress_info_set_details (job->progress, files_left_s);
 	} else {
 		char *details, *time_left_s;
 		int remaining_time;
-		double transfer_rate;
 
-		transfer_rate = transfer_info->num_files / elapsed;
 		remaining_time = files_left / transfer_rate;
 
 		/* Translators: %T will expand to a time like "2 minutes".


### PR DESCRIPTION
Fixes the condition for showing an estimate of the remaining duration in case a copy operation is queued, aligning to the delete operation case.