### PR TITLE
wayland: set desktop layer as background not bottom

### DIFF
--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -239,7 +239,7 @@ caja_desktop_window_new (CajaApplication *application,
         gtk_layer_init_for_window (gtkwin);
 
         /* Order below normal windows */
-        gtk_layer_set_layer (gtkwin, GTK_LAYER_SHELL_LAYER_BOTTOM);
+        gtk_layer_set_layer (gtkwin, GTK_LAYER_SHELL_LAYER_BACKGROUND);
 
         gtk_layer_set_namespace (gtkwin, "desktop");
 


### PR DESCRIPTION
*Force caja on wayland to be the true background layer so windows like conky always render on top of it
*without this clicking on the desktop window raises it over conky and hides it