### PR TITLE
location-bar: add trailing slash to displayed location path

### DIFF
--- a/src/caja-location-bar.c
+++ b/src/caja-location-bar.c
@@ -579,6 +579,17 @@ caja_location_bar_set_location (CajaLocationBar *bar,
         g_object_unref (file);
         caja_location_entry_update_current_location (CAJA_LOCATION_ENTRY (bar->details->entry),
                 formatted_location);
+
+        /* Add trailing slash in display only so users can immediately type a subfolder */
+        if (!g_str_has_suffix (formatted_location, G_DIR_SEPARATOR_S))
+        {
+            char *display_location;
+
+            display_location = g_strconcat (formatted_location, G_DIR_SEPARATOR_S, NULL);
+            caja_entry_set_text (CAJA_ENTRY (bar->details->entry), display_location);
+            g_free (display_location);
+        }
+
         g_free (formatted_location);
     }
 


### PR DESCRIPTION
When pressing Ctrl+L to show the location bar, the displayed path now includes a trailing slash so users can immediately start typing a subfolder name without having to press the slash key first.

Fixes #874