### PR TITLE
file-manager: fix double-free and relative path crash for submodule gitdir pointers

### DIFF
--- a/src/file-manager/fm-icon-container.c
+++ b/src/file-manager/fm-icon-container.c
@@ -22,6 +22,7 @@
    Author: Michael Meeks <michael@ximian.com>
 */
 #include <config.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <glib/gi18n.h>
@@ -301,13 +302,15 @@ fm_icon_container_get_icon_text_attribute_names (CajaIconContainer *container,
  **/
 static char *
 get_git_branch (const char *git_path) {
+    gchar *resolved_gitdir = NULL;
     gchar *head_content = NULL;
     gchar *branch_name = NULL;
     gchar *head_path = NULL;
+    const gchar *effective_gitdir;
 
     if (g_file_test (git_path, G_FILE_TEST_IS_REGULAR))
     {
-        /* It's a file, thus we are probably dealing with a submodule, so read it to resolve the real git dir */
+        /* It's a file — submodule or worktree. Read it to resolve the real git dir. */
         gchar *contents = NULL;
         if (g_file_get_contents (git_path, &contents, NULL, NULL) && contents)
         {
@@ -316,19 +319,38 @@ get_git_branch (const char *git_path) {
             {
                 size_t git_dir_prefix_len = strlen (git_dir_prefix);
                 gchar *relative = g_strstrip (contents + git_dir_prefix_len);
-                gchar *base = g_path_get_dirname (git_path);
-                g_free (git_path);
-                git_path = g_build_filename (base, relative, NULL);
-                g_free (base);
+                if (!g_path_is_absolute (relative))
+                {
+                    gchar *base   = g_path_get_dirname (git_path);
+                    gchar *joined = g_build_filename (base, relative, NULL);
+                    g_free (base);
+                    /* realpath resolves ../ components; returns NULL if path does not exist */
+                    char *rp = realpath (joined, NULL);
+                    g_free (joined);
+                    if (rp != NULL)
+                    {
+                        resolved_gitdir = g_strdup (rp);
+                        free (rp);
+                    }
+                }
+                else
+                {
+                    resolved_gitdir = g_strdup (relative);
+                }
             }
             g_free (contents);
         }
+        effective_gitdir = resolved_gitdir;   /* may be NULL if path absent on disk */
+    }
+    else
+    {
+        effective_gitdir = git_path;
     }
 
     /* Extract the current git branch name of the repository from file HEAD within .git directory */
-    if (g_file_test (git_path, G_FILE_TEST_IS_DIR))
+    if (effective_gitdir != NULL && g_file_test (effective_gitdir, G_FILE_TEST_IS_DIR))
     {
-        head_path = g_build_filename (git_path, "HEAD", NULL);
+        head_path = g_build_filename (effective_gitdir, "HEAD", NULL);
         if (g_file_get_contents (head_path, &head_content, NULL, NULL))
         {
             g_strstrip (head_content);
@@ -350,6 +372,7 @@ get_git_branch (const char *git_path) {
         }
     }
 
+    g_free (resolved_gitdir);
     g_free (head_content);
     g_free (head_path);
 


### PR DESCRIPTION
## Problem

When Caja enumerates a directory whose subdirectories contain a `.git` *file*
(rather than a `.git` directory — as used by git submodules and linked
worktrees), `get_git_branch()` crashes intermittently via heap corruption.

The root cause is a **double-free**:

1. Inside `get_git_branch()`, when `.git` is a regular file the code calls
   `g_free(git_path)` on its own `const char *` parameter (to free the
   caller's allocation before reassigning the local variable).
2. The caller then calls `g_free(git_path)` again on the same pointer after
   `get_git_branch()` returns.

The resulting heap corruption is non-deterministic — it manifests as a crash
elsewhere in the process, not at the site of the double-free, which is why a
desktop code review found no obvious NULL-dereference path in the feature code.

A secondary issue: `g_build_filename()` does not canonicalise `../` components
in relative `gitdir:` paths. If the resolved path does not exist on disk
(e.g. an uninitialised submodule), `realpath()` returns NULL; without a guard
this would be passed into subsequent GLib calls.

## Fix

- Introduce a `resolved_gitdir` local variable to hold the heap-allocated
  resolved path. The `git_path` parameter (which belongs to the caller) is
  never freed inside the function.
- Use `realpath()` to canonicalise relative `gitdir:` paths containing `../`
  components. The result is copied into GLib-managed memory with `g_strdup()`
  and the `malloc()`-allocated `realpath()` buffer is freed with `free()`.
- Guard against a NULL return from `realpath()` — when the target path is
  absent on disk, `effective_gitdir` is set to NULL and the subsequent
  `g_file_test()` call is skipped cleanly.
- Add `#include <stdlib.h>` for `realpath()` and `free()`.

## Crash reproduction

Navigate to a parent directory in Caja icon view that contains a subdirectory
with a `.git` file whose `gitdir:` line holds a relative path
(e.g. `gitdir: ../../../../../.git/modules/...`). With the Display Git Branch
preference enabled, Caja crashes on directory enumeration. After this fix,
enumeration completes without crashing.