### PR TITLE
Solve slow copy of big folders

### DIFF
--- a/libcaja-private/caja-undostack-manager.c
+++ b/libcaja-private/caja-undostack-manager.c
@@ -748,6 +748,9 @@ caja_undostack_manager_add_action (CajaUndoStackManager * manager,
     return;
   }
 
+  action->sources = g_list_reverse (action->sources);
+  action->destinations = g_list_reverse (action->destinations);
+
   action->manager = manager;
 
   g_mutex_lock (&priv->mutex);
@@ -922,9 +925,9 @@ void caja_undostack_manager_data_add_origin_target_pair
     return;
 
   char *src_relative = g_file_get_relative_path (data->src_dir, origin);
-  data->sources = g_list_append (data->sources, src_relative);
+  data->sources = g_list_prepend (data->sources, src_relative);
   char *dest_relative = g_file_get_relative_path (data->dest_dir, target);
-  data->destinations = g_list_append (data->destinations, dest_relative);
+  data->destinations = g_list_prepend (data->destinations, dest_relative);
 
   data->isValid = TRUE;
 }


### PR DESCRIPTION
This is a long standing problem I've been personally struggling for years. The issue was undostack, ```add_origin_target_pair``` is called once per file and ```g_list_append``` walks the whole list every call.
Other users also noticed that it starts fast and gets slow down as expected. 

The solution is already in the documentation of [g_list_append](https://docs.gtk.org/glib/type_func.List.append.html).

> g_list_append() has to traverse the entire list to find the end, which is inefficient when adding multiple elements. A common idiom to avoid the inefficiency is to use g_list_prepend() and reverse the list with g_list_reverse() when all elements have been added.

So I switched to ```g_list_prepend```, as far as I know there's no side effect of having undostack in reverse order but I added code to reverse it as the documentation points anyway.