### PR TITLE
fm-tree-model: compare removed mount root by URI

### DIFF
--- a/src/file-manager/fm-tree-model.c
+++ b/src/file-manager/fm-tree-model.c
@@ -1774,17 +1774,15 @@ void
 fm_tree_model_remove_root_uri (FMTreeModel *model, const char *uri)
 {
     TreeNode *node;
-    CajaFile *file;
 
-    file = caja_file_get_by_uri (uri);
     for (node = model->details->root_node; node != NULL; node = node->next)
     {
-        if (file == node->file)
+        /* compare by URI, as file entry may already have been deleted */
+        if (caja_file_matches_uri(node->file, uri))
         {
             break;
         }
     }
-    caja_file_unref (file);
 
     if (node)
     {


### PR DESCRIPTION
Due to a race condition, the corresponding file entry may already have been deleted. So the node of the unmounted device would be created as a new file again here, leading to two different files having the same URI. This way the loop comparison would never match then.

Fixes #1903.