### PR TITLE
wayland/window closing: avoid a crash on gtk_widget_destroy

### DIFF
--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -4416,7 +4416,10 @@ destroy (GtkWidget *object)
     /* destroy interactive search dialog */
     if (container->details->search_window)
     {
-        gtk_widget_destroy (container->details->search_window);
+        /*current GTK docs do not advise calling gtk_widget_destroy on child widgets
+         *gtk_widget_destroy (container->details->search_window);
+         *also note that GtkContainer destroys it's child widgets when it is destroyed
+         */
         container->details->search_window = NULL;
         container->details->search_entry = NULL;
         if (container->details->typeselect_flush_timeout)


### PR DESCRIPTION
* Do not attempt to unref or destroy a child of a container

*In GTK 3 at least, GtkContainers automatically destroy child widgets when destroyed

*Trying to do this with glib 2.82 or later causes sporadic crashes on closing a navigation window at least in wayland.
