### PR TITLE
file: Fallback to fast-content-type if content-type is not set

### DIFF
--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -2460,6 +2460,9 @@ update_info_internal (CajaFile *file,
 	}
 
 	mime_type = g_file_info_get_content_type (info);
+	if (mime_type == NULL) {
+		mime_type = g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_STANDARD_FAST_CONTENT_TYPE);
+	}
 	if (eel_strcmp (file->details->mime_type, mime_type) != 0) {
 		changed = TRUE;
 		g_clear_pointer (&file->details->mime_type, g_ref_string_release);


### PR DESCRIPTION
The G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE attribute doesn't have to be always set. See https://gitlab.gnome.org/GNOME/gvfs/-/merge_requests/68 for more details. In that case, Caja fallbacks to the "application/octet-stream" type, which causes issues when opening the files. Let's fallback to the "standard::fast-content-type" attribute instead to fix issues when opening such files.

Imported from Nautilus commit: https://gitlab.gnome.org/GNOME/nautilus/-/commit/0e5978035b0fc87c91d7b93ed79c64d51b6d6825

Fixes #1840.

@sijskes could you give this a spin and see if it fixes it?  It's simply an import of the Nautilus fix, but it might just do it.