### PR TITLE
directory-async: Improve performance

### DIFF
--- a/libcaja-private/caja-directory-async.c
+++ b/libcaja-private/caja-directory-async.c
@@ -147,7 +147,7 @@ struct DeepCountState
     GFileEnumerator *enumerator;
     GFile *deep_count_location;
     GList *deep_count_subdirectories;
-    GArray *seen_deep_count_inodes;
+    GHashTable *seen_deep_count_inodes;
     char *fs_id;
 };
 
@@ -2821,21 +2821,13 @@ static inline gboolean
 seen_inode (DeepCountState *state,
             GFileInfo *info)
 {
-    guint64 inode, inode2;
-    guint i;
+    guint64 inode;
 
     inode = g_file_info_get_attribute_uint64 (info, G_FILE_ATTRIBUTE_UNIX_INODE);
 
     if (inode != 0)
     {
-        for (i = 0; i < state->seen_deep_count_inodes->len; i++)
-        {
-            inode2 = g_array_index (state->seen_deep_count_inodes, guint64, i);
-            if (inode == inode2)
-            {
-                return TRUE;
-            }
-        }
+        return g_hash_table_lookup (state->seen_deep_count_inodes, &inode) != NULL;
     }
 
     return FALSE;
@@ -2850,7 +2842,9 @@ mark_inode_as_seen (DeepCountState *state,
     inode = g_file_info_get_attribute_uint64 (info, G_FILE_ATTRIBUTE_UNIX_INODE);
     if (inode != 0)
     {
-        g_array_append_val (state->seen_deep_count_inodes, inode);
+        guint64 *key = g_new (guint64, 1);
+        *key = inode;
+        g_hash_table_add (state->seen_deep_count_inodes, key);
     }
 }
 
@@ -2925,7 +2919,7 @@ deep_count_state_free (DeepCountState *state)
         g_object_unref (state->deep_count_location);
     }
     g_list_free_full (state->deep_count_subdirectories, g_object_unref);
-    g_array_free (state->seen_deep_count_inodes, TRUE);
+    g_hash_table_unref (state->seen_deep_count_inodes);
     g_free (state->fs_id);
     g_free (state);
 }
@@ -3189,7 +3183,7 @@ deep_count_start (CajaDirectory *directory,
     state = g_new0 (DeepCountState, 1);
     state->directory = directory;
     state->cancellable = g_cancellable_new ();
-    state->seen_deep_count_inodes = g_array_new (FALSE, TRUE, sizeof (guint64));
+    state->seen_deep_count_inodes = g_hash_table_new_full (g_int64_hash, g_int64_equal, g_free, NULL);
     state->fs_id = NULL;
 
     directory->details->deep_count_in_progress = state;

--- a/libcaja-private/caja-directory-async.c
+++ b/libcaja-private/caja-directory-async.c
@@ -161,11 +161,6 @@ typedef struct
     } callback;
     gpointer callback_data;
     Request request;
-    gboolean active; /* Set to FALSE when the callback is triggered and
-			  * scheduled to be called at idle, its still kept
-			  * in the list so we can kill it when the file
-			  * goes away.
-			  */
 } ReadyCallback;
 
 typedef struct
@@ -335,7 +330,7 @@ caja_directory_verify_request_counts (CajaDirectory *directory)
     {
         counters[i] = 0;
     }
-    for (l = directory->details->call_when_ready_list; l != NULL; l = l->next)
+    for (l = directory->details->call_when_ready_lists.unsatisfied; l != NULL; l = l->next)
     {
         ReadyCallback *callback = l->data;
         request_counter_add_request (counters, callback->request);
@@ -1338,22 +1333,6 @@ ready_callback_key_compare (gconstpointer a, gconstpointer b)
     return 0;
 }
 
-static int
-ready_callback_key_compare_only_active (gconstpointer a, gconstpointer b)
-{
-    const ReadyCallback *callback_a;
-
-    callback_a = a;
-
-    /* Non active callbacks never match */
-    if (!callback_a->active)
-    {
-        return -1;
-    }
-
-    return ready_callback_key_compare (a, b);
-}
-
 static void
 ready_callback_call (CajaDirectory *directory,
                      const ReadyCallback *callback)
@@ -1406,7 +1385,6 @@ caja_directory_call_when_ready_internal (CajaDirectory *directory,
     g_assert (file != NULL || directory_callback != NULL);
 
     /* Construct a callback object. */
-    callback.active = TRUE;
     callback.file = file;
     if (file == NULL)
     {
@@ -1431,9 +1409,9 @@ caja_directory_call_when_ready_internal (CajaDirectory *directory,
     }
 
     /* Check if the callback is already there. */
-    if (g_list_find_custom (directory->details->call_when_ready_list,
-                            &callback,
-                            ready_callback_key_compare_only_active) != NULL)
+    GList *unsatisfied_list = directory->details->call_when_ready_lists.unsatisfied;
+
+    if (g_list_find_custom (unsatisfied_list, &callback, ready_callback_key_compare) != NULL)
     {
         if (file_callback != NULL && directory_callback != NULL)
         {
@@ -1444,9 +1422,9 @@ caja_directory_call_when_ready_internal (CajaDirectory *directory,
     }
 
     /* Add the new callback to the list. */
-    directory->details->call_when_ready_list = g_list_prepend
-            (directory->details->call_when_ready_list,
-             g_memdup (&callback, sizeof (callback)));
+    unsatisfied_list = g_list_prepend (unsatisfied_list, g_memdup (&callback, sizeof (callback)));
+    directory->details->call_when_ready_lists.unsatisfied = unsatisfied_list;
+
     request_counter_add_request (directory->details->call_when_ready_counters,
                                  callback.request);
 
@@ -1478,14 +1456,14 @@ caja_directory_check_if_ready_internal (CajaDirectory *directory,
 
 static void
 remove_callback_link_keep_data (CajaDirectory *directory,
-                                GList *link)
+                                GList *link,
+                                gboolean ready)
 {
-    ReadyCallback *callback;
+    ReadyCallback *callback = link->data;
+    GList **list = ready ? &directory->details->call_when_ready_lists.ready :
+                           &directory->details->call_when_ready_lists.unsatisfied;
 
-    callback = link->data;
-
-    directory->details->call_when_ready_list = g_list_remove_link
-            (directory->details->call_when_ready_list, link);
+    *list = g_list_remove_link (*list, link);
 
     request_counter_remove_request (directory->details->call_when_ready_counters,
                                     callback->request);
@@ -1494,13 +1472,50 @@ remove_callback_link_keep_data (CajaDirectory *directory,
 
 static void
 remove_callback_link (CajaDirectory *directory,
-                      GList *link)
+                      GList *link,
+                      gboolean ready)
 {
     ReadyCallback *callback;
 
     callback = link->data;
-    remove_callback_link_keep_data (directory, link);
+    remove_callback_link_keep_data (directory, link, ready);
     g_free (callback);
+}
+
+static void
+remove_similar_callbacks (CajaDirectory *directory,
+                          ReadyCallback *callback)
+{
+    GList *node;
+
+    /* Remove all queued callback from the list (including ready). */
+    do
+    {
+        node = g_list_find_custom (directory->details->call_when_ready_lists.ready,
+                                   callback,
+                                   ready_callback_key_compare);
+        if (node != NULL)
+        {
+            remove_callback_link (directory, node, TRUE);
+
+            caja_directory_async_state_changed (directory);
+        }
+    }
+    while (node != NULL);
+
+    do
+    {
+        node = g_list_find_custom (directory->details->call_when_ready_lists.unsatisfied,
+                                   callback,
+                                   ready_callback_key_compare);
+        if (node != NULL)
+        {
+            remove_callback_link (directory, node, FALSE);
+
+            caja_directory_async_state_changed (directory);
+        }
+    }
+    while (node != NULL);
 }
 
 void
@@ -1511,7 +1526,6 @@ caja_directory_cancel_callback_internal (CajaDirectory *directory,
         gpointer callback_data)
 {
     ReadyCallback callback;
-    GList *node;
 
     if (directory == NULL)
     {
@@ -1535,20 +1549,7 @@ caja_directory_cancel_callback_internal (CajaDirectory *directory,
     }
     callback.callback_data = callback_data;
 
-    /* Remove all queued callback from the list (including non-active). */
-    do
-    {
-        node = g_list_find_custom (directory->details->call_when_ready_list,
-                                   &callback,
-                                   ready_callback_key_compare);
-        if (node != NULL)
-        {
-            remove_callback_link (directory, node);
-
-            caja_directory_async_state_changed (directory);
-        }
-    }
-    while (node != NULL);
+    remove_similar_callbacks (directory, &callback);
 }
 
 static void
@@ -1653,21 +1654,39 @@ caja_async_destroying_file (CajaFile *file)
     changed = FALSE;
 
     /* Check for callbacks. */
-    for (node = directory->details->call_when_ready_list; node != NULL; node = next)
+    node = directory->details->call_when_ready_lists.unsatisfied;
+
+    for (; node != NULL; node = next)
     {
         next = node->next;
         callback = node->data;
 
-        if (callback->file == file)
+        if (callback->file != file)
         {
-            /* Client should have cancelled callback. */
-            if (callback->active)
-            {
-                g_warning ("destroyed file has call_when_ready pending");
-            }
-            remove_callback_link (directory, node);
-            changed = TRUE;
+            continue;
         }
+
+        /* Client should have cancelled callback. */
+        g_warning ("destroyed file has call_when_ready pending");
+
+        remove_callback_link (directory, node, FALSE);
+        changed = TRUE;
+    }
+
+    node = directory->details->call_when_ready_lists.ready;
+
+    for (; node != NULL; node = next)
+    {
+        next = node->next;
+        callback = node->data;
+
+        if (callback->file != file)
+        {
+            continue;
+        }
+
+        remove_callback_link (directory, node, TRUE);
+        changed = TRUE;
     }
 
     /* Check for monitors. */
@@ -1993,7 +2012,7 @@ static gboolean
 call_ready_callbacks_at_idle (gpointer callback_data)
 {
     CajaDirectory *directory;
-    GList *node, *next;
+    GList *node;
     ReadyCallback *callback;
 
     directory = CAJA_DIRECTORY (callback_data);
@@ -2002,27 +2021,13 @@ call_ready_callbacks_at_idle (gpointer callback_data)
     caja_directory_ref (directory);
 
     callback = NULL;
-    while (1)
+    /* Check if any callbacks are ready and call them if they are. */
+    while ((node = directory->details->call_when_ready_lists.ready) != NULL)
     {
-        /* Check if any callbacks are non-active and call them if they are. */
-        for (node = directory->details->call_when_ready_list;
-                node != NULL; node = next)
-        {
-            next = node->next;
-            callback = node->data;
-            if (!callback->active)
-            {
-                /* Non-active, remove and call */
-                break;
-            }
-        }
-        if (node == NULL)
-        {
-            break;
-        }
+        callback = node->data;
 
         /* Callbacks are one-shots, so remove it now. */
-        remove_callback_link_keep_data (directory, node);
+        remove_callback_link_keep_data (directory, node, TRUE);
 
         /* Call the callback. */
         ready_callback_call (directory, callback);
@@ -2046,7 +2051,7 @@ schedule_call_ready_callbacks (CajaDirectory *directory)
     }
 }
 
-/* Marks all callbacks that are ready as non-active and
+/* Moves all the callbacks that are ready and
  * calls them at idle time, unless they are removed
  * before then */
 static gboolean
@@ -2054,20 +2059,22 @@ call_ready_callbacks (CajaDirectory *directory)
 {
     gboolean found_any;
     GList *node, *next;
-    ReadyCallback *callback = NULL;
+    GList **unsatisfied_list, **ready_list;
+
+    unsatisfied_list = &directory->details->call_when_ready_lists.unsatisfied;
+    ready_list = &directory->details->call_when_ready_lists.ready;
 
     found_any = FALSE;
 
     /* Check if any callbacks are satisifed and mark them for call them if they are. */
-    for (node = directory->details->call_when_ready_list;
-            node != NULL; node = next)
+    for (node = *unsatisfied_list; node != NULL; node = next)
     {
         next = node->next;
-        callback = node->data;
-        if (callback->active &&
-                request_is_satisfied (directory, callback->file, callback->request))
+        ReadyCallback *callback = node->data;
+        if (request_is_satisfied (directory, callback->file, callback->request))
         {
-            callback->active = FALSE;
+            *unsatisfied_list = g_list_delete_link (*unsatisfied_list, node);
+            *ready_list = g_list_prepend (*ready_list, callback);
             found_any = TRUE;
         }
     }
@@ -2088,7 +2095,17 @@ caja_directory_has_active_request_for_file (CajaDirectory *directory,
     ReadyCallback *callback = NULL;
     Monitor *monitor = NULL;
 
-    for (node = directory->details->call_when_ready_list;
+    for (node = directory->details->call_when_ready_lists.unsatisfied;
+            node != NULL; node = node->next)
+    {
+        callback = node->data;
+        if (callback->file == file ||
+                callback->file == NULL)
+        {
+            return TRUE;
+        }
+    }
+    for (node = directory->details->call_when_ready_lists.ready;
             node != NULL; node = node->next)
     {
         callback = node->data;
@@ -2465,12 +2482,11 @@ is_needy (CajaFile *file,
     {
         ReadyCallback *callback = NULL;
 
-        for (node = directory->details->call_when_ready_list;
+        for (node = directory->details->call_when_ready_lists.unsatisfied;
                 node != NULL; node = node->next)
         {
             callback = node->data;
-            if (callback->active &&
-                    REQUEST_WANTS_TYPE (callback->request, request_type_wanted))
+            if (REQUEST_WANTS_TYPE (callback->request, request_type_wanted))
             {
                 if (callback->file == file)
                 {

--- a/libcaja-private/caja-directory-async.c
+++ b/libcaja-private/caja-directory-async.c
@@ -1379,6 +1379,7 @@ caja_directory_call_when_ready_internal (CajaDirectory *directory,
         gpointer callback_data)
 {
     ReadyCallback callback;
+    GList *node;
 
     g_assert (directory == NULL || CAJA_IS_DIRECTORY (directory));
     g_assert (file == NULL || CAJA_IS_FILE (file));
@@ -1409,9 +1410,9 @@ caja_directory_call_when_ready_internal (CajaDirectory *directory,
     }
 
     /* Check if the callback is already there. */
-    GList *unsatisfied_list = directory->details->call_when_ready_lists.unsatisfied;
+    node = g_hash_table_lookup (directory->details->call_when_ready_hash.unsatisfied, callback.file);
 
-    if (g_list_find_custom (unsatisfied_list, &callback, ready_callback_key_compare) != NULL)
+    if (g_list_find_custom (node, &callback, ready_callback_key_compare) != NULL)
     {
         if (file_callback != NULL && directory_callback != NULL)
         {
@@ -1422,9 +1423,8 @@ caja_directory_call_when_ready_internal (CajaDirectory *directory,
     }
 
     /* Add the new callback to the list. */
-    unsatisfied_list = g_list_prepend (unsatisfied_list, g_memdup (&callback, sizeof (callback)));
-    directory->details->call_when_ready_lists.unsatisfied = unsatisfied_list;
-
+    node = g_list_prepend (node, g_memdup (&callback, sizeof (callback)));
+    g_hash_table_replace (directory->details->call_when_ready_hash.unsatisfied, callback.file, node);
     request_counter_add_request (directory->details->call_when_ready_counters,
                                  callback.request);
 
@@ -1454,23 +1454,39 @@ caja_directory_check_if_ready_internal (CajaDirectory *directory,
     return request_is_satisfied (directory, file, request);
 }
 
-static void
+static GList *
 remove_callback_link_keep_data (CajaDirectory *directory,
                                 GList *link,
                                 gboolean ready)
 {
     ReadyCallback *callback = link->data;
-    GList **list = ready ? &directory->details->call_when_ready_lists.ready :
-                           &directory->details->call_when_ready_lists.unsatisfied;
+    GList *list = g_list_first (link);
+    gboolean is_first_link = (list == link);
 
-    *list = g_list_remove_link (*list, link);
+    list = g_list_delete_link (list, link);
+
+    if (is_first_link)
+    {
+        GHashTable *hash = ready ? directory->details->call_when_ready_hash.ready :
+                                   directory->details->call_when_ready_hash.unsatisfied;
+
+        if (list != NULL)
+        {
+            g_hash_table_replace (hash, callback->file, list);
+        }
+        else
+        {
+            g_hash_table_remove (hash, callback->file);
+        }
+    }
 
     request_counter_remove_request (directory->details->call_when_ready_counters,
                                     callback->request);
-    g_list_free_1 (link);
+
+    return list;
 }
 
-static void
+static GList *
 remove_callback_link (CajaDirectory *directory,
                       GList *link,
                       gboolean ready)
@@ -1478,22 +1494,24 @@ remove_callback_link (CajaDirectory *directory,
     ReadyCallback *callback;
 
     callback = link->data;
-    remove_callback_link_keep_data (directory, link, ready);
+    link = remove_callback_link_keep_data (directory, link, ready);
     g_free (callback);
+
+    return link;
 }
 
 static void
 remove_similar_callbacks (CajaDirectory *directory,
                           ReadyCallback *callback)
 {
-    GList *node;
+    GList *list, *node;
 
     /* Remove all queued callback from the list (including ready). */
     do
     {
-        node = g_list_find_custom (directory->details->call_when_ready_lists.ready,
-                                   callback,
-                                   ready_callback_key_compare);
+        list = g_hash_table_lookup (directory->details->call_when_ready_hash.ready, callback->file);
+        node = g_list_find_custom (list, callback, ready_callback_key_compare);
+
         if (node != NULL)
         {
             remove_callback_link (directory, node, TRUE);
@@ -1505,9 +1523,9 @@ remove_similar_callbacks (CajaDirectory *directory,
 
     do
     {
-        node = g_list_find_custom (directory->details->call_when_ready_lists.unsatisfied,
-                                   callback,
-                                   ready_callback_key_compare);
+        list = g_hash_table_lookup (directory->details->call_when_ready_hash.unsatisfied,
+                                    callback->file);
+        node = g_list_find_custom (list, callback, ready_callback_key_compare);
         if (node != NULL)
         {
             remove_callback_link (directory, node, FALSE);
@@ -1647,45 +1665,28 @@ caja_async_destroying_file (CajaFile *file)
     CajaDirectory *directory;
     gboolean changed;
     GList *node, *next;
-    ReadyCallback *callback = NULL;
     Monitor *monitor = NULL;
 
     directory = file->details->directory;
     changed = FALSE;
 
     /* Check for callbacks. */
-    node = directory->details->call_when_ready_lists.unsatisfied;
+    node = g_hash_table_lookup (directory->details->call_when_ready_hash.unsatisfied, file);
 
+    /* Client should have cancelled callback. */
     for (; node != NULL; node = next)
     {
-        next = node->next;
-        callback = node->data;
-
-        if (callback->file != file)
-        {
-            continue;
-        }
-
-        /* Client should have cancelled callback. */
         g_warning ("destroyed file has call_when_ready pending");
 
-        remove_callback_link (directory, node, FALSE);
+        next = remove_callback_link (directory, node, FALSE);
         changed = TRUE;
     }
 
-    node = directory->details->call_when_ready_lists.ready;
+    node = g_hash_table_lookup (directory->details->call_when_ready_hash.ready, file);
 
     for (; node != NULL; node = next)
     {
-        next = node->next;
-        callback = node->data;
-
-        if (callback->file != file)
-        {
-            continue;
-        }
-
-        remove_callback_link (directory, node, TRUE);
+        next = remove_callback_link (directory, node, TRUE);
         changed = TRUE;
     }
 
@@ -2020,9 +2021,11 @@ call_ready_callbacks_at_idle (gpointer callback_data)
 
     caja_directory_ref (directory);
 
-    callback = NULL;
+    GHashTableIter hash_iter;
+    g_hash_table_iter_init (&hash_iter, directory->details->call_when_ready_hash.ready);
+
     /* Check if any callbacks are ready and call them if they are. */
-    while ((node = directory->details->call_when_ready_lists.ready) != NULL)
+    while (g_hash_table_iter_next (&hash_iter, NULL, (gpointer *) &node))
     {
         callback = node->data;
 
@@ -2032,6 +2035,10 @@ call_ready_callbacks_at_idle (gpointer callback_data)
         /* Call the callback. */
         ready_callback_call (directory, callback);
         g_free (callback);
+
+        /* Need to parse the node from the hash table again because it might
+        * have been freed */
+        g_hash_table_iter_init (&hash_iter, directory->details->call_when_ready_hash.ready);
     }
 
     caja_directory_async_state_changed (directory);
@@ -2058,26 +2065,50 @@ static gboolean
 call_ready_callbacks (CajaDirectory *directory)
 {
     gboolean found_any;
-    GList *node, *next;
-    GList **unsatisfied_list, **ready_list;
+    GList *unsatisfied_list, *ready_list, *node, *next;
+    GList *values, *v;
 
-    unsatisfied_list = &directory->details->call_when_ready_lists.unsatisfied;
-    ready_list = &directory->details->call_when_ready_lists.ready;
+    /* g_hash_table_get_values returns a freshly-allocated list that is
+     * safe to iterate even if the hash table is modified during the loop. */
+    values = g_hash_table_get_values (directory->details->call_when_ready_hash.unsatisfied);
 
     found_any = FALSE;
 
-    /* Check if any callbacks are satisifed and mark them for call them if they are. */
-    for (node = *unsatisfied_list; node != NULL; node = next)
+    /* Check if any callbacks are satisfied and mark them for call them if they are. */
+    for (v = values; v != NULL; v = v->next)
     {
-        next = node->next;
-        ReadyCallback *callback = node->data;
-        if (request_is_satisfied (directory, callback->file, callback->request))
+        unsatisfied_list = v->data;
+        for (node = unsatisfied_list; node != NULL; node = next)
         {
-            *unsatisfied_list = g_list_delete_link (*unsatisfied_list, node);
-            *ready_list = g_list_prepend (*ready_list, callback);
-            found_any = TRUE;
+            next = node->next;
+            ReadyCallback *callback = node->data;
+            if (request_is_satisfied (directory, callback->file, callback->request))
+            {
+                unsatisfied_list = g_list_delete_link (unsatisfied_list, node);
+
+                if (unsatisfied_list != NULL)
+                {
+                    g_hash_table_replace (directory->details->call_when_ready_hash.unsatisfied,
+                                          callback->file, unsatisfied_list);
+                }
+                else
+                {
+                    g_hash_table_remove (directory->details->call_when_ready_hash.unsatisfied,
+                                         callback->file);
+                }
+
+                ready_list = g_hash_table_lookup (directory->details->call_when_ready_hash.ready,
+                                                  callback->file);
+                ready_list = g_list_prepend (ready_list, callback);
+                g_hash_table_replace (directory->details->call_when_ready_hash.ready,
+                                      callback->file, ready_list);
+
+                found_any = TRUE;
+            }
         }
     }
+
+    g_list_free (values);
 
     if (found_any)
     {
@@ -2092,28 +2123,14 @@ caja_directory_has_active_request_for_file (CajaDirectory *directory,
         CajaFile *file)
 {
     GList *node;
-    ReadyCallback *callback = NULL;
     Monitor *monitor = NULL;
 
-    for (node = directory->details->call_when_ready_lists.unsatisfied;
-            node != NULL; node = node->next)
+    if (g_hash_table_lookup (directory->details->call_when_ready_hash.unsatisfied, NULL) != NULL ||
+        g_hash_table_lookup (directory->details->call_when_ready_hash.unsatisfied, file) != NULL ||
+        g_hash_table_lookup (directory->details->call_when_ready_hash.ready, NULL) != NULL ||
+        g_hash_table_lookup (directory->details->call_when_ready_hash.ready, file) != NULL)
     {
-        callback = node->data;
-        if (callback->file == file ||
-                callback->file == NULL)
-        {
-            return TRUE;
-        }
-    }
-    for (node = directory->details->call_when_ready_lists.ready;
-            node != NULL; node = node->next)
-    {
-        callback = node->data;
-        if (callback->file == file ||
-                callback->file == NULL)
-        {
-            return TRUE;
-        }
+        return TRUE;
     }
 
     for (node = directory->details->monitor_list;
@@ -2482,18 +2499,23 @@ is_needy (CajaFile *file,
     {
         ReadyCallback *callback = NULL;
 
-        for (node = directory->details->call_when_ready_lists.unsatisfied;
-                node != NULL; node = node->next)
+        node = g_hash_table_lookup (directory->details->call_when_ready_hash.unsatisfied, file);
+        for (; node != NULL; node = node->next)
         {
             callback = node->data;
             if (REQUEST_WANTS_TYPE (callback->request, request_type_wanted))
             {
-                if (callback->file == file)
-                {
-                    return TRUE;
-                }
-                if (callback->file == NULL
-                        && file != directory->details->as_file)
+                return TRUE;
+            }
+        }
+
+        if (file != directory->details->as_file)
+        {
+            node = g_hash_table_lookup (directory->details->call_when_ready_hash.unsatisfied, NULL);
+            for (; node != NULL; node = node->next)
+            {
+                callback = node->data;
+                if (REQUEST_WANTS_TYPE (callback->request, request_type_wanted))
                 {
                     return TRUE;
                 }

--- a/libcaja-private/caja-directory-private.h
+++ b/libcaja-private/caja-directory-private.h
@@ -89,10 +89,15 @@ struct _CajaDirectoryPrivate
     CajaFileQueue *low_priority_queue;
     CajaFileQueue *extension_queue;
 
-    /* These lists are going to be pretty short.  If we think they
-     * are going to get big, we can use hash tables instead.
+    /* Callbacks are inserted into ready when the callback is triggered and
+     * scheduled to be called at idle. It's still kept in the list so we
+     * can kill it when the file goes away before being called.
      */
-    GList *call_when_ready_list;
+    struct
+    {
+            GList *unsatisfied;
+            GList *ready;
+    } call_when_ready_lists;
     RequestCounter call_when_ready_counters;
     GList *monitor_list;
     RequestCounter monitor_counters;

--- a/libcaja-private/caja-directory-private.h
+++ b/libcaja-private/caja-directory-private.h
@@ -90,14 +90,15 @@ struct _CajaDirectoryPrivate
     CajaFileQueue *extension_queue;
 
     /* Callbacks are inserted into ready when the callback is triggered and
-     * scheduled to be called at idle. It's still kept in the list so we
-     * can kill it when the file goes away before being called.
+     * scheduled to be called at idle. It's still kept in the hash table so we
+     * can kill it when the file goes away before being called. The hash table
+     * uses the file pointer of the ReadyCallback as a key.
      */
     struct
     {
-            GList *unsatisfied;
-            GList *ready;
-    } call_when_ready_lists;
+            GHashTable *unsatisfied;
+            GHashTable *ready;
+    } call_when_ready_hash;
     RequestCounter call_when_ready_counters;
     GList *monitor_list;
     RequestCounter monitor_counters;

--- a/libcaja-private/caja-directory.c
+++ b/libcaja-private/caja-directory.c
@@ -119,6 +119,8 @@ caja_directory_init (CajaDirectory *directory)
     directory->details->high_priority_queue = caja_file_queue_new ();
     directory->details->low_priority_queue = caja_file_queue_new ();
     directory->details->extension_queue = caja_file_queue_new ();
+    directory->details->call_when_ready_hash.unsatisfied = g_hash_table_new (NULL, NULL);
+    directory->details->call_when_ready_hash.ready = g_hash_table_new (NULL, NULL);
     directory->details->free_space = (guint64)-1;
 }
 
@@ -194,6 +196,8 @@ caja_directory_finalize (GObject *object)
     caja_file_queue_destroy (directory->details->high_priority_queue);
     caja_file_queue_destroy (directory->details->low_priority_queue);
     caja_file_queue_destroy (directory->details->extension_queue);
+    g_clear_pointer (&directory->details->call_when_ready_hash.unsatisfied, g_hash_table_unref);
+    g_clear_pointer (&directory->details->call_when_ready_hash.ready, g_hash_table_unref);
     g_assert (directory->details->directory_load_in_progress == NULL);
     g_assert (directory->details->count_in_progress == NULL);
     g_assert (directory->details->dequeue_pending_idle_id == 0);


### PR DESCRIPTION
This improves performance of listing files by using hash tables instead of arrays.

It's a direct backport of the following commits:
- https://gitlab.gnome.org/GNOME/nautilus/commit/156ff75c
- https://gitlab.gnome.org/GNOME/nautilus/commit/cdf326a0
- https://gitlab.gnome.org/GNOME/nautilus/commit/4ef8b232

Fixes #1900