### PR TITLE
wayland: ensure windows can be moved and resized  if compositor is using CSD

### DIFF
--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -632,17 +632,6 @@ caja_window_set_initial_window_geometry (CajaWindow *window)
 }
 
 static void
-caja_window_constructed (GObject *self)
-{
-    CajaWindow *window;
-
-    window = CAJA_WINDOW (self);
-
-    caja_window_initialize_bookmarks_menu (window);
-    caja_window_set_initial_window_geometry (window);
-}
-
-static void
 caja_window_set_property (GObject *object,
                           guint arg_id,
                           const GValue *value,
@@ -742,6 +731,12 @@ caja_window_constructor (GType type,
 
     slot = caja_window_open_slot (window->details->active_pane, 0);
     caja_window_set_active_slot (window, slot);
+    /*We can now do this here instead of in a separate constructed function
+     *and we need to because the separate constructed function causes the
+     *window to be un-draggable/un-resizable with the mouse in wayland
+     */
+    caja_window_initialize_bookmarks_menu (window);
+    caja_window_set_initial_window_geometry (window);
 
     return object;
 }
@@ -2170,7 +2165,6 @@ caja_window_class_init (CajaWindowClass *class)
     GtkBindingSet *binding_set;
 
     G_OBJECT_CLASS (class)->constructor = caja_window_constructor;
-    G_OBJECT_CLASS (class)->constructed = caja_window_constructed;
     G_OBJECT_CLASS (class)->get_property = caja_window_get_property;
     G_OBJECT_CLASS (class)->set_property = caja_window_set_property;
     G_OBJECT_CLASS (class)->finalize = caja_window_finalize;


### PR DESCRIPTION
Ensure that nagivation and spatial windows can be moved and resized when running under wayland with CSD enabled, note that CSD is the default in many compositors and forced in some. 

Also note that in wayfire, using CSD will pick up the GTK theme's decorations which will look like they do for windows that do not use headerbars (such as all MATE apps) in Mutter. This gives far better support for the MATE themes than firedecor or similar SSD decorators for wayfire. We read the port of the metacity theme to GTK and without a GtkHeaderBar we get normal titlebar theming and dimensions unless the theme itself has an issue.