### PR TITLE
ci: remove redundant GH CLI installation step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,6 @@ jobs:
       - name: Build the source code
         run: .github/workflows/builds.sh
 
-      - name: Install GH CLI
-        uses: dev-hanz-ops/install-gh-cli-action@v0.2.1
-        with:
-          gh-cli-version: 2.39.1
-
       - name: Create github release
         run: |
           gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --generate-notes caja-*.tar.xz


### PR DESCRIPTION
sorry, for atril I accidently pushed this directly to master (https://github.com/mate-desktop/atril/commit/a6a92da563e1bdb6e6520b5ec5f67a7dcef4056a). I can revert it if it is not wished. Also maybe we should set it so that no one can push directly to master by default.