### PR TITLE
Desktop: really ensure that desktop window is never decorated

### DIFF
--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -116,7 +116,6 @@ caja_desktop_window_init (CajaDesktopWindow *window)
 
     gtk_widget_hide (CAJA_WINDOW (window)->details->statusbar);
     gtk_widget_hide (CAJA_WINDOW (window)->details->menubar);
-    gtk_window_set_decorated (GTK_WINDOW (window), FALSE);
 
     /* Don't allow close action on desktop */
     G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
@@ -220,6 +219,7 @@ caja_desktop_window_new (CajaApplication *application,
                               "width_request", width_request,
                               "height_request", height_request,
                               "screen", screen,
+                              "decorated", FALSE,
                               NULL));
     /* Stop wrong desktop window size in GTK 3.20*/
     /* We don't want to set a default size, which the parent does, since this */


### PR DESCRIPTION
The `decorated` property needs to be set before the window is realized, otherwise it has no effect. Set it directly in the constructor.

Fixes: 1cc61bef81c28fba1277cd996c32621b441da068