### PR TITLE
fix(*): fix some memory leak problem

### DIFF
--- a/libcaja-private/caja-extensions.c
+++ b/libcaja-private/caja-extensions.c
@@ -63,13 +63,13 @@ extension_new (gchar *filename, gboolean state, gboolean python, GObject *module
         ext->copyright = g_key_file_get_locale_string (extension_file, CAJA_EXTENSION_GROUP, "Copyright", NULL, NULL);
         ext->version = g_key_file_get_string (extension_file, CAJA_EXTENSION_GROUP, "Version", NULL);
         ext->website = g_key_file_get_string (extension_file, CAJA_EXTENSION_GROUP, "Website", NULL);
-        g_key_file_free (extension_file);
     }
     else
     {
         caja_debug_log (FALSE, CAJA_DEBUG_LOG_DOMAIN_USER, "Error loading keys from file \"%s\": %s\n", extension_filename, error->message);
         g_error_free (error);
     }
+    g_key_file_free (extension_file);
     g_free (extension_filename);
 
     if (python)

--- a/libcaja-private/caja-file-operations.c
+++ b/libcaja-private/caja-file-operations.c
@@ -6097,7 +6097,7 @@ create_job (GIOSchedulerJob *io_job,
 					     &error);
 		// Start UNDO-REDO
 		if (res) {
-			caja_undostack_manager_data_set_create_data(common->undo_redo_data,
+			caja_undostack_manager_data_take_create_data(common->undo_redo_data,
 					g_file_get_uri(dest),
 					NULL);
 		}
@@ -6112,7 +6112,7 @@ create_job (GIOSchedulerJob *io_job,
 					   &error);
 			// Start UNDO-REDO
 			if (res) {
-				caja_undostack_manager_data_set_create_data(common->undo_redo_data,
+				caja_undostack_manager_data_take_create_data(common->undo_redo_data,
 						g_file_get_uri(dest),
 						g_file_get_uri(job->src));
 			}
@@ -6141,7 +6141,7 @@ create_job (GIOSchedulerJob *io_job,
 								     &error);
 					// Start UNDO-REDO
 					if (res) {
-						caja_undostack_manager_data_set_create_data(common->undo_redo_data,
+						caja_undostack_manager_data_take_create_data(common->undo_redo_data,
 								g_file_get_uri(dest),
 								g_strdup(data));
 					}

--- a/libcaja-private/caja-undostack-manager.c
+++ b/libcaja-private/caja-undostack-manager.c
@@ -1050,18 +1050,20 @@ void caja_undostack_manager_data_set_recursive_permissions
 }
 
 /** ****************************************************************
- * Sets create file information
+ * Takes create file information
+ * Note:
+ * The caller must not free target_uri and template after calling this function.
  ** ****************************************************************/
 void
-caja_undostack_manager_data_set_create_data (CajaUndoStackActionData *
+caja_undostack_manager_data_take_create_data (CajaUndoStackActionData *
     data, char *target_uri, char *template)
 {
 
   if (!data)
     return;
 
-  data->template = g_strdup (template);
-  data->target_uri = g_strdup (target_uri);
+  data->template = template;
+  data->target_uri = target_uri;
 
   data->isValid = TRUE;
 }

--- a/libcaja-private/caja-undostack-manager.h
+++ b/libcaja-private/caja-undostack-manager.h
@@ -144,7 +144,7 @@ caja_undostack_manager_data_add_origin_target_pair(
     CajaUndoStackActionData* data, GFile* origin, GFile* target);
 
 void
-caja_undostack_manager_data_set_create_data(
+caja_undostack_manager_data_take_create_data(
     CajaUndoStackActionData* data, char* target_uri, char* template_uri);
 
 void

--- a/src/caja-bookmarks-sidebar.c
+++ b/src/caja-bookmarks-sidebar.c
@@ -143,8 +143,6 @@ update_bookmarks (CajaBookmarksSidebar *sidebar)
             continue;
         }
 
-        bookmark_uri = caja_bookmark_get_uri (bookmark);
-
         root = caja_bookmark_get_location (bookmark);
         file = caja_file_get (root);
 
@@ -167,6 +165,7 @@ update_bookmarks (CajaBookmarksSidebar *sidebar)
                             -1);
 
         /* Select the bookmark if we're in the directory the bookmark points to. */
+        bookmark_uri = caja_bookmark_get_uri (bookmark);
         if (g_strcmp0 (bookmark_uri, sidebar->current_uri) == 0)
             gtk_tree_selection_select_iter (selection, &iter);
 

--- a/src/caja-information-panel.c
+++ b/src/caja-information-panel.c
@@ -998,7 +998,6 @@ selection_changed_callback (CajaWindowInfo *window,
         GFile *selected;
         CajaFile *file;
 
-        selection = caja_window_info_get_selection (window);
         selected = selection->data;
 
         /* this should never fail here, as we're displaying the file */

--- a/src/caja-navigation-window.c
+++ b/src/caja-navigation-window.c
@@ -634,6 +634,11 @@ caja_navigation_window_destroy (GtkWidget *object)
 
     caja_navigation_window_unset_focus_widget (window);
 
+    if (window->details->header_size_group != NULL)
+    {
+        g_object_unref (window->details->header_size_group);
+        window->details->header_size_group = NULL;
+    }
     window->sidebar = NULL;
     g_list_foreach (window->sidebar_panels, (GFunc)g_object_unref, NULL);
     g_list_free (window->sidebar_panels);

--- a/src/caja-window-manage-views.c
+++ b/src/caja-window-manage-views.c
@@ -908,6 +908,7 @@ begin_location_change (CajaWindowSlot *slot,
     CajaDirectory *directory;
     gboolean force_reload;
     GFile *parent;
+    gboolean is_need_free_selection = FALSE;
 
     g_assert (slot != NULL);
     g_assert (location != NULL);
@@ -930,6 +931,7 @@ begin_location_change (CajaWindowSlot *slot,
             parent = g_file_get_parent (from_folder);
         }
         if (parent != NULL) {
+            is_need_free_selection = TRUE;
             new_selection = g_list_prepend (NULL, g_object_ref(from_folder));
         }
         g_object_unref (from_folder);
@@ -1016,6 +1018,12 @@ begin_location_change (CajaWindowSlot *slot,
                                got_file_info_for_view_selection_callback,
                                slot);
 
+    // If the externally passed 'new_selection' is NULL, the caller will not unref the content of 'new_selection'.
+    // In this case, it is necessary to manually unref.
+    if (is_need_free_selection)
+    {
+        g_list_free_full (new_selection, g_object_unref);
+    }
     g_object_unref (window);
 }
 

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -5100,6 +5100,7 @@ add_extension_menu_items (FMDirectoryView *view,
 
 			caja_menu_item_list_free (children);
 			g_free (subdir);
+			g_object_unref (menu);
 		}
 	}
 }


### PR DESCRIPTION
I used Valgrind to check Caja and then fixed some memory leaks reported by Valgrind. Since the memory leak report file is too large (about 50MB), I did not upload it. If needed, I can upload this part of the report.