### PR TITLE
preferences: add option to disable thumbnails in large directories

### DIFF
--- a/data/caja-file-management-properties.ui
+++ b/data/caja-file-management-properties.ui
@@ -68,6 +68,32 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="model11">
+    <columns>
+      <!-- column-name gchararray -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">100 files</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">500 files</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">1,000 files</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">5,000 files</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">10,000 files</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">No limit</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkListStore" id="model2">
     <columns>
       <!-- column-name gchararray -->
@@ -1770,6 +1796,51 @@
                             <property name="position">1</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkBox" id="hbox_thumbnail_directory_limit">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkLabel" id="preview_label_directory_limit">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Only in _folders with fewer than:</property>
+                                <property name="use-underline">True</property>
+                                <property name="mnemonic-widget">preview_image_directory_limit_combobox</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="preview_image_directory_limit_combobox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="model">model11</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="renderer11"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -2564,6 +2635,7 @@
       <widget name="preview_label_0"/>
       <widget name="preview_label_1"/>
       <widget name="preview_label_2"/>
+      <widget name="preview_label_directory_limit"/>
       <widget name="preview_label_3"/>
       <widget name="preview_label_4"/>
     </widgets>

--- a/libcaja-private/caja-file.c
+++ b/libcaja-private/caja-file.c
@@ -4338,6 +4338,7 @@ get_custom_icon (CajaFile *file)
 }
 
 static guint64 cached_thumbnail_limit;
+static guint64 cached_thumbnail_directory_limit;
 int cached_thumbnail_size;
 static int show_image_thumbs;
 
@@ -4365,6 +4366,12 @@ caja_file_should_show_thumbnail (CajaFile *file)
 	GFilesystemPreviewType use_preview;
 
 	use_preview = caja_file_get_filesystem_use_preview (file);
+
+	if (file->details->directory != NULL &&
+	    file->details->directory->details->confirmed_file_count > 0 &&
+	    (guint64) file->details->directory->details->confirmed_file_count > cached_thumbnail_directory_limit) {
+		return FALSE;
+	}
 
 	mime_type = file->details->mime_type;
 	if (mime_type == NULL) {
@@ -8535,6 +8542,16 @@ thumbnail_limit_changed_callback (gpointer user_data)
 }
 
 static void
+thumbnail_directory_limit_changed_callback (gpointer user_data)
+{
+	g_settings_get (caja_preferences,
+	                CAJA_PREFERENCES_IMAGE_FILE_THUMBNAIL_DIRECTORY_LIMIT,
+	                "t", &cached_thumbnail_directory_limit);
+
+	emit_change_signals_for_all_files_in_all_directories ();
+}
+
+static void
 thumbnail_size_changed_callback (gpointer user_data)
 {
 	cached_thumbnail_size = g_settings_get_int (caja_icon_view_preferences, CAJA_PREFERENCES_ICON_VIEW_THUMBNAIL_SIZE);
@@ -8654,6 +8671,11 @@ caja_file_class_init (CajaFileClass *class)
 	g_signal_connect_swapped (caja_preferences,
 							  "changed::" CAJA_PREFERENCES_IMAGE_FILE_THUMBNAIL_LIMIT,
 							  G_CALLBACK (thumbnail_limit_changed_callback),
+							  NULL);
+	thumbnail_directory_limit_changed_callback (NULL);
+	g_signal_connect_swapped (caja_preferences,
+							  "changed::" CAJA_PREFERENCES_IMAGE_FILE_THUMBNAIL_DIRECTORY_LIMIT,
+							  G_CALLBACK (thumbnail_directory_limit_changed_callback),
 							  NULL);
 	thumbnail_size_changed_callback (NULL);
 	g_signal_connect_swapped (caja_icon_view_preferences,

--- a/libcaja-private/caja-global-preferences.h
+++ b/libcaja-private/caja-global-preferences.h
@@ -186,6 +186,7 @@ typedef enum
 #define CAJA_PREFERENCES_SHOW_DIRECTORY_ITEM_COUNTS "show-directory-item-counts"
 #define CAJA_PREFERENCES_SHOW_IMAGE_FILE_THUMBNAILS	"show-image-thumbnails"
 #define CAJA_PREFERENCES_IMAGE_FILE_THUMBNAIL_LIMIT	"thumbnail-limit"
+#define CAJA_PREFERENCES_IMAGE_FILE_THUMBNAIL_DIRECTORY_LIMIT	"thumbnail-directory-limit"
 #define CAJA_PREFERENCES_PREVIEW_SOUND		        "preview-sound"
 
     typedef enum

--- a/libcaja-private/org.mate.caja.gschema.xml
+++ b/libcaja-private/org.mate.caja.gschema.xml
@@ -165,6 +165,11 @@
       <summary>Maximum image size for thumbnailing</summary>
       <description>Images over this size (in bytes) won't be  thumbnailed. The purpose of this setting is to  avoid thumbnailing large images that may take a long time to load or use lots of memory.</description>
     </key>
+    <key name="thumbnail-directory-limit" type="t">
+      <default>5000</default>
+      <summary>Maximum number of files in a directory for thumbnailing</summary>
+      <description>Directories with more than this number of files won't show thumbnails. The purpose of this setting is to avoid the performance penalty of generating thumbnails in very large directories. The file count includes hidden files regardless of whether they are displayed.</description>
+    </key>
     <key name="preview-sound" enum="org.mate.caja.SpeedTradeoff">
       <aliases><alias value='local_only' target='local-only'/></aliases>
       <default>'local-only'</default>

--- a/src/caja-file-management-properties.c
+++ b/src/caja-file-management-properties.c
@@ -77,6 +77,7 @@
 
 /* int enums */
 #define CAJA_FILE_MANAGEMENT_PROPERTIES_THUMBNAIL_LIMIT_WIDGET "preview_image_size_combobox"
+#define CAJA_FILE_MANAGEMENT_PROPERTIES_THUMBNAIL_DIRECTORY_LIMIT_WIDGET "preview_image_directory_limit_combobox"
 
 static const char * const default_view_values[] =
 {
@@ -178,6 +179,16 @@ static const guint64 thumbnail_limit_values[] =
     1073741824,
     2147483648U,
     4294967295U
+};
+
+static const guint64 thumbnail_directory_limit_values[] =
+{
+    100,
+    500,
+    1000,
+    5000,
+    10000,
+    G_MAXUINT64
 };
 
 static const char * const icon_captions_components[] =
@@ -1210,6 +1221,12 @@ caja_file_management_properties_dialog_setup (GtkBuilder *builder, GtkWindow *wi
                             CAJA_PREFERENCES_IMAGE_FILE_THUMBNAIL_LIMIT,
                             thumbnail_limit_values,
                             G_N_ELEMENTS (thumbnail_limit_values));
+
+    bind_builder_uint_enum (builder, caja_preferences,
+                            CAJA_FILE_MANAGEMENT_PROPERTIES_THUMBNAIL_DIRECTORY_LIMIT_WIDGET,
+                            CAJA_PREFERENCES_IMAGE_FILE_THUMBNAIL_DIRECTORY_LIMIT,
+                            thumbnail_directory_limit_values,
+                            G_N_ELEMENTS (thumbnail_directory_limit_values));
 
     caja_file_management_properties_dialog_setup_icon_caption_page (builder);
     caja_file_management_properties_dialog_setup_list_column_page (builder);


### PR DESCRIPTION
Directories with many files have significant performance issues when generating thumbnails. This adds a preference that disables thumbnails when the directory exceeds the threshold.

Fixes #1304

<img width="422" alt="Screenshot at 2026-05-18 23-09-31" src="https://github.com/user-attachments/assets/2e021064-8f62-4225-a2c1-cb4316b51c6a" />