### PR TITLE
file-manager: classify git worktrees and submodules with distinct icon labels

### DIFF
--- a/src/file-manager/fm-icon-container.c
+++ b/src/file-manager/fm-icon-container.c
@@ -22,7 +22,6 @@
    Author: Michael Meeks <michael@ximian.com>
 */
 #include <config.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include <glib/gi18n.h>
@@ -327,17 +326,9 @@ get_git_branch (const char *git_path) {
                 gchar *relative = g_strstrip (contents + git_dir_prefix_len);
                 if (!g_path_is_absolute (relative))
                 {
-                    gchar *base   = g_path_get_dirname (git_path);
-                    gchar *joined = g_build_filename (base, relative, NULL);
+                    gchar *base = g_path_get_dirname (git_path);
+                    resolved_gitdir = g_canonicalize_filename (relative, base);
                     g_free (base);
-                    /* realpath resolves ../ components; returns NULL if path does not exist */
-                    char *rp = realpath (joined, NULL);
-                    g_free (joined);
-                    if (rp != NULL)
-                    {
-                        resolved_gitdir = g_strdup (rp);
-                        free (rp);
-                    }
                 }
                 else
                 {

--- a/src/file-manager/fm-icon-container.c
+++ b/src/file-manager/fm-icon-container.c
@@ -316,7 +316,7 @@ get_git_branch (const char *git_path) {
 
     if (g_file_test (git_path, G_FILE_TEST_IS_REGULAR))
     {
-        /* It's a file — submodule or worktree. Read it to resolve the real git dir. */
+        /* It's a file, thus we are probably dealing with a submodule, so read it to resolve the real git dir */
         gchar *contents = NULL;
         if (g_file_get_contents (git_path, &contents, NULL, NULL) && contents)
         {
@@ -357,9 +357,9 @@ get_git_branch (const char *git_path) {
     if (effective_gitdir != NULL && g_file_test (effective_gitdir, G_FILE_TEST_IS_DIR))
     {
         GitdirType gitdir_type;
-        if (strstr (effective_gitdir, ".git/worktrees/") != NULL)
+        if (strstr (effective_gitdir, "/.git/worktrees/") != NULL)
             gitdir_type = GITDIR_WORKTREE;
-        else if (strstr (effective_gitdir, ".git/modules/") != NULL)
+        else if (strstr (effective_gitdir, "/.git/modules/") != NULL)
             gitdir_type = GITDIR_SUBMODULE;
         else
             gitdir_type = GITDIR_STANDARD;

--- a/src/file-manager/fm-icon-container.c
+++ b/src/file-manager/fm-icon-container.c
@@ -22,6 +22,7 @@
    Author: Michael Meeks <michael@ximian.com>
 */
 #include <config.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <glib/gi18n.h>
@@ -301,13 +302,15 @@ fm_icon_container_get_icon_text_attribute_names (CajaIconContainer *container,
  **/
 static char *
 get_git_branch (const char *git_path) {
+    gchar *resolved_gitdir = NULL;
     gchar *head_content = NULL;
     gchar *branch_name = NULL;
     gchar *head_path = NULL;
+    const gchar *effective_gitdir;
 
     if (g_file_test (git_path, G_FILE_TEST_IS_REGULAR))
     {
-        /* It's a file, thus we are probably dealing with a submodule, so read it to resolve the real git dir */
+        /* It's a file — submodule or worktree. Read it to resolve the real git dir. */
         gchar *contents = NULL;
         if (g_file_get_contents (git_path, &contents, NULL, NULL) && contents)
         {
@@ -316,19 +319,38 @@ get_git_branch (const char *git_path) {
             {
                 size_t git_dir_prefix_len = strlen (git_dir_prefix);
                 gchar *relative = g_strstrip (contents + git_dir_prefix_len);
-                gchar *base = g_path_get_dirname (git_path);
-                g_free (git_path);
-                git_path = g_build_filename (base, relative, NULL);
-                g_free (base);
+                if (!g_path_is_absolute (relative))
+                {
+                    gchar *base   = g_path_get_dirname (git_path);
+                    gchar *joined = g_build_filename (base, relative, NULL);
+                    g_free (base);
+                    /* realpath resolves ../ components; returns NULL if path does not exist */
+                    char *rp = realpath (joined, NULL);
+                    g_free (joined);
+                    if (rp != NULL)
+                    {
+                        resolved_gitdir = g_strdup (rp);
+                        free (rp);
+                    }
+                }
+                else
+                {
+                    resolved_gitdir = g_strdup (relative);
+                }
             }
             g_free (contents);
         }
+        effective_gitdir = resolved_gitdir;   /* may be NULL if path absent on disk */
+    }
+    else
+    {
+        effective_gitdir = git_path;
     }
 
     /* Extract the current git branch name of the repository from file HEAD within .git directory */
-    if (g_file_test (git_path, G_FILE_TEST_IS_DIR))
+    if (effective_gitdir != NULL && g_file_test (effective_gitdir, G_FILE_TEST_IS_DIR))
     {
-        head_path = g_build_filename (git_path, "HEAD", NULL);
+        head_path = g_build_filename (effective_gitdir, "HEAD", NULL);
         if (g_file_get_contents (head_path, &head_content, NULL, NULL))
         {
             g_strstrip (head_content);
@@ -350,6 +372,7 @@ get_git_branch (const char *git_path) {
         }
     }
 
+    g_free (resolved_gitdir);
     g_free (head_content);
     g_free (head_path);
 

--- a/src/file-manager/fm-icon-container.c
+++ b/src/file-manager/fm-icon-container.c
@@ -297,6 +297,12 @@ fm_icon_container_get_icon_text_attribute_names (CajaIconContainer *container,
     return attributes;
 }
 
+typedef enum {
+    GITDIR_STANDARD,
+    GITDIR_WORKTREE,
+    GITDIR_SUBMODULE,
+} GitdirType;
+
 /**
  * Parse a .git directory/file to determine repository branch name
  **/
@@ -347,9 +353,20 @@ get_git_branch (const char *git_path) {
         effective_gitdir = git_path;
     }
 
-    /* Extract the current git branch name of the repository from file HEAD within .git directory */
+    /* Classify the git context, then extract branch name from HEAD */
     if (effective_gitdir != NULL && g_file_test (effective_gitdir, G_FILE_TEST_IS_DIR))
     {
+        GitdirType gitdir_type;
+        if (strstr (effective_gitdir, ".git/worktrees/") != NULL)
+            gitdir_type = GITDIR_WORKTREE;
+        else if (strstr (effective_gitdir, ".git/modules/") != NULL)
+            gitdir_type = GITDIR_SUBMODULE;
+        else
+            gitdir_type = GITDIR_STANDARD;
+
+        const char *suffix = (gitdir_type == GITDIR_WORKTREE) ? " ⎇" :
+                             (gitdir_type == GITDIR_SUBMODULE) ? " ⊂" : "";
+
         head_path = g_build_filename (effective_gitdir, "HEAD", NULL);
         if (g_file_get_contents (head_path, &head_content, NULL, NULL))
         {
@@ -359,15 +376,19 @@ get_git_branch (const char *git_path) {
                 gchar **parts = g_strsplit (head_content, "/", -1);
                 if (parts != NULL)
                 {
-                    branch_name = g_strdup (parts[g_strv_length(parts) - 1]);
-                    g_strchomp (branch_name);
+                    gchar *raw = g_strdup (parts[g_strv_length(parts) - 1]);
+                    g_strchomp (raw);
+                    branch_name = g_strdup_printf ("%s%s", raw, suffix);
+                    g_free (raw);
                     g_strfreev (parts);
                 }
             }
             else
             {
                 /* Repository is in a detached HEAD state */
-                branch_name = g_strdup_printf (_("detached: %.7s"), head_content);
+                gchar *base_name = g_strdup_printf (_("detached: %.7s"), head_content);
+                branch_name = g_strdup_printf ("%s%s", base_name, suffix);
+                g_free (base_name);
             }
         }
     }


### PR DESCRIPTION
## Summary

Extends the git branch display feature in Caja's icon view to visually
distinguish three types of git-tracked directories:

| Directory type  | Label          |
|-----------------|----------------|
| Standard repo   | `[branch]`     |
| Linked worktree | `[branch ⎇]`  |
| Submodule       | `[branch ⊂]`  |

The ⎇ symbol (U+2387, ALTERNATIVE KEY) is widely used by git prompt tools
to denote linked worktrees. The ⊂ symbol (U+2282, SUBSET OF) reflects that
a submodule is a repository contained within another.

The suffix is appended for both normal branch names and detached HEAD
labels (e.g. `[detached: abc1234 ⎇]`).

## Implementation

Classification is performed inside `get_git_branch()` after the gitdir
path has been fully resolved, by checking for the well-known path
components that git always uses:

```c
if (strstr (effective_gitdir, ".git/worktrees/") != NULL)
    gitdir_type = GITDIR_WORKTREE;
else if (strstr (effective_gitdir, ".git/modules/") != NULL)
    gitdir_type = GITDIR_SUBMODULE;
else
    gitdir_type = GITDIR_STANDARD;
```

A file-scoped `GitdirType` enum encodes the three cases. No changes are
required outside `fm-icon-container.c`.

## Relationship to PR #1892

This branch includes the bug fix from PR #1892 (double-free and
`realpath()` for relative `gitdir:` paths) as a prerequisite commit,
since the feature builds directly on the `effective_gitdir` variable
introduced by that fix. Maintainers may choose to merge #1892 first and
rebase this branch, or merge both together.

## Testing

A representative test tree covering all three cases can be created with:

```bash
# Standard repository
git init main-repo && cd main-repo
git checkout -b main
echo "test" > README.md && git add . && git commit -m "init"

# Linked worktree (produces .git file with absolute gitdir path)
git checkout -b feature-xyz && git checkout main
git worktree add ../feature-worktree feature-xyz

# Submodule (produces .git file with relative ../  gitdir path)
cd .. && git init container-repo && cd container-repo
git checkout -b main
echo "container" > README.md && git add . && git commit -m "init"
git -c protocol.file.allow=always submodule add ../main-repo submodule
git commit -m "Add submodule"
```

Navigate to the parent of `main-repo/` and `feature-worktree/` in Caja
icon view to see `[main]` and `[feature-xyz ⎇]` respectively. Navigate
into `container-repo/` to see `[main ⊂]` on the `submodule/` icon.

The submodule case (`gitdir: ../.git/modules/submodule`) also exercises
the relative-path crash fix from PR #1892 — if enumeration of
`container-repo/` completes without crashing, both fixes are working.