### PR TITLE
Fix "RenameSelectAll" support in FMListView and enable multiple rename keypresses to toggle selection modes

### DIFF
--- a/libcaja-private/caja-file-utilities.c
+++ b/libcaja-private/caja-file-utilities.c
@@ -32,6 +32,7 @@
 #include <eel/eel-glib-extensions.h>
 #include <eel/eel-stock-dialogs.h>
 #include <eel/eel-string.h>
+#include <eel/eel-vfs-extensions.h>
 #include <eel/eel-debug.h>
 
 #include "caja-file-utilities.h"
@@ -1327,6 +1328,36 @@ caja_get_filesystem_id_by_uri (const char *uri, gboolean follow)
     filesystem_id = caja_get_filesystem_id_by_location (location, follow);
     g_object_unref (location);
     return filesystem_id;
+}
+
+static void
+get_rename_region_full (const char *filename, int *start_offset, int *end_offset)
+{
+    g_return_if_fail (start_offset != NULL);
+    g_return_if_fail (end_offset != NULL);
+
+    *start_offset = 0;
+    *end_offset = 0;
+
+    g_return_if_fail (filename != NULL);
+
+    *end_offset = g_utf8_strlen (filename, -1);
+}
+
+void
+caja_filename_get_rename_region (gboolean    select_all,
+                                 const char *filename,
+                                 int        *start_offset,
+                                 int        *end_offset)
+{
+    if (select_all)
+    {
+        get_rename_region_full (filename, start_offset, end_offset);
+    }
+    else
+    {
+        eel_filename_get_rename_region (filename, start_offset, end_offset);
+    }
 }
 
 #if !defined (CAJA_OMIT_SELF_CHECK)

--- a/libcaja-private/caja-file-utilities.h
+++ b/libcaja-private/caja-file-utilities.h
@@ -27,6 +27,7 @@
 
 #include <gio/gio.h>
 #include <gtk/gtk.h>
+#include "caja-global-preferences.h"
 
 #define CAJA_SAVED_SEARCH_EXTENSION ".savedSearch"
 #define CAJA_SAVED_SEARCH_MIMETYPE "application/x-mate-saved-search"
@@ -96,5 +97,10 @@ void caja_restore_files_from_trash (GList *files,
                                     GtkWindow *parent_window);
 char * caja_get_filesystem_id_by_location (GFile *location, gboolean follow);
 char * caja_get_filesystem_id_by_uri (const char *uri, gboolean follow);
+
+void caja_filename_get_rename_region(gboolean        select_all,
+                                     const char     *filename,
+                                     int            *start_offset,
+                                     int            *end_offset);
 
 #endif /* CAJA_FILE_UTILITIES_H */

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -9007,9 +9007,14 @@ caja_icon_container_start_renaming_selected_item (CajaIconContainer *container,
     details = container->details;
     if (details->renaming)
     {
+        details->rename_select_all = !details->rename_select_all;
+
+        editable_text = eel_editable_label_get_text (EEL_EDITABLE_LABEL (details->rename_widget));
+        caja_filename_get_rename_region (details->rename_select_all, editable_text, &start_offset, &end_offset);
+
         eel_editable_label_select_region (EEL_EDITABLE_LABEL (details->rename_widget),
-                                          0,
-                                          -1);
+                                          start_offset,
+                                          end_offset);
         return;
     }
 
@@ -9125,6 +9130,7 @@ caja_icon_container_start_renaming_selected_item (CajaIconContainer *container,
                                  width, -1);
     eel_editable_label_set_text (EEL_EDITABLE_LABEL (details->rename_widget),
                                  editable_text);
+    details->rename_select_all = select_all;
     caja_filename_get_rename_region (select_all, editable_text, &start_offset, &end_offset);
     gtk_widget_show (details->rename_widget);
     gtk_widget_grab_focus (details->rename_widget);

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -47,6 +47,7 @@
 #include <eel/eel-canvas.h>
 #include <eel/eel-canvas-rect-ellipse.h>
 
+#include "caja-file-utilities.h"
 #include "caja-icon-container.h"
 #include "caja-debug-log.h"
 #include "caja-global-preferences.h"
@@ -9124,15 +9125,7 @@ caja_icon_container_start_renaming_selected_item (CajaIconContainer *container,
                                  width, -1);
     eel_editable_label_set_text (EEL_EDITABLE_LABEL (details->rename_widget),
                                  editable_text);
-    if (select_all)
-    {
-        start_offset = 0;
-        end_offset = -1;
-    }
-    else
-    {
-        eel_filename_get_rename_region (editable_text, &start_offset, &end_offset);
-    }
+    caja_filename_get_rename_region (select_all, editable_text, &start_offset, &end_offset);
     gtk_widget_show (details->rename_widget);
     gtk_widget_grab_focus (details->rename_widget);
 

--- a/libcaja-private/caja-icon-private.h
+++ b/libcaja-private/caja-icon-private.h
@@ -186,6 +186,7 @@ struct CajaIconContainerDetails
 
     /* Renaming Details */
     gboolean renaming;
+    gboolean rename_select_all;
     GtkWidget *rename_widget;	/* Editable text item */
     char *original_text;			/* Copy of editable text for later compare */
 

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -3253,8 +3253,9 @@ fm_list_view_start_renaming_file (FMDirectoryView *view,
 
     /* set cursor also triggers editing-started, where we save the editable widget */
     if (list_view->details->editable_widget != NULL) {
-            eel_filename_get_rename_region (list_view->details->original_name,
-                                            &start_offset, &end_offset);
+            caja_filename_get_rename_region (select_all,
+                                             list_view->details->original_name,
+                                             &start_offset, &end_offset);
 
             gtk_editable_select_region (GTK_EDITABLE (list_view->details->editable_widget),
                                         start_offset, end_offset);

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -110,6 +110,7 @@ struct FMListViewDetails
 
     CajaFile *renaming_file;
     gboolean rename_done;
+    gboolean rename_select_all;
     guint renaming_file_activate_timeout;
 
     gulong clipboard_handler_id;
@@ -3219,10 +3220,19 @@ fm_list_view_start_renaming_file (FMDirectoryView *view,
     /* Select all if we are in renaming mode already */
     if (list_view->details->file_name_column && list_view->details->editable_widget)
     {
+        char *current_text = gtk_editable_get_chars (GTK_EDITABLE (list_view->details->editable_widget), 0, -1);
+        list_view->details->rename_select_all = !list_view->details->rename_select_all;
+        caja_filename_get_rename_region (
+            list_view->details->rename_select_all,
+            current_text,
+            &start_offset,
+            &end_offset);
+        g_free (current_text);
+
         gtk_editable_select_region (
             GTK_EDITABLE (list_view->details->editable_widget),
-            0,
-            -1);
+            start_offset,
+            end_offset);
         return;
     }
 
@@ -3253,6 +3263,7 @@ fm_list_view_start_renaming_file (FMDirectoryView *view,
 
     /* set cursor also triggers editing-started, where we save the editable widget */
     if (list_view->details->editable_widget != NULL) {
+            list_view->details->rename_select_all = select_all;
             caja_filename_get_rename_region (select_all,
                                              list_view->details->original_name,
                                              &start_offset, &end_offset);


### PR DESCRIPTION
# Issues

1. Caja supports highlighting a full filename during a rename rather than the filename minus the extension by pressing an alternate accelerator key combination. By default, this is Shift+F2 rather than F2, although it is not shown in any menu. (**Note**: I've noticed on some systems that there is bug in either XKB or GTK expose by a recent XKB change that interferes with the default accelerator bindings, so it may be necessary to rebind one or the other so as not to share the same base key.) However, this functionality only works in Icon/Compact view and not in List view, as although `fm_list_view_start_renaming_file ()` contains the `select_all` flag as a parameter, the current implementation ignores it.
2. There exists an alternative means to select the full filename for a rename operation by pressing the rename accelerator (e.g. F2) twice. This is already supported for both view widget types, but always selects the full filename no matter what. This seems redundant if the `RenameSelectAll` accelerator was used; in such a case, there is no quick keypress to switch back to selecting the filename without the extension without cancelling the rename operation first.

# Actual behavior

1. Pressing the `RenameSelectAll` accelerator in Icon/Compact view mode selects the full filename, but doing the same in List view mode selects the filename without the extension.
2. Pressing the `RenameSelectAll` accelerator a second time Icon/Compact view mode selects the full filename (again), which is the exact same result as pressing `Rename` twice in a row.

# Expected behavior

1. Pressing the `RenameSelectAll` accelerator in any of Icon/Compact/List view mode selects the full filename.
2. Pressing the `RenameSelectAll` accelerator twice in a row carries out some meaningful behavior distinct from pressing `Rename` twice in a row.

# Fixes

1. This PR unifies the logic of determining the rename region into a helper function (`caja_filename_get_rename_region ()`) and then applies it to both `FMListView` (for the fix) and `CajaIconContainer` (for a consistent code path). This ensures that pressing the `RenameSelectAll` accelerator in a List view selects the full filename.
2. A separate (optional) commit is also included to change the multiple-rename-press logic to a toggle. The widgets remember which selection type (partial or full) was used to begin the rename operation and will switch to the other if pressed again (regardless of which rename accelerator was pressed).
    * I considered using `select_all` again if the accelerator was pressed with no current text selection, but I did not want to break the current behavior of the second press of the rename accelerator selecting the full filename. This could be changed while preserving the double press behavior if desired (F2, F2 -> Select all; F2, deselect, F2 -> Select partial, F2, deselect, Shift+F2 -> Select All).

# Other

I can separate the second commit into another PR if desired; however, they seemed closely related enough to go together.