### PR TITLE
fm-directory-view: fix the issue where renaming a file to a hidden file name does not work

### DIFF
--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -2896,8 +2896,7 @@ process_new_files (FMDirectoryView *view)
 					new_changed_files = g_list_delete_link (new_changed_files, node);
 					old_added_files = g_list_prepend (old_added_files, pending);
 				}
-			} else if (fm_directory_view_should_show_file (view, pending->file)
-                || (!still_should_show_file (view, pending->file, pending->directory) && caja_directory_are_all_files_seen (view->details->model))) {
+			} else {
 				new_changed_files = g_list_delete_link (new_changed_files, node);
 				old_changed_files = g_list_prepend (old_changed_files, pending);
 			}


### PR DESCRIPTION
Fixes an issue where creating a file and naming it with a dot prefix (e.g., .hidden) would not take effect; the filename would revert to the default and the file would not be automatically hidden. This issue also occurs when changing an existing file's name to a hidden name. 
Fixed https://github.com/mate-desktop/caja/issues/1746
<img width="714" height="752" alt="0ac49f4f-bf7e-4d00-95e5-c2a28026bd7a" src="https://github.com/user-attachments/assets/71e4624a-2409-4087-8b1b-e0b326605284" />
<img width="775" height="729" alt="f3b351e0-a72f-446f-95a5-8b8c56ece100" src="https://github.com/user-attachments/assets/83ee44d4-5200-4f53-8f8a-222990b3bf02" />
