### PR TITLE
Fix some memory problem that report by valgrind

### DIFF
--- a/libcaja-private/caja-icon-info.c
+++ b/libcaja-private/caja-icon-info.c
@@ -347,7 +347,7 @@ caja_icon_info_lookup (GIcon *icon,
 
         lookup_key.icon = icon;
         lookup_key.scale = scale;
-        lookup_key.size = size * scale;
+        lookup_key.size = size;
 
         icon_info = g_hash_table_lookup (loadable_icon_cache, &lookup_key);
         if (icon_info)

--- a/src/caja-emblem-sidebar.c
+++ b/src/caja-emblem-sidebar.c
@@ -360,6 +360,10 @@ create_popup_menu (CajaEmblemSidebar *emblem_sidebar)
 
     popup = gtk_menu_new ();
 
+    gtk_menu_attach_to_widget (GTK_MENU (popup),
+                               GTK_WIDGET (emblem_sidebar),
+                               NULL);
+
     gtk_menu_set_reserve_toggle_size (GTK_MENU (popup), FALSE);
 
     /* add the "rename" menu item */

--- a/src/caja-notes-viewer.c
+++ b/src/caja-notes-viewer.c
@@ -338,6 +338,8 @@ caja_notes_viewer_init (CajaNotesViewer *sidebar)
     /* create the text container */
     details->text_buffer = gtk_text_buffer_new (NULL);
     details->note_text_field = gtk_text_view_new_with_buffer (details->text_buffer);
+    // gtk_text_view_new_with_buffer will add reference to text buffer
+    g_object_unref (details->text_buffer);
 
     gtk_text_view_set_editable (GTK_TEXT_VIEW (details->note_text_field), TRUE);
     gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (details->note_text_field),

--- a/src/caja-window-menus.c
+++ b/src/caja-window-menus.c
@@ -1165,7 +1165,11 @@ add_extension_menu_items (CajaWindow *window,
 
             caja_menu_item_list_free (children);
             g_free (subdir);
+
+            g_object_unref (menu);
         }
+
+        g_object_unref (action);
     }
 }
 


### PR DESCRIPTION
**This Valgrind report was run against caja-1.22.0, but I found that this problem is not fixed in the latest version.**

```valgrind
==2022== 2,934,352 bytes in 15,676 blocks are still reachable in loss record 1,823 of 1,825
==2022==    at 0x87725F6: g_type_create_instance (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x87561FC: ??? (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8758120: g_object_new_valist (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8758468: g_object_new (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x63572E7: ??? (in /usr/lib64/libgtk-3.so.0.2200.30)
==2022==    by 0x6468B06: ??? (in /usr/lib64/libgtk-3.so.0.2200.30)
==2022==    by 0x87724EA: g_type_create_instance (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x87561FC: ??? (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8757AAC: g_object_new_with_properties (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8758490: g_object_new (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x457C4F: create_popup_menu (caja-emblem-sidebar.c:358)
==2022==    by 0x457C4F: caja_emblem_sidebar_init (caja-emblem-sidebar.c:1044)
==2022==    by 0x87724EA: g_type_create_instance (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x87561FC: ??? (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8757AAC: g_object_new_with_properties (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8758490: g_object_new (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x4590A9: caja_emblem_sidebar_create (caja-emblem-sidebar.c:1141)
==2022==    by 0x4650BE: add_sidebar_panels (caja-navigation-window.c:965)
==2022==    by 0x4650BE: caja_navigation_window_set_up_sidebar (caja-navigation-window.c:468)
==2022==    by 0x4650BE: caja_navigation_window_show_sidebar (caja-navigation-window.c:1062)
==2022==    by 0x465296: caja_navigation_window_show (caja-navigation-window.c:1163)
==2022==    by 0x8750987: g_closure_invoke (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8762886: ??? (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876AFF0: g_signal_emit_valist (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876B2DE: g_signal_emit (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x65B31C1: gtk_widget_show (in /usr/lib64/libgtk-3.so.0.2200.30)
==2022==    by 0x48A40D: caja_window_show_window (caja-window.c:694)
==2022==    by 0x49D545: finish_loading (fm-directory-view.c:9849)
==2022==    by 0x49D545: finish_loading_if_all_metadata_loaded (fm-directory-view.c:9902)
==2022==    by 0x4D89B1: ready_callback_call (caja-directory-async.c:1394)
==2022==    by 0x4DDC52: call_ready_callbacks_at_idle (caja-directory-async.c:2056)
==2022==    by 0x89D9C76: ??? (in /usr/lib64/libglib-2.0.so.0.5600.1)
==2022==    by 0x89DD048: g_main_context_dispatch (in /usr/lib64/libglib-2.0.so.0.5600.1)
==2022==    by 0x89DD3A7: ??? (in /usr/lib64/libglib-2.0.so.0.5600.1)
==2022==    by 0x89DD45B: g_main_context_iteration (in /usr/lib64/libglib-2.0.so.0.5600.1)
==2022==    by 0x8445334: g_application_run (in /usr/lib64/libgio-2.0.so.0.5600.1)
==2022==    by 0x44C3DB: main (caja-main.c:355)

==2022== 2,253,267 bytes in 51,404 blocks are still reachable in loss record 1,822 of 1,825
==2022==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==2022==    by 0x89E268D: g_malloc (in /usr/lib64/libglib-2.0.so.0.5600.1)
==2022==    by 0x8431D4F: ??? (in /usr/lib64/libgio-2.0.so.0.5600.1)
==2022==    by 0x87565C8: ??? (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8758120: g_object_new_valist (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8758468: g_object_new (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x5154FD: caja_icon_info_lookup_from_name (caja-icon-info.c:440)
==2022==    by 0x46A6DE: get_type_icon_info (caja-pathbar.c:1511)
==2022==    by 0x46A6DE: caja_path_bar_update_button_appearance (caja-pathbar.c:1668)
==2022==    by 0x8750987: g_closure_invoke (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876305C: ??? (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876AFF0: g_signal_emit_valist (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876B2DE: g_signal_emit (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x4FE1E3: caja_file_emit_changed (caja-file.c:7849)
==2022==    by 0x4E05BF: caja_directory_emit_change_signals (caja-directory.c:696)
==2022==    by 0x4E0623: emit_change_signals_for_all_files (caja-directory.c:218)
==2022==    by 0x4E069A: emit_change_signals_for_all_files_in_all_directories (caja-directory.c:249)
==2022==    by 0x8750987: g_closure_invoke (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876305C: ??? (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876AFF0: g_signal_emit_valist (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876B2DE: g_signal_emit (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x84B330B: ??? (in /usr/lib64/libgio-2.0.so.0.5600.1)
==2022==    by 0xFC21DEB: ffi_call_unix64 (in /usr/lib64/libffi.so.6.0.1)
==2022==    by 0xFC21714: ffi_call (in /usr/lib64/libffi.so.6.0.1)
==2022==    by 0x8751624: g_cclosure_marshal_generic_va (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x8750BB6: ??? (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876A656: g_signal_emit_valist (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x876B2DE: g_signal_emit (in /usr/lib64/libgobject-2.0.so.0.5600.1)
==2022==    by 0x84B3A97: ??? (in /usr/lib64/libgio-2.0.so.0.5600.1)
==2022==    by 0x84AE66E: ??? (in /usr/lib64/libgio-2.0.so.0.5600.1)
==2022==    by 0x89D9C76: ??? (in /usr/lib64/libglib-2.0.so.0.5600.1)
==2022==    by 0x89DD048: g_main_context_dispatch (in /usr/lib64/libglib-2.0.so.0.5600.1)
==2022==    by 0x89DD3A7: ??? (in /usr/lib64/libglib-2.0.so.0.5600.1)
==2022==    by 0x89DD45B: g_main_context_iteration (in /usr/lib64/libglib-2.0.so.0.5600.1)
==2022==    by 0x8445334: g_application_run (in /usr/lib64/libgio-2.0.so.0.5600.1)
==2022==    by 0x44C3DB: main (caja-main.c:355)
```