### PR TITLE
Various small accessibility improvements adding missing or insufficient labels

### DIFF
--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -2277,22 +2277,76 @@ eel_labeled_image_accessible_init (EelLabeledImageAccessible *accessible)
  * GTK accessible parent.  CheckButton and ToggleButton accessible objects
  * share the same type as GTK uses the same there. */
 
+typedef GtkButton EelLabeledImageButton;
+typedef GtkButtonClass EelLabeledImageButtonClass;
+
+G_DEFINE_TYPE (EelLabeledImageButton,
+               eel_labeled_image_button,
+               GTK_TYPE_BUTTON)
+
 static void
-eel_labeled_image_button_class_init (GtkWidgetClass *klass)
+eel_labeled_image_button_class_init (EelLabeledImageButtonClass *klass)
 {
-    gtk_widget_class_set_accessible_type (klass, eel_labeled_image_button_accessible_get_type ());
+    gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass), eel_labeled_image_button_accessible_get_type ());
 }
 
 static void
-eel_labeled_image_toggle_button_class_init (GtkWidgetClass *klass)
+eel_labeled_image_button_init (EelLabeledImageButton *obj)
 {
-    gtk_widget_class_set_accessible_type (klass, eel_labeled_image_toggle_button_accessible_get_type ());
+}
+
+typedef GtkCheckButton EelLabeledImageCheckButton;
+typedef GtkCheckButtonClass EelLabeledImageCheckButtonClass;
+
+G_DEFINE_TYPE (EelLabeledImageCheckButton,
+               eel_labeled_image_check_button,
+               GTK_TYPE_CHECK_BUTTON)
+
+static void
+eel_labeled_image_check_button_class_init (EelLabeledImageCheckButtonClass *klass)
+{
+    gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass), eel_labeled_image_toggle_button_accessible_get_type ());
 }
 
 static void
-eel_labeled_image_radio_button_class_init (GtkWidgetClass *klass)
+eel_labeled_image_check_button_init (EelLabeledImageCheckButton *obj)
 {
-    gtk_widget_class_set_accessible_type (klass, eel_labeled_image_radio_button_accessible_get_type ());
+}
+
+typedef GtkToggleButton EelLabeledImageToggleButton;
+typedef GtkToggleButtonClass EelLabeledImageToggleButtonClass;
+
+G_DEFINE_TYPE (EelLabeledImageToggleButton,
+               eel_labeled_image_toggle_button,
+               GTK_TYPE_TOGGLE_BUTTON)
+
+static void
+eel_labeled_image_toggle_button_class_init (EelLabeledImageToggleButtonClass *klass)
+{
+    gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass), eel_labeled_image_toggle_button_accessible_get_type ());
+}
+
+static void
+eel_labeled_image_toggle_button_init (EelLabeledImageToggleButton *obj)
+{
+}
+
+typedef GtkRadioButton EelLabeledImageRadioButton;
+typedef GtkRadioButtonClass EelLabeledImageRadioButtonClass;
+
+G_DEFINE_TYPE (EelLabeledImageRadioButton,
+               eel_labeled_image_radio_button,
+               GTK_TYPE_RADIO_BUTTON)
+
+static void
+eel_labeled_image_radio_button_class_init (EelLabeledImageRadioButtonClass *klass)
+{
+    gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass), eel_labeled_image_radio_button_accessible_get_type ());
+}
+
+static void
+eel_labeled_image_radio_button_init (EelLabeledImageRadioButton *obj)
+{
 }
 
 typedef GtkButtonAccessible EelLabeledImageButtonAccessible;
@@ -2359,120 +2413,4 @@ eel_labeled_image_radio_button_accessible_class_init (EelLabeledImageRadioButton
 static void
 eel_labeled_image_radio_button_accessible_init (EelLabeledImageRadioButtonAccessible *obj)
 {
-}
-
-static GType
-eel_labeled_image_button_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo info =
-        {
-            sizeof (GtkButtonClass),
-            (GBaseInitFunc) NULL,
-            (GBaseFinalizeFunc) NULL,
-            (GClassInitFunc) eel_labeled_image_button_class_init,
-            NULL, /* class_finalize */
-            NULL, /* class_data */
-            sizeof (GtkButton),
-            0, /* n_preallocs */
-            (GInstanceInitFunc) NULL,
-            NULL /* value_table */
-        };
-
-        type = g_type_register_static
-               (GTK_TYPE_BUTTON,
-                "EelLabeledImageButton", &info, 0);
-    }
-
-    return type;
-}
-
-static GType
-eel_labeled_image_check_button_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo info =
-        {
-            sizeof (GtkCheckButtonClass),
-            (GBaseInitFunc) NULL,
-            (GBaseFinalizeFunc) NULL,
-            (GClassInitFunc) eel_labeled_image_toggle_button_class_init,
-            NULL, /* class_finalize */
-            NULL, /* class_data */
-            sizeof (GtkCheckButton),
-            0, /* n_preallocs */
-            (GInstanceInitFunc) NULL,
-            NULL /* value_table */
-        };
-
-        type = g_type_register_static
-               (GTK_TYPE_CHECK_BUTTON,
-                "EelLabeledImageCheckButton", &info, 0);
-    }
-
-    return type;
-}
-
-static GType
-eel_labeled_image_toggle_button_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo info =
-        {
-            sizeof (GtkToggleButtonClass),
-            (GBaseInitFunc) NULL,
-            (GBaseFinalizeFunc) NULL,
-            (GClassInitFunc) eel_labeled_image_toggle_button_class_init,
-            NULL, /* class_finalize */
-            NULL, /* class_data */
-            sizeof (GtkToggleButton),
-            0, /* n_preallocs */
-            (GInstanceInitFunc) NULL,
-            NULL /* value_table */
-        };
-
-        type = g_type_register_static
-               (GTK_TYPE_TOGGLE_BUTTON,
-                "EelLabeledImageToggleButton", &info, 0);
-    }
-
-    return type;
-}
-
-static GType
-eel_labeled_image_radio_button_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo info =
-        {
-            sizeof (GtkRadioButtonClass),
-            (GBaseInitFunc) NULL,
-            (GBaseFinalizeFunc) NULL,
-            (GClassInitFunc) eel_labeled_image_radio_button_class_init,
-            NULL, /* class_finalize */
-            NULL, /* class_data */
-            sizeof (GtkRadioButton),
-            0, /* n_preallocs */
-            (GInstanceInitFunc) NULL,
-            NULL /* value_table */
-        };
-
-        type = g_type_register_static
-               (GTK_TYPE_RADIO_BUTTON,
-                "EelLabeledImageRadioButton", &info, 0);
-    }
-
-    return type;
 }

--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -2178,17 +2178,6 @@ eel_labeled_image_set_can_focus (EelLabeledImage *labeled_image,
     gtk_widget_set_can_focus (GTK_WIDGET (labeled_image), can_focus);
 }
 
-static AtkObjectClass *a11y_parent_class = NULL;
-
-static void
-eel_labeled_image_accessible_initialize (AtkObject *accessible,
-        gpointer   widget)
-{
-    a11y_parent_class->initialize (accessible, widget);
-    atk_object_set_role (accessible, ATK_ROLE_IMAGE);
-
-}
-
 static EelLabeledImage *
 get_image (gpointer object)
 {
@@ -2248,29 +2237,27 @@ eel_labeled_image_accessible_image_interface_init (AtkImageIface *iface)
     iface->get_image_size = eel_labeled_image_accessible_image_get_size;
 }
 
-typedef struct _EelLabeledImageAccessible EelLabeledImageAccessible;
-typedef struct _EelLabeledImageAccessibleClass EelLabeledImageAccessibleClass;
-
-struct _EelLabeledImageAccessible
-{
-    GtkContainerAccessible parent;
-};
-
-struct _EelLabeledImageAccessibleClass
-{
-    GtkContainerAccessibleClass parent_class;
-};
+typedef GtkContainerAccessible EelLabeledImageAccessible;
+typedef GtkContainerAccessibleClass EelLabeledImageAccessibleClass;
 
 G_DEFINE_TYPE_WITH_CODE (EelLabeledImageAccessible,
                          eel_labeled_image_accessible,
                          GTK_TYPE_CONTAINER_ACCESSIBLE,
                          G_IMPLEMENT_INTERFACE (ATK_TYPE_IMAGE,
                                                 eel_labeled_image_accessible_image_interface_init));
+
+static void
+eel_labeled_image_accessible_initialize (AtkObject *accessible,
+                                         gpointer   widget)
+{
+    ATK_OBJECT_CLASS (eel_labeled_image_accessible_parent_class)->initialize (accessible, widget);
+    atk_object_set_role (accessible, ATK_ROLE_IMAGE);
+}
+
 static void
 eel_labeled_image_accessible_class_init (EelLabeledImageAccessibleClass *klass)
 {
     AtkObjectClass *atk_class = ATK_OBJECT_CLASS (klass);
-    a11y_parent_class = g_type_class_peek_parent (klass);
 
     atk_class->get_name = eel_labeled_image_accessible_get_name;
     atk_class->initialize = eel_labeled_image_accessible_initialize;

--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -91,6 +91,7 @@ static GType         eel_labeled_image_toggle_button_get_type (void);
 /* GtkWidgetClass methods */
 static GType eel_labeled_image_accessible_get_type (void);
 static GType eel_labeled_image_button_accessible_get_type (void);
+static GType eel_labeled_image_check_button_accessible_get_type (void);
 static GType eel_labeled_image_toggle_button_accessible_get_type (void);
 static GType eel_labeled_image_radio_button_accessible_get_type (void);
 
@@ -2271,146 +2272,63 @@ eel_labeled_image_accessible_init (EelLabeledImageAccessible *accessible)
 {
 }
 
-/* Actual accessible implementations for Button, CheckButton, ToggleButton and
- * RadioButton are the same as EelLabeledImageAccessible, which handles those
- * cases as well.  We have different objects just to inherit from the correct
- * GTK accessible parent.  CheckButton and ToggleButton accessible objects
- * share the same type as GTK uses the same there. */
+/* Defines GObject types for the various buttons.  This takes care of creating
+ * the related accessible type as well and to plug it to the base
+ * EelLabeledImageAccessible which handles those cases as well -- having
+ * different accessible types for each of those is only required to inherit
+ * from the correct GTK accessible parent. */
 
-typedef GtkButton EelLabeledImageButton;
-typedef GtkButtonClass EelLabeledImageButtonClass;
+#define DEFINE_LABELLED_IMAGE_BUTTON_TYPE(TN, t_n, TP, T_P, ATP, A_T_P)         \
+    typedef TP TN;                                                              \
+    typedef TP##Class TN##Class;                                                \
+    typedef ATP TN##Accessible;                                                 \
+    typedef ATP##Class TN##AccessibleClass;                                     \
+    G_DEFINE_TYPE (TN, t_n, T_P)                                                \
+    G_DEFINE_TYPE_WITH_CODE (TN##Accessible, t_n##_accessible, A_T_P,           \
+                             G_IMPLEMENT_INTERFACE (ATK_TYPE_IMAGE,             \
+                                                    eel_labeled_image_accessible_image_interface_init)) \
+    static void t_n##_class_init(TN##Class *klass)                              \
+    {                                                                           \
+        gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass),         \
+                                              t_n##_accessible_get_type ());    \
+    }                                                                           \
+    static void t_n##_init (TN *obj)                                            \
+    {                                                                           \
+    }                                                                           \
+    static void t_n##_accessible_class_init(TN##AccessibleClass *klass)         \
+    {                                                                           \
+        AtkObjectClass *atk_class = ATK_OBJECT_CLASS (klass);                   \
+        atk_class->get_name = eel_labeled_image_accessible_get_name;            \
+    }                                                                           \
+    static void t_n##_accessible_init (TN##Accessible *obj)                     \
+    {                                                                           \
+    }
 
-G_DEFINE_TYPE (EelLabeledImageButton,
-               eel_labeled_image_button,
-               GTK_TYPE_BUTTON)
 
-static void
-eel_labeled_image_button_class_init (EelLabeledImageButtonClass *klass)
-{
-    gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass), eel_labeled_image_button_accessible_get_type ());
-}
+DEFINE_LABELLED_IMAGE_BUTTON_TYPE (EelLabeledImageButton,
+                                   eel_labeled_image_button,
+                                   GtkButton,
+                                   GTK_TYPE_BUTTON,
+                                   GtkButtonAccessible,
+                                   GTK_TYPE_BUTTON_ACCESSIBLE)
 
-static void
-eel_labeled_image_button_init (EelLabeledImageButton *obj)
-{
-}
+DEFINE_LABELLED_IMAGE_BUTTON_TYPE (EelLabeledImageCheckButton,
+                                   eel_labeled_image_check_button,
+                                   GtkCheckButton,
+                                   GTK_TYPE_CHECK_BUTTON,
+                                   GtkToggleButtonAccessible,
+                                   GTK_TYPE_TOGGLE_BUTTON_ACCESSIBLE)
 
-typedef GtkCheckButton EelLabeledImageCheckButton;
-typedef GtkCheckButtonClass EelLabeledImageCheckButtonClass;
+DEFINE_LABELLED_IMAGE_BUTTON_TYPE (EelLabeledImageToggleButton,
+                                   eel_labeled_image_toggle_button,
+                                   GtkToggleButton,
+                                   GTK_TYPE_TOGGLE_BUTTON,
+                                   GtkToggleButtonAccessible,
+                                   GTK_TYPE_TOGGLE_BUTTON_ACCESSIBLE)
 
-G_DEFINE_TYPE (EelLabeledImageCheckButton,
-               eel_labeled_image_check_button,
-               GTK_TYPE_CHECK_BUTTON)
-
-static void
-eel_labeled_image_check_button_class_init (EelLabeledImageCheckButtonClass *klass)
-{
-    gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass), eel_labeled_image_toggle_button_accessible_get_type ());
-}
-
-static void
-eel_labeled_image_check_button_init (EelLabeledImageCheckButton *obj)
-{
-}
-
-typedef GtkToggleButton EelLabeledImageToggleButton;
-typedef GtkToggleButtonClass EelLabeledImageToggleButtonClass;
-
-G_DEFINE_TYPE (EelLabeledImageToggleButton,
-               eel_labeled_image_toggle_button,
-               GTK_TYPE_TOGGLE_BUTTON)
-
-static void
-eel_labeled_image_toggle_button_class_init (EelLabeledImageToggleButtonClass *klass)
-{
-    gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass), eel_labeled_image_toggle_button_accessible_get_type ());
-}
-
-static void
-eel_labeled_image_toggle_button_init (EelLabeledImageToggleButton *obj)
-{
-}
-
-typedef GtkRadioButton EelLabeledImageRadioButton;
-typedef GtkRadioButtonClass EelLabeledImageRadioButtonClass;
-
-G_DEFINE_TYPE (EelLabeledImageRadioButton,
-               eel_labeled_image_radio_button,
-               GTK_TYPE_RADIO_BUTTON)
-
-static void
-eel_labeled_image_radio_button_class_init (EelLabeledImageRadioButtonClass *klass)
-{
-    gtk_widget_class_set_accessible_type (GTK_WIDGET_CLASS (klass), eel_labeled_image_radio_button_accessible_get_type ());
-}
-
-static void
-eel_labeled_image_radio_button_init (EelLabeledImageRadioButton *obj)
-{
-}
-
-typedef GtkButtonAccessible EelLabeledImageButtonAccessible;
-typedef GtkButtonAccessibleClass EelLabeledImageButtonAccessibleClass;
-
-G_DEFINE_TYPE_WITH_CODE (EelLabeledImageButtonAccessible,
-                         eel_labeled_image_button_accessible,
-                         GTK_TYPE_BUTTON_ACCESSIBLE,
-                         G_IMPLEMENT_INTERFACE (ATK_TYPE_IMAGE,
-                                                eel_labeled_image_accessible_image_interface_init));
-
-static void
-eel_labeled_image_button_accessible_class_init (EelLabeledImageButtonAccessibleClass *klass)
-{
-    AtkObjectClass *atk_class = ATK_OBJECT_CLASS (klass);
-
-    atk_class->get_name = eel_labeled_image_accessible_get_name;
-}
-
-static void
-eel_labeled_image_button_accessible_init (EelLabeledImageButtonAccessible *obj)
-{
-}
-
-typedef GtkToggleButtonAccessible EelLabeledImageToggleButtonAccessible;
-typedef GtkToggleButtonAccessibleClass EelLabeledImageToggleButtonAccessibleClass;
-
-G_DEFINE_TYPE_WITH_CODE (EelLabeledImageToggleButtonAccessible,
-                         eel_labeled_image_toggle_button_accessible,
-                         GTK_TYPE_TOGGLE_BUTTON_ACCESSIBLE,
-                         G_IMPLEMENT_INTERFACE (ATK_TYPE_IMAGE,
-                                                eel_labeled_image_accessible_image_interface_init));
-
-static void
-eel_labeled_image_toggle_button_accessible_class_init (EelLabeledImageToggleButtonAccessibleClass *klass)
-{
-    AtkObjectClass *atk_class = ATK_OBJECT_CLASS (klass);
-
-    atk_class->get_name = eel_labeled_image_accessible_get_name;
-}
-
-static void
-eel_labeled_image_toggle_button_accessible_init (EelLabeledImageToggleButtonAccessible *obj)
-{
-}
-
-typedef GtkRadioButtonAccessible EelLabeledImageRadioButtonAccessible;
-typedef GtkRadioButtonAccessibleClass EelLabeledImageRadioButtonAccessibleClass;
-
-G_DEFINE_TYPE_WITH_CODE (EelLabeledImageRadioButtonAccessible,
-                         eel_labeled_image_radio_button_accessible,
-                         GTK_TYPE_RADIO_BUTTON_ACCESSIBLE,
-                         G_IMPLEMENT_INTERFACE (ATK_TYPE_IMAGE,
-                                                eel_labeled_image_accessible_image_interface_init));
-
-static void
-eel_labeled_image_radio_button_accessible_class_init (EelLabeledImageRadioButtonAccessibleClass *klass)
-{
-    AtkObjectClass *atk_class = ATK_OBJECT_CLASS (klass);
-
-    atk_class->get_name = eel_labeled_image_accessible_get_name;
-}
-
-static void
-eel_labeled_image_radio_button_accessible_init (EelLabeledImageRadioButtonAccessible *obj)
-{
-}
+DEFINE_LABELLED_IMAGE_BUTTON_TYPE (EelLabeledImageRadioButton,
+                                   eel_labeled_image_radio_button,
+                                   GtkRadioButton,
+                                   GTK_TYPE_RADIO_BUTTON,
+                                   GtkRadioButtonAccessible,
+                                   GTK_TYPE_RADIO_BUTTON_ACCESSIBLE)

--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -90,6 +90,9 @@ static GType         eel_labeled_image_toggle_button_get_type (void);
 
 /* GtkWidgetClass methods */
 static GType eel_labeled_image_accessible_get_type (void);
+static GType eel_labeled_image_button_accessible_get_type (void);
+static GType eel_labeled_image_toggle_button_accessible_get_type (void);
+static GType eel_labeled_image_radio_button_accessible_get_type (void);
 
 /* Private EelLabeledImage methods */
 static EelDimensions labeled_image_get_image_dimensions   (const EelLabeledImage *labeled_image);
@@ -2268,8 +2271,93 @@ eel_labeled_image_accessible_init (EelLabeledImageAccessible *accessible)
 {
 }
 
+/* Actual accessible implementations for Button, CheckButton, ToggleButton and
+ * RadioButton are the same as EelLabeledImageAccessible, which handles those
+ * cases as well.  We have different objects just to inherit from the correct
+ * GTK accessible parent.  CheckButton and ToggleButton accessible objects
+ * share the same type as GTK uses the same there. */
+
 static void
 eel_labeled_image_button_class_init (GtkWidgetClass *klass)
+{
+    gtk_widget_class_set_accessible_type (klass, eel_labeled_image_button_accessible_get_type ());
+}
+
+static void
+eel_labeled_image_toggle_button_class_init (GtkWidgetClass *klass)
+{
+    gtk_widget_class_set_accessible_type (klass, eel_labeled_image_toggle_button_accessible_get_type ());
+}
+
+static void
+eel_labeled_image_radio_button_class_init (GtkWidgetClass *klass)
+{
+    gtk_widget_class_set_accessible_type (klass, eel_labeled_image_radio_button_accessible_get_type ());
+}
+
+typedef GtkButtonAccessible EelLabeledImageButtonAccessible;
+typedef GtkButtonAccessibleClass EelLabeledImageButtonAccessibleClass;
+
+G_DEFINE_TYPE_WITH_CODE (EelLabeledImageButtonAccessible,
+                         eel_labeled_image_button_accessible,
+                         GTK_TYPE_BUTTON_ACCESSIBLE,
+                         G_IMPLEMENT_INTERFACE (ATK_TYPE_IMAGE,
+                                                eel_labeled_image_accessible_image_interface_init));
+
+static void
+eel_labeled_image_button_accessible_class_init (EelLabeledImageButtonAccessibleClass *klass)
+{
+    AtkObjectClass *atk_class = ATK_OBJECT_CLASS (klass);
+
+    atk_class->get_name = eel_labeled_image_accessible_get_name;
+}
+
+static void
+eel_labeled_image_button_accessible_init (EelLabeledImageButtonAccessible *obj)
+{
+}
+
+typedef GtkToggleButtonAccessible EelLabeledImageToggleButtonAccessible;
+typedef GtkToggleButtonAccessibleClass EelLabeledImageToggleButtonAccessibleClass;
+
+G_DEFINE_TYPE_WITH_CODE (EelLabeledImageToggleButtonAccessible,
+                         eel_labeled_image_toggle_button_accessible,
+                         GTK_TYPE_TOGGLE_BUTTON_ACCESSIBLE,
+                         G_IMPLEMENT_INTERFACE (ATK_TYPE_IMAGE,
+                                                eel_labeled_image_accessible_image_interface_init));
+
+static void
+eel_labeled_image_toggle_button_accessible_class_init (EelLabeledImageToggleButtonAccessibleClass *klass)
+{
+    AtkObjectClass *atk_class = ATK_OBJECT_CLASS (klass);
+
+    atk_class->get_name = eel_labeled_image_accessible_get_name;
+}
+
+static void
+eel_labeled_image_toggle_button_accessible_init (EelLabeledImageToggleButtonAccessible *obj)
+{
+}
+
+typedef GtkRadioButtonAccessible EelLabeledImageRadioButtonAccessible;
+typedef GtkRadioButtonAccessibleClass EelLabeledImageRadioButtonAccessibleClass;
+
+G_DEFINE_TYPE_WITH_CODE (EelLabeledImageRadioButtonAccessible,
+                         eel_labeled_image_radio_button_accessible,
+                         GTK_TYPE_RADIO_BUTTON_ACCESSIBLE,
+                         G_IMPLEMENT_INTERFACE (ATK_TYPE_IMAGE,
+                                                eel_labeled_image_accessible_image_interface_init));
+
+static void
+eel_labeled_image_radio_button_accessible_class_init (EelLabeledImageRadioButtonAccessibleClass *klass)
+{
+    AtkObjectClass *atk_class = ATK_OBJECT_CLASS (klass);
+
+    atk_class->get_name = eel_labeled_image_accessible_get_name;
+}
+
+static void
+eel_labeled_image_radio_button_accessible_init (EelLabeledImageRadioButtonAccessible *obj)
 {
 }
 
@@ -2314,7 +2402,7 @@ eel_labeled_image_check_button_get_type (void)
             sizeof (GtkCheckButtonClass),
             (GBaseInitFunc) NULL,
             (GBaseFinalizeFunc) NULL,
-            (GClassInitFunc) eel_labeled_image_button_class_init,
+            (GClassInitFunc) eel_labeled_image_toggle_button_class_init,
             NULL, /* class_finalize */
             NULL, /* class_data */
             sizeof (GtkCheckButton),
@@ -2343,7 +2431,7 @@ eel_labeled_image_toggle_button_get_type (void)
             sizeof (GtkToggleButtonClass),
             (GBaseInitFunc) NULL,
             (GBaseFinalizeFunc) NULL,
-            (GClassInitFunc) eel_labeled_image_button_class_init,
+            (GClassInitFunc) eel_labeled_image_toggle_button_class_init,
             NULL, /* class_finalize */
             NULL, /* class_data */
             sizeof (GtkToggleButton),
@@ -2372,7 +2460,7 @@ eel_labeled_image_radio_button_get_type (void)
             sizeof (GtkRadioButtonClass),
             (GBaseInitFunc) NULL,
             (GBaseFinalizeFunc) NULL,
-            (GClassInitFunc) eel_labeled_image_button_class_init,
+            (GClassInitFunc) eel_labeled_image_radio_button_class_init,
             NULL, /* class_finalize */
             NULL, /* class_data */
             sizeof (GtkRadioButton),

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -4245,13 +4245,23 @@ add_permissions_combo_box (FMPropertiesWindow *window, GtkGrid *grid,
 	GtkListStore *store;
 	GtkCellRenderer *cell;
 	GtkTreeIter iter;
+	AtkObject *atk_object;
+	static const gchar *const descriptions[4][3] = {
+		{ N_("Access:"), N_("Folder access:"), N_("File access:") },
+		/* As the UI lacks semantic grouping, provide more context for accessibility */
+		{ N_("User access:"), N_("User folder access:"), N_("User file access:") },
+		{ N_("Group access:"), N_("Group folder access:"), N_("Group file access:") },
+		{ N_("Others access:"), N_("Others folder access:"), N_("Others file access:") }
+	};
+	const guint group = short_label ? 0 : is_folder ? 1 : 2;
 
-	if (short_label) {
-		label = attach_title_field (grid, _("Access:"));
-	} else if (is_folder) {
-		label = attach_title_field (grid, _("Folder access:"));
-	} else {
-		label = attach_title_field (grid, _("File access:"));
+	g_return_if_fail (type + 1 < G_N_ELEMENTS (descriptions));
+
+	label = attach_title_field (grid, _(descriptions[0][group]));
+
+	atk_object = gtk_widget_get_accessible (GTK_WIDGET (label));
+	if (GTK_IS_ACCESSIBLE (atk_object)) {
+		atk_object_set_name (atk_object, _(descriptions[type + 1][group]));
 	}
 
 	store = gtk_list_store_new (3, G_TYPE_STRING, G_TYPE_INT, G_TYPE_BOOLEAN);


### PR DESCRIPTION
This replaces #1568.  It gives mostly the same results, but in what I believe a better way:
* [Properties window: add accessible description to “Execute” check box](https://github.com/mate-desktop/caja/pull/1568/commits/e830ac40e711b8ea9bc396c49666fc540f83f65d)]: this seems to be a hack for an Orca bug that I could not reproduce, so nothing similar is added here
* [Properties window: add accessible label to icon button](https://github.com/mate-desktop/caja/pull/1568/commits/2042ef4b03daaccdff71e8a647630afcf6c59a32) and [Properties window: add accessible name & description to icon button](https://github.com/mate-desktop/caja/pull/1568/commits/128d6dcc1420411819ed7c9240d665855386329d) are implemented differently: 4abe18dbd3aeb1f609fde72a1f534bc5a829f6f2 for the icon/button, and a8e36f3bfe154237b00853e2804a50afe5531f30 for the emblems (which also fixes the property browser, see below)
* [Properties window: ensure that the “Others” label can be read](https://github.com/mate-desktop/caja/pull/1568/commits/894b6a4518f6adc9558e571141aea7cf12a5d6a6) is implemented differently, in a way that also improves the other permission combo boxes: 30e3cf5dfbfd138a84a2a29ba3483a48f0cb04a4
* [Property browser: add accessible labels](https://github.com/mate-desktop/caja/pull/1568/commits/6023ae04d7044877203ba521cca0557f770504cf) is fixed properly and more thoroughly by fixing the accessible implementation of the related widgets: a8e36f3bfe154237b00853e2804a50afe5531f30
* [Notes viewer sidebar: allow keyboard navigation with Shift-Tab](https://github.com/mate-desktop/caja/pull/1568/commits/693434b47626d8b021b24117cdbe50344c5fdd30): I don't see any reason for this, one can navigate with <kbd>Ctrl+Tab</kbd> or <kbd>Ctrl+Shift+Tab</kbd> already in there, like in other text views.

Basically this fixes the issues identified in #1568, improving some results, trying to use generic solutions were possible, and not trying to workaround outdated Orca bugs.  Tested with Orca 48.